### PR TITLE
Created candidate invite endpoint

### DIFF
--- a/alembic/versions/7dea06d20deb_add_candidate_name_to_candidate_sessions.py
+++ b/alembic/versions/7dea06d20deb_add_candidate_name_to_candidate_sessions.py
@@ -1,0 +1,28 @@
+"""add candidate_name to candidate_sessions
+
+Revision ID: 7dea06d20deb
+Revises: 229e1ede13cc
+Create Date: 2025-12-14 10:37:42.218422
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = '7dea06d20deb'
+down_revision: Union[str, Sequence[str], None] = '229e1ede13cc'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "candidate_sessions",
+        sa.Column("candidate_name", sa.String(length=255), nullable=False, server_default=""),
+    )
+    op.alter_column("candidate_sessions", "candidate_name", server_default=None)
+
+
+def downgrade() -> None:
+    op.drop_column("candidate_sessions", "candidate_name")

--- a/app/config.py
+++ b/app/config.py
@@ -27,6 +27,8 @@ class Settings(BaseSettings):
     AUTH0_CLIENT_ID: str | None = None
     AUTH0_CLIENT_SECRET: str | None = None
 
+    CANDIDATE_PORTAL_BASE_URL: str = ""
+
     @property
     def database_url_sync(self) -> str:
         """Sync DSN for Alembic / sync SQLAlchemy.

--- a/app/models/candidate_session.py
+++ b/app/models/candidate_session.py
@@ -5,13 +5,14 @@ from app.models.base import Base
 
 
 class CandidateSession(Base):
-    """Candidate's invitation and progress for a simulation."""
+    """Candidate session record for invited candidates."""
 
     __tablename__ = "candidate_sessions"
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     simulation_id: Mapped[int] = mapped_column(ForeignKey("simulations.id"))
     candidate_user_id: Mapped[int | None] = mapped_column(ForeignKey("users.id"))
+    candidate_name: Mapped[str] = mapped_column(String(255))
     invite_email: Mapped[str] = mapped_column(String(255))
     token: Mapped[str] = mapped_column(String(255), unique=True, index=True)
     status: Mapped[str] = mapped_column(String(50))

--- a/app/schemas/candidate_session.py
+++ b/app/schemas/candidate_session.py
@@ -1,0 +1,16 @@
+from pydantic import BaseModel, EmailStr, Field
+
+
+class CandidateInviteRequest(BaseModel):
+    """Schema for inviting a candidate to a simulation."""
+
+    candidateName: str = Field(..., min_length=1, max_length=255)
+    inviteEmail: EmailStr
+
+
+class CandidateInviteResponse(BaseModel):
+    """Schema for the response after inviting a candidate."""
+
+    candidateSessionId: int
+    token: str
+    inviteUrl: str

--- a/poetry.lock
+++ b/poetry.lock
@@ -448,6 +448,27 @@ test = ["certifi (>=2024)", "cryptography-vectors (==46.0.3)", "pretend (>=0.7)"
 test-randomorder = ["pytest-randomly"]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+description = "DNS toolkit"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af"},
+    {file = "dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f"},
+]
+
+[package.extras]
+dev = ["black (>=25.1.0)", "coverage (>=7.0)", "flake8 (>=7)", "hypercorn (>=0.17.0)", "mypy (>=1.17)", "pylint (>=3)", "pytest (>=8.4)", "pytest-cov (>=6.2.0)", "quart-trio (>=0.12.0)", "sphinx (>=8.2.0)", "sphinx-rtd-theme (>=3.0.0)", "twine (>=6.1.0)", "wheel (>=0.45.0)"]
+dnssec = ["cryptography (>=45)"]
+doh = ["h2 (>=4.2.0)", "httpcore (>=1.0.0)", "httpx (>=0.28.0)"]
+doq = ["aioquic (>=1.2.0)"]
+idna = ["idna (>=3.10)"]
+trio = ["trio (>=0.30)"]
+wmi = ["wmi (>=1.5.1) ; platform_system == \"Windows\""]
+
+[[package]]
 name = "ecdsa"
 version = "0.19.1"
 description = "ECDSA cryptographic signature library (pure python)"
@@ -465,6 +486,22 @@ six = ">=1.9.0"
 [package.extras]
 gmpy = ["gmpy"]
 gmpy2 = ["gmpy2"]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+description = "A robust email address syntax and deliverability validation library."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4"},
+    {file = "email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426"},
+]
+
+[package.dependencies]
+dnspython = ">=2.0.0"
+idna = ">=2.0.0"
 
 [[package]]
 name = "fastapi"
@@ -1840,4 +1877,4 @@ files = [
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.11"
-content-hash = "eb381525a904921e22b93e4f53d289be2dd559dfca651f39238a7f43ff51a04b"
+content-hash = "474fbf60d6470a3c5b048d57c6a497a47c382ffcc16d8d0f90a46f459fa7db5d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ bcrypt = "^4.1.2"
 # Utils
 python-dotenv = "^1.0.0"
 greenlet = "^3.3.0"
+email-validator = "^2.3.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.4"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,14 @@
 import pytest_asyncio
+from fastapi import HTTPException, Request, status
 from httpx import AsyncClient
-from sqlalchemy import text
+from sqlalchemy import select, text
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from app.config import settings
 from app.db import get_session
 from app.main import app
+from app.models.user import User
+from app.security.current_user import get_current_user
 
 
 @pytest_asyncio.fixture
@@ -36,9 +39,30 @@ async def async_client(async_session: AsyncSession):
     async def override_get_session():
         yield async_session
 
-    app.dependency_overrides[get_session] = override_get_session
+    async def override_get_current_user(request: Request) -> User:
+        # In tests, authenticate via x-dev-user-email using the SAME async_session
+        email = (request.headers.get("x-dev-user-email") or "").strip()
+        if not email:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Missing x-dev-user-email header",
+            )
 
+        result = await async_session.execute(select(User).where(User.email == email))
+        user = result.scalar_one_or_none()
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=f"Dev user not found: {email}. Seed this user in the DB first.",
+            )
+        return user
+
+    app.dependency_overrides[get_session] = override_get_session
+    app.dependency_overrides[get_current_user] = override_get_current_user
+
+    # Optional: base_url can stay as-is now since we bypass localhost checks entirely.
     async with AsyncClient(app=app, base_url="http://test") as client:
         yield client
 
     app.dependency_overrides.pop(get_session, None)
+    app.dependency_overrides.pop(get_current_user, None)

--- a/tests/test_candidate_invites.py
+++ b/tests/test_candidate_invites.py
@@ -1,0 +1,151 @@
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.models.candidate_session import CandidateSession
+from app.models.company import Company
+from app.models.user import User
+
+
+async def seed_recruiter(
+    session: AsyncSession, *, email: str, company_name: str
+) -> User:
+    """
+    DEV_AUTH_BYPASS requires the user already exists and has a valid company_id.
+    Seed a company + recruiter user.
+    """
+    company = Company(name=company_name)
+    session.add(company)
+    await session.flush()  # populate company.id
+
+    user = User(
+        name=email.split("@")[0],
+        email=email,
+        role="recruiter",
+        company_id=company.id,
+        password_hash="",
+    )
+    session.add(user)
+    await session.commit()
+    await session.refresh(user)
+    return user
+
+
+@pytest.mark.asyncio
+async def test_invite_creates_candidate_session(
+    async_client, async_session: AsyncSession, monkeypatch
+):
+    monkeypatch.setenv("DEV_AUTH_BYPASS", "1")
+
+    await seed_recruiter(
+        async_session,
+        email="recruiterA@simuhire.com",
+        company_name="Recruiter A Co",
+    )
+
+    # Create simulation
+    create_sim = await async_client.post(
+        "/api/simulations",
+        headers={"x-dev-user-email": "recruiterA@simuhire.com"},
+        json={
+            "title": "Backend Node Simulation",
+            "role": "Backend Engineer",
+            "techStack": "Node.js, PostgreSQL",
+            "seniority": "Mid",
+            "focus": "Build new API feature and debug an issue",
+        },
+    )
+    assert create_sim.status_code == 201
+    sim_id = create_sim.json()["id"]
+
+    # Invite candidate
+    resp = await async_client.post(
+        f"/api/simulations/{sim_id}/invite",
+        headers={"x-dev-user-email": "recruiterA@simuhire.com"},
+        json={"candidateName": "Jane Doe", "inviteEmail": "jane@example.com"},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+
+    assert isinstance(body["candidateSessionId"], int)
+    assert body["candidateSessionId"] > 0
+
+    assert isinstance(body["token"], str)
+    # token_urlsafe(32) is typically ~43 chars, but just ensure "unguessable-ish"
+    assert len(body["token"]) >= 32
+
+    assert isinstance(body["inviteUrl"], str)
+    assert body["inviteUrl"].endswith(f"/candidate/session/{body['token']}")
+
+    # Verify DB row
+    stmt = select(CandidateSession).where(
+        CandidateSession.id == body["candidateSessionId"]
+    )
+    cs = (await async_session.execute(stmt)).scalar_one()
+
+    assert cs.simulation_id == sim_id
+    assert cs.invite_email == "jane@example.com"
+    assert cs.status == "not_started"
+    assert cs.token == body["token"]
+
+    # candidateName -> candidate_name
+    assert cs.candidate_name == "Jane Doe"
+
+
+@pytest.mark.asyncio
+async def test_invite_invalid_simulation_returns_404(
+    async_client, async_session: AsyncSession, monkeypatch
+):
+    monkeypatch.setenv("DEV_AUTH_BYPASS", "1")
+
+    await seed_recruiter(
+        async_session,
+        email="recruiterA@simuhire.com",
+        company_name="Recruiter A Co",
+    )
+
+    resp = await async_client.post(
+        "/api/simulations/999999/invite",
+        headers={"x-dev-user-email": "recruiterA@simuhire.com"},
+        json={"candidateName": "Jane Doe", "inviteEmail": "jane@example.com"},
+    )
+    assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_invite_not_owned_simulation_returns_404(
+    async_client, async_session: AsyncSession
+):
+    await seed_recruiter(
+        async_session,
+        email="recruiterA@simuhire.com",
+        company_name="Recruiter A Co",
+    )
+    await seed_recruiter(
+        async_session,
+        email="recruiterB@simuhire.com",
+        company_name="Recruiter B Co",
+    )
+
+    # Recruiter A creates sim
+    create_sim = await async_client.post(
+        "/api/simulations",
+        headers={"x-dev-user-email": "recruiterA@simuhire.com"},
+        json={
+            "title": "Sim Owned By A",
+            "role": "Backend Engineer",
+            "techStack": "Node.js, PostgreSQL",
+            "seniority": "Mid",
+            "focus": "Focus",
+        },
+    )
+    assert create_sim.status_code == 201
+    sim_id = create_sim.json()["id"]
+
+    # Recruiter B attempts invite -> 404 (do not leak existence)
+    resp = await async_client.post(
+        f"/api/simulations/{sim_id}/invite",
+        headers={"x-dev-user-email": "recruiterB@simuhire.com"},
+        json={"candidateName": "Jane Doe", "inviteEmail": "jane@example.com"},
+    )
+    assert resp.status_code == 404

--- a/tests/test_simulations_list.py
+++ b/tests/test_simulations_list.py
@@ -101,6 +101,7 @@ async def test_list_simulations_candidate_counts(authed_client, async_session):
     cs1 = CandidateSession(
         simulation_id=sim_id,
         candidate_user_id=None,
+        candidate_name="Candidate A",
         invite_email="a@example.com",
         token="tok_1",
         status="invited",
@@ -110,6 +111,7 @@ async def test_list_simulations_candidate_counts(authed_client, async_session):
     cs2 = CandidateSession(
         simulation_id=sim_id,
         candidate_user_id=None,
+        candidate_name="Candidate B",
         invite_email="b@example.com",
         token="tok_2",
         status="invited",


### PR DESCRIPTION
## Summary

This PR implements recruiter-driven candidate invites for a simulation by creating a `candidate_sessions` row with a secure, unguessable token and returning an invite URL that the candidate can use to start the simulation later.

This completes GitHub issue **#7: `candidate_sessions: create invite token for candidate`**.

---

## What changed

### 1) New recruiter endpoint: create candidate invite

**Endpoint**
- `POST /api/simulations/{simulationId}/invite`

**Auth**
- Recruiter-authenticated (uses existing `get_current_user` patterns)

**Request body**
- `candidateName` (string)
- `inviteEmail` (email)

**Behavior**
- Validates the recruiter owns the simulation (scoped by `created_by`).
- Creates a `candidate_sessions` record tied to the simulation.
- Generates a **secure random token** (unguessable, 32+ chars).
- Sets session status to **`not_started`**.
- Returns:
  - `candidateSessionId`
  - `token`
  - `inviteUrl` (candidate link containing the token)

**Error cases**
- Invalid `simulationId` → `404 Simulation not found`
- Recruiter trying to invite for a simulation they do not own → `404 Simulation not found` (no existence leakage)

---

### 2) Candidate session model updated

**DB / model fields used**
- `candidate_name` (required)
- `invite_email`
- `token` (unique, indexed)
- `status` (set to `not_started`)
- `started_at`, `completed_at` (nullable)

Note: The invite flow is implemented; **token resolution** via `GET /candidate/session/{token}` is explicitly left for the next issue as per the milestone plan.

---

### 3) New schemas (Pydantic)

Added request/response schemas for the invite endpoint:
- `CandidateInviteRequest`
- `CandidateInviteResponse`

(Uses the existing API conventions in `app/schemas/*`.)

---

### 4) Tests added

Added integration tests to cover the issue test plan, including:
- Invite creates a `candidate_sessions` row with **`not_started`** status.
- Response includes `candidateSessionId` and `token`.
- Invalid simulation ID returns `404`.
- Recruiter cannot invite candidates for simulations they do not own.

Also updated existing simulation list tests to include `candidate_name` where needed after making it required.

---

### 5) Test infrastructure fix (important)

To avoid async event-loop / engine conflicts in tests, updated `tests/conftest.py` to override:
- `get_session` (already overridden)
- `get_current_user` (new override)

This ensures authentication during tests uses the **same AsyncSession** and does not create a separate DB engine/session, preventing the classic `Future attached to a different loop` asyncpg error.

---

## Manual QA performed

Using Postman (local dev):
1. **Happy path**
   - `POST /api/simulations/{simulationId}/invite`
   - Received `201 Created` with `candidateSessionId`, `token`, `inviteUrl`

2. **Invalid simulation**
   - `POST /api/simulations/999999/invite`
   - Received `404 Simulation not found`

3. **Not owned simulation**
   - Attempted invite as a different recruiter
   - Received `404 Simulation not found`

4. **DB verification**
   - Confirmed created row exists and has **status = `not_started`**
   - Confirmed token present and long/random

---

## How to test

### Automated
```bash
./precommit.sh
```

### Manual (Postman)
1. Create a simulation as recruiter A
2. Create an invite for that simulation
3. Validate response contains `candidateSessionId`, `token`, `inviteUrl`
4. Validate invalid sim id returns `404`
5. Validate not-owned sim id returns `404`

Optional DB check:
```sql
SELECT id, simulation_id, candidate_name, invite_email, status, token
FROM candidate_sessions
ORDER BY id DESC
LIMIT 5;
```

---

## Notes / Follow-ups

- Next milestone work will implement **`GET /candidate/session/{token}`** to resolve the invite token and begin the candidate session.
- Invite URL currently points to the local candidate portal base (`http://localhost:3000/...`) as used for MVP local dev; can be parameterized later (e.g., env-configured frontend base URL).


Fixes #7 