### PR TITLE
Added fetching candidate current task

### DIFF
--- a/app/routers/simulations.py
+++ b/app/routers/simulations.py
@@ -107,6 +107,7 @@ async def create_simulation(
             day_index=t["day_index"],
             type=t["type"],
             title=t["title"],
+            description=t["description"],
         )
         db.add(task)
         created_tasks.append(task)

--- a/app/schemas/candidate_session.py
+++ b/app/schemas/candidate_session.py
@@ -2,6 +2,8 @@ from datetime import datetime
 
 from pydantic import BaseModel, EmailStr, Field
 
+from app.schemas.task import TaskPublic
+
 
 class CandidateInviteRequest(BaseModel):
     """Schema for inviting a candidate to a simulation."""
@@ -35,3 +37,22 @@ class CandidateSessionResolveResponse(BaseModel):
     completedAt: datetime | None
     candidateName: str
     simulation: CandidateSimulationSummary
+
+
+class ProgressSummary(BaseModel):
+    """Summary of progress for the candidate session."""
+
+    completed: int
+    total: int
+
+
+class CurrentTaskResponse(BaseModel):
+    """Schema for the current task assigned to the candidate."""
+
+    candidateSessionId: int
+    status: str
+    currentDayIndex: int | None
+    currentTask: TaskPublic | None
+    completedTaskIds: list[int]
+    progress: ProgressSummary
+    isComplete: bool

--- a/app/schemas/simulation.py
+++ b/app/schemas/simulation.py
@@ -5,7 +5,7 @@ from typing import Literal
 
 from pydantic import BaseModel, Field
 
-TaskType = Literal["design", "code", "debug", "documentation"]
+TaskType = Literal["design", "code", "debug", "handoff", "documentation"]
 
 
 class SimulationCreate(BaseModel):

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -1,0 +1,11 @@
+from pydantic import BaseModel
+
+
+class TaskPublic(BaseModel):
+    """Public-facing task schema for candidates. Keeps only what the candidate needs to see."""
+
+    id: int
+    dayIndex: int
+    title: str
+    type: str
+    description: str

--- a/app/services/simulation_blueprint.py
+++ b/app/services/simulation_blueprint.py
@@ -1,7 +1,47 @@
 DEFAULT_5_DAY_BLUEPRINT = [
-    {"day_index": 1, "type": "design", "title": "Architecture Plan"},
-    {"day_index": 2, "type": "code", "title": "Implement Feature"},
-    {"day_index": 3, "type": "code", "title": "Adapt to New Requirements"},
-    {"day_index": 4, "type": "debug", "title": "Debugging Scenario"},
-    {"day_index": 5, "type": "documentation", "title": "Documentation & Handoff"},
+    {
+        "day_index": 1,
+        "type": "design",
+        "title": "Architecture Plan",
+        "description": (
+            "Design the system architecture for the feature. "
+            "Describe data models, APIs, constraints, and tradeoffs."
+        ),
+    },
+    {
+        "day_index": 2,
+        "type": "code",
+        "title": "Feature Implementation",
+        "description": (
+            "Implement the required backend feature according to the design. "
+            "Ensure correctness and code quality."
+        ),
+    },
+    {
+        "day_index": 3,
+        "type": "debug",
+        "title": "Debugging Exercise",
+        "description": (
+            "Investigate failing tests or bugs in the codebase and "
+            "apply fixes with regression coverage."
+        ),
+    },
+    {
+        "day_index": 4,
+        "type": "handoff",
+        "title": "Refactor & Handoff",
+        "description": (
+            "Refactor the solution for clarity and maintainability. "
+            "Prepare it so another engineer could continue your work."
+        ),
+    },
+    {
+        "day_index": 5,
+        "type": "documentation",
+        "title": "Documentation",
+        "description": (
+            "Write concise documentation explaining how the system works, "
+            "how to run it, and key design decisions."
+        ),
+    },
 ]

--- a/runBackend.sh
+++ b/runBackend.sh
@@ -34,6 +34,11 @@ if [[ "$1" == "migrate" ]]; then
     exit 0
 fi
 
+echo "🌱 Seeding local recruiters..."
+export ENV=local
+export DEV_AUTH_BYPASS=1
+poetry run python scripts/seed_local_recruiters.py
+
 echo "🔧 Starting FastAPI server..."
 
 $RUN uvicorn app.main:app --reload --host 0.0.0.0 --port 8000

--- a/tests/test_simulations_create.py
+++ b/tests/test_simulations_create.py
@@ -47,8 +47,8 @@ async def test_create_simulation_creates_sim_and_5_tasks(async_client, async_ses
         assert [t["type"] for t in data["tasks"]] == [
             "design",
             "code",
-            "code",
             "debug",
+            "handoff",
             "documentation",
         ]
     finally:


### PR DESCRIPTION
## Summary

### ✅ New Endpoint
**GET** `/api/candidate/session/{candidateSessionId}/current_task`

- Authenticated via **token-bound candidate session** (`x-candidate-token`)
- Safely rejects invalid session/token mismatches (404)
- Handles expired invite tokens (410)

---

## Core Functionality

### Task Sequencing
- Determines the *current task* as the lowest `day_index` task **without a submission**
- Ordering enforced at the database level (`ORDER BY day_index ASC`)

### Completion Logic
- When all tasks are submitted:
  - Returns `isComplete: true`
  - Omits `currentTask`
  - Marks candidate session as `completed`
  - Sets `completed_at` timestamp

---

## Response Shape

```json
{
  "candidateSessionId": number,
  "status": "in_progress | completed",
  "currentDayIndex": number | null,
  "currentTask": {
    "id": number,
    "dayIndex": number,
    "title": string,
    "type": string,
    "description": string
  } | null,
  "completedTaskIds": number[],
  "progress": {
    "completed": number,
    "total": number
  },
  "isComplete": boolean
}
```

---

## Data & Schema Updates

### Task Description Persistence
- Updated simulation blueprint to include **non-null task descriptions**
- Ensured descriptions are persisted when creating `Task` records
- Guarantees frontend always receives meaningful task context

### Task Type Expansion
- Extended allowed task types to include:
  - `handoff`
- Updated schema literals to reflect real simulation flow:
  ```
  design → code → debug → handoff → documentation
  ```

---

## Files Touched

### Routers
- `app/routers/candidate.py`
  - Added `current_task` endpoint
  - Enforced session/token validation
  - Implemented sequencing + completion logic

- `app/routers/simulations.py`
  - Persist task descriptions during simulation creation

### Schemas
- `app/schemas/task.py`
  - Public task schema with description support

- `app/schemas/candidate_session.py`
  - `CurrentTaskResponse`, `ProgressSummary`

- `app/schemas/simulation.py`
  - Expanded `TaskType` literal to include `handoff`

### Services
- `app/services/simulation_blueprint.py`
  - Added descriptions for all default 5-day tasks

---

## Tests Added / Updated

- `test_candidate_session_resolve.py`
  - Initial task resolution (Day 1)
  - Progression across days
  - Completion behavior
  - Token/session isolation

- `test_simulations_create.py`
  - Updated expected task types to match new blueprint

All tests pass locally via `./precommit.sh`.

---

## Manual Verification

- Endpoint verified via Postman:
  - Happy path
  - Invalid token rejection
  - Correct payload shape
  - Accurate progress counters

---

## Outcome

- Fully satisfies GitHub Issue #9
- Strong API contract for frontend consumption
- Deterministic, test-covered task sequencing
- Production-ready and safe

Fixes #9 