### PR TITLE
Added ability to submit day task

### DIFF
--- a/alembic/versions/b5e134bdb971_add_code_blob_unique_constraint_for_.py
+++ b/alembic/versions/b5e134bdb971_add_code_blob_unique_constraint_for_.py
@@ -1,0 +1,34 @@
+"""add-code_blob-unique-constraint-for-submissions
+
+Revision ID: b5e134bdb971
+Revises: 174928546828
+Create Date: 2025-12-14 15:02:39.333038
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = 'b5e134bdb971'
+down_revision: Union[str, Sequence[str], None] = '174928546828'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column("submissions", sa.Column("code_blob", sa.Text(), nullable=True))
+    op.create_unique_constraint(
+        "uq_submissions_candidate_session_task",
+        "submissions",
+        ["candidate_session_id", "task_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_constraint(
+        "uq_submissions_candidate_session_task",
+        "submissions",
+        type_="unique",
+    )
+    op.drop_column("submissions", "code_blob")

--- a/app/main.py
+++ b/app/main.py
@@ -4,7 +4,7 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import settings
-from app.routers import auth, candidate, health, simulations
+from app.routers import auth, candidate, health, simulations, tasks
 
 
 def _parse_csv(value: str | None) -> list[str]:
@@ -66,6 +66,11 @@ def create_app() -> FastAPI:
         candidate.router,
         prefix=f"{settings.API_PREFIX}/candidate",
         tags=["candidate"],
+    )
+    app.include_router(
+        tasks.router,
+        prefix=f"{settings.API_PREFIX}/tasks",
+        tags=["tasks"],
     )
 
     return app

--- a/app/models/submission.py
+++ b/app/models/submission.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from sqlalchemy import DateTime, ForeignKey, Integer, String, Text
+from sqlalchemy import DateTime, ForeignKey, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from app.models.base import Base
@@ -10,6 +10,13 @@ class Submission(Base):
     """Candidate submission for a task."""
 
     __tablename__ = "submissions"
+    __table_args__ = (
+        UniqueConstraint(
+            "candidate_session_id",
+            "task_id",
+            name="uq_submissions_candidate_session_task",
+        ),
+    )
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
     candidate_session_id: Mapped[int] = mapped_column(
@@ -19,6 +26,7 @@ class Submission(Base):
     submitted_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
     content_text: Mapped[str | None] = mapped_column(Text)
     code_repo_path: Mapped[str | None] = mapped_column(String(500))
+    code_blob: Mapped[str | None] = mapped_column(Text)
 
     tests_passed: Mapped[int | None] = mapped_column(Integer)
     tests_failed: Mapped[int | None] = mapped_column(Integer)

--- a/app/routers/tasks.py
+++ b/app/routers/tasks.py
@@ -1,0 +1,163 @@
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Header, HTTPException, Path, status
+from sqlalchemy import distinct, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.db import get_session
+from app.models.candidate_session import CandidateSession
+from app.models.submission import Submission
+from app.models.task import Task
+from app.schemas.submission import (
+    ProgressSummary,
+    SubmissionCreateRequest,
+    SubmissionCreateResponse,
+)
+
+router = APIRouter()
+
+
+TEXT_TASK_TYPES = {"design", "documentation", "handoff"}
+CODE_TASK_TYPES = {"code", "debug"}
+
+
+async def _load_candidate_session_or_404(
+    db: AsyncSession,
+    candidate_session_id: int,
+    token: str,
+) -> CandidateSession:
+    stmt = select(CandidateSession).where(CandidateSession.id == candidate_session_id)
+    res = await db.execute(stmt)
+    cs = res.scalar_one_or_none()
+
+    if cs is None:
+        raise HTTPException(status_code=404, detail="Candidate session not found")
+    if cs.token != token:
+        raise HTTPException(status_code=404, detail="Candidate session not found")
+
+    now = datetime.now(UTC)
+    if cs.expires_at is not None and cs.expires_at < now:
+        raise HTTPException(status_code=410, detail="Invite token expired")
+
+    return cs
+
+
+async def _compute_current_task(db: AsyncSession, cs: CandidateSession) -> Task | None:
+    tasks_stmt = (
+        select(Task)
+        .where(Task.simulation_id == cs.simulation_id)
+        .order_by(Task.day_index.asc())
+    )
+    tasks_res = await db.execute(tasks_stmt)
+    tasks = list(tasks_res.scalars().all())
+
+    if not tasks:
+        raise HTTPException(status_code=500, detail="Simulation has no tasks")
+
+    completed_stmt = select(distinct(Submission.task_id)).where(
+        Submission.candidate_session_id == cs.id
+    )
+    completed_res = await db.execute(completed_stmt)
+    completed_task_ids = set(completed_res.scalars().all())
+
+    return next((t for t in tasks if t.id not in completed_task_ids), None)
+
+
+@router.post(
+    "/{task_id}/submit",
+    response_model=SubmissionCreateResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def submit_task(
+    task_id: Annotated[int, Path(..., ge=1)],
+    payload: SubmissionCreateRequest,
+    x_candidate_token: Annotated[str, Header(..., alias="x-candidate-token")],
+    x_candidate_session_id: Annotated[int, Header(..., alias="x-candidate-session-id")],
+    db: Annotated[AsyncSession, Depends(get_session)],
+) -> SubmissionCreateResponse:
+    """Submit a task for a candidate session. Enforces ordering and idempotency."""
+    cs = await _load_candidate_session_or_404(
+        db, x_candidate_session_id, x_candidate_token
+    )
+
+    task_stmt = select(Task).where(Task.id == task_id)
+    task_res = await db.execute(task_stmt)
+    task = task_res.scalar_one_or_none()
+    if task is None:
+        raise HTTPException(status_code=404, detail="Task not found")
+    if task.simulation_id != cs.simulation_id:
+        raise HTTPException(status_code=404, detail="Task not found")
+
+    dup_stmt = select(Submission.id).where(
+        Submission.candidate_session_id == cs.id,
+        Submission.task_id == task_id,
+    )
+    dup_res = await db.execute(dup_stmt)
+    if dup_res.scalar_one_or_none() is not None:
+        raise HTTPException(status_code=409, detail="Task already submitted")
+
+    current_task = await _compute_current_task(db, cs)
+    if current_task is None:
+        raise HTTPException(status_code=409, detail="Simulation already completed")
+    if current_task.id != task_id:
+        raise HTTPException(status_code=400, detail="Task out of order")
+
+    task_type = (task.type or "").lower()
+
+    if task_type in TEXT_TASK_TYPES:
+        if not payload.contentText or not payload.contentText.strip():
+            raise HTTPException(status_code=400, detail="contentText is required")
+    elif task_type in CODE_TASK_TYPES:
+        has_code_blob = bool(payload.codeBlob and payload.codeBlob.strip())
+        has_files = bool(payload.files)
+        if not (has_code_blob or has_files):
+            raise HTTPException(status_code=400, detail="codeBlob or files is required")
+    else:
+        raise HTTPException(status_code=500, detail="Unknown task type")
+
+    now = datetime.now(UTC)
+    sub = Submission(
+        candidate_session_id=cs.id,
+        task_id=task.id,
+        submitted_at=now,
+        content_text=payload.contentText,
+        code_blob=payload.codeBlob,
+        code_repo_path=None,
+    )
+
+    db.add(sub)
+    try:
+        await db.commit()
+    except IntegrityError as exc:
+        await db.rollback()
+        raise HTTPException(status_code=409, detail="Task already submitted") from exc
+    await db.refresh(sub)
+
+    tasks_stmt = select(Task.id).where(Task.simulation_id == cs.simulation_id)
+    tasks_res = await db.execute(tasks_stmt)
+    total = len(list(tasks_res.scalars().all()))
+
+    completed_stmt = select(distinct(Submission.task_id)).where(
+        Submission.candidate_session_id == cs.id
+    )
+    completed_res = await db.execute(completed_stmt)
+    completed = len(set(completed_res.scalars().all()))
+    is_complete = completed >= total and total > 0
+
+    if is_complete and cs.status != "completed":
+        cs.status = "completed"
+        if cs.completed_at is None:
+            cs.completed_at = now
+        await db.commit()
+        await db.refresh(cs)
+
+    return SubmissionCreateResponse(
+        submissionId=sub.id,
+        taskId=task.id,
+        candidateSessionId=cs.id,
+        submittedAt=sub.submitted_at,
+        progress=ProgressSummary(completed=completed, total=total),
+        isComplete=is_complete,
+    )

--- a/app/schemas/submission.py
+++ b/app/schemas/submission.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class SubmissionCreateRequest(BaseModel):
+    """Schema for creating a submission."""
+
+    contentText: str | None = Field(default=None)
+    codeBlob: str | None = Field(default=None)
+    files: dict[str, str] | None = Field(default=None)
+
+
+class ProgressSummary(BaseModel):
+    """Schema for summarizing progress."""
+
+    completed: int
+    total: int
+
+
+class SubmissionCreateResponse(BaseModel):
+    """Schema for submission creation response."""
+
+    submissionId: int
+    taskId: int
+    candidateSessionId: int
+    submittedAt: datetime
+    progress: ProgressSummary
+    isComplete: bool


### PR DESCRIPTION
## Summary

This PR implements the candidate-facing **unified submission endpoint** that allows candidates to submit either **text** or **code** responses for a simulation task, while enforcing:

- Candidate-session authentication (token-bound)
- Strict task ordering (must submit the current task)
- **No double submission** (duplicate submissions are rejected with `409`)
- Safe isolation (token/session mismatch does not leak existence)
- Progress tracking via submissions (advances current task and updates completion)

This completes the **M1 Core Simulation Flow** capability needed for candidates to progress Day 1 → Day 5 without AI.

---

## What shipped

### 1) New/updated API endpoint

#### `POST /api/tasks/{taskId}/submit`

**Auth**
- Requires candidate session headers:
  - `x-candidate-token`
  - `x-candidate-session-id`

**Request body**
- For text tasks:
  - `contentText: string`
- For code tasks (MVP):
  - `codeBlob: string` (temporary storage of candidate code as a blob; later can evolve to file sets / repo pointers)

**Behavior**
- Creates a `submissions` row for the given `(candidate_session_id, task_id)`
- Enforces **ordering**:
  - Only the current task (lowest unsubmitted `day_index`) can be submitted
  - Out-of-order submissions return **400** (`Task out of order`)
- Enforces **no duplicates**:
  - Submitting the same task twice returns **409** (`Task already submitted`)
  - Duplicate check occurs before ordering checks so resubmits yield 409 (not 400)
- Enforces **token/session isolation**:
  - Token + session mismatch returns **404** (safe, non-leaky)

**Response**
- Returns submission metadata + progress:
  - `submissionId`
  - `taskId`
  - `candidateSessionId`
  - `submittedAt`
  - `progress: { completed, total }`
  - `isComplete`

---

### 2) Data model & persistence

#### `submissions` storage
Supports:
- `content_text` (text answers)
- `code_blob` (code answers stored as a blob for now)

#### Migration
- Added DB support for storing `code_blob` in `submissions`
- Ensures local + CI environments have schema parity

---

### 3) Candidate flow integration

This endpoint integrates with the already-shipped candidate flow:

1. Candidate receives invite
2. `GET /api/candidate/session/{token}` resolves token and transitions session to `in_progress`
3. `GET /api/candidate/session/{candidateSessionId}/current_task` returns the current task based on submissions
4. Candidate submits:
   - `POST /api/tasks/{taskId}/submit`
5. Current task advances automatically to the next day once submission exists

---

## Error handling

| Scenario | Result |
|---|---|
| Invalid session | `404` |
| Token/session mismatch | `404` (safe) |
| Expired token | `410` |
| Submitting out of order | `400` (`Task out of order`) |
| Duplicate submission | `409` (`Task already submitted`) |

---

## Tests added/updated

### Automated tests
Added comprehensive test coverage to validate the issue test plan:

- ✅ Submitting Day 1 text task creates a submission and advances progress
- ✅ Submitting Day 2 code task stores code blob
- ✅ Out-of-order submission rejected with 400
- ✅ Token/session mismatch rejected safely
- ✅ Duplicate submission rejected with 409

All tests pass:
- `./precommit.sh` ✅
- `pytest` ✅

---

## Manual verification (Postman)

Verified end-to-end in Postman:

- **Submit Day 1 (text)** → `201 Created`, progress increments to `1/5`
- **Submit Day 2 (codeBlob)** → `201 Created`, progress increments to `2/5`
- **Out of order submit** → `400` with `Task out of order`
- **Duplicate submit** → `409` with `Task already submitted`

---

## How to run locally

### 1) Seed recruiters (DEV auth bypass)
```bash
export ENV=local
export DEV_AUTH_BYPASS=1
poetry run python scripts/seed_local_recruiters.py
```

### 2) Apply migrations
```bash
poetry run alembic upgrade head
```

### 3) Run tests
```bash
./precommit.sh
```

---

## Notes / Follow-ups

- `codeBlob` is intentionally minimal for M1. In M2, this can evolve to:
  - multi-file submissions
  - repo snapshot pointers
  - sandbox execution artifacts (test output, pass/fail counts)
- (If not already present in CI) ensure workflow runs:
  - `alembic upgrade head` before `pytest`

---

## Acceptance criteria checklist (Issue #10)

- [x] Unified submission endpoint implemented
- [x] Text submissions supported (`contentText`)
- [x] Code submissions supported (`codeBlob`)
- [x] Creates submissions row for `(candidate_session_id, task_id)`
- [x] Enforces ordering; out-of-order returns 400
- [x] Prevents duplicates; returns 409
- [x] Token/session mismatch rejected safely
- [x] Tests and Postman validation complete


Fixes #10 