### PR TITLE
Add Comprehensive Backend Tests for Milestone 1 code

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,41 @@
+import pytest
+
+from app.config import Settings
+
+
+def test_database_url_sync_normalizes_postgres_scheme():
+    s = Settings(
+        DATABASE_URL_SYNC="postgres://user:pass@localhost:5432/db",
+        DATABASE_URL="",
+    )
+    assert s.database_url_sync == "postgresql://user:pass@localhost:5432/db"
+
+
+def test_database_url_sync_raises_when_missing():
+    s = Settings(DATABASE_URL="", DATABASE_URL_SYNC="")
+    with pytest.raises(ValueError):
+        _ = s.database_url_sync
+
+
+def test_database_url_async_adds_asyncpg_driver():
+    s = Settings(
+        DATABASE_URL="postgresql://user:pass@localhost:5432/dbname",
+        DATABASE_URL_SYNC="postgresql://user:pass@localhost:5432/dbname",
+    )
+    assert (
+        s.database_url_async == "postgresql+asyncpg://user:pass@localhost:5432/dbname"
+    )
+
+
+def test_auth0_helpers_default_to_domain():
+    s = Settings(
+        AUTH0_DOMAIN="example.auth0.com",
+        AUTH0_ALGORITHMS="RS256, HS256",
+        AUTH0_API_AUDIENCE="api://test",
+        AUTH0_ISSUER="",
+        AUTH0_JWKS_URL="",
+    )
+
+    assert s.auth0_issuer == "https://example.auth0.com/"
+    assert s.auth0_jwks_url == "https://example.auth0.com/.well-known/jwks.json"
+    assert s.auth0_algorithms == ["RS256", "HS256"]


### PR DESCRIPTION
## Overview
- Expanded test coverage across candidate session resolution, task submission flows, simulation access control, and configuration helpers.
- Validated candidate journey (invite → resolve → current task → submissions → completion) with success and error paths.
- Ensured settings helpers normalize database URLs and Auth0 config defaults.

## Details
- **Candidate session**: Added resolution state change, expired/invalid token handling, and current task behaviors.
- **Task submission**: Added validation for text/code payloads, out-of-order protection, and completion status updates.
- **Simulations**: Added recruiter-only access checks for create/list and verified candidate counts visibility.
- **Config**: Added unit tests for DSN normalization and Auth0 issuer/JWKS helpers.

## Tests
- `poetry run pytest` (all 34 tests passing; existing Pydantic v2 deprecation warnings remain in `app/schemas/simulation.py`).
