### PR TITLE
Implemented persistent sandbox test results on submissions

### DIFF
--- a/alembic/versions/3d7f8c5b6b8c_add_last_run_at_to_submissions.py
+++ b/alembic/versions/3d7f8c5b6b8c_add_last_run_at_to_submissions.py
@@ -1,0 +1,28 @@
+"""Add last_run_at to submissions
+
+Revision ID: 3d7f8c5b6b8c
+Revises: fa61fe2e7edd
+Create Date: 2025-12-20 12:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "3d7f8c5b6b8c"
+down_revision: Union[str, Sequence[str], None] = "fa61fe2e7edd"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "submissions",
+        sa.Column("last_run_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("submissions", "last_run_at")

--- a/app/domain/submissions/schemas.py
+++ b/app/domain/submissions/schemas.py
@@ -84,7 +84,8 @@ class RecruiterTestResultsOut(APIModel):
     passed: int | None = None
     failed: int | None = None
     total: int | None = None
-    output: str | None = None
+    output: dict[str, object] | str | None = None
+    lastRunAt: datetime | None = None
 
 
 class RecruiterSubmissionDetailOut(APIModel):

--- a/app/domain/submissions/submission.py
+++ b/app/domain/submissions/submission.py
@@ -28,9 +28,12 @@ class Submission(Base):
     code_repo_path: Mapped[str | None] = mapped_column(String(500))
     code_blob: Mapped[str | None] = mapped_column(Text)
 
-    tests_passed: Mapped[int | None] = mapped_column(Integer)
-    tests_failed: Mapped[int | None] = mapped_column(Integer)
-    test_output: Mapped[str | None] = mapped_column(Text)
+    tests_passed: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    tests_failed: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    test_output: Mapped[str | None] = mapped_column(Text, nullable=True)
+    last_run_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     candidate_session = relationship("CandidateSession", back_populates="submissions")
     task = relationship("Task", back_populates="submissions")

--- a/tests/api/test_recruiter_submissions_get.py
+++ b/tests/api/test_recruiter_submissions_get.py
@@ -1,3 +1,4 @@
+import json
 from datetime import UTC, datetime
 
 import pytest
@@ -93,6 +94,54 @@ async def test_recruiter_cannot_access_other_recruiters_submission(
     )
     # prefer 404 to avoid leaking existence
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_recruiter_parses_structured_test_output(
+    async_client, async_session: AsyncSession
+):
+    recruiter = await create_recruiter(
+        async_session, email="struct@test.com", name="Struct Recruiter"
+    )
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    task = tasks[1]
+    cs = await create_candidate_session(
+        async_session, simulation=sim, status="in_progress"
+    )
+
+    output = {
+        "status": "failed",
+        "passed": 1,
+        "failed": 2,
+        "total": 3,
+        "stdout": "prints",
+        "stderr": "boom",
+        "timeout": False,
+    }
+    sub = await create_submission(
+        async_session,
+        candidate_session=cs,
+        task=task,
+        content_text=None,
+        code_blob="code",
+        tests_passed=None,
+        tests_failed=None,
+        test_output=json.dumps(output),
+        last_run_at=datetime.now(UTC),
+    )
+
+    resp = await async_client.get(
+        f"/api/submissions/{sub.id}",
+        headers={"x-dev-user-email": recruiter.email},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()["testResults"]
+    assert data["status"] == "failed"
+    assert data["passed"] == 1
+    assert data["failed"] == 2
+    assert data["total"] == 3
+    assert data["output"]["stdout"] == "prints"
+    assert data["output"]["stderr"] == "boom"
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_task_submit.py
+++ b/tests/api/test_task_submit.py
@@ -118,9 +118,10 @@ async def test_submit_day1_text_creates_submission_and_advances(
 
 @pytest.mark.asyncio
 async def test_submit_day2_code_stores_code_blob(
-    async_client, async_session: AsyncSession, monkeypatch
+    async_client, async_session: AsyncSession, monkeypatch, sandbox_stubber
 ):
     monkeypatch.setenv("DEV_AUTH_BYPASS", "1")
+    sandbox_stubber()
 
     recruiter_email = "recruiterA@simuhire.com"
     await seed_recruiter(
@@ -342,9 +343,10 @@ async def test_code_submission_requires_code_or_files(
 
 @pytest.mark.asyncio
 async def test_submitting_all_tasks_marks_session_complete(
-    async_client, async_session: AsyncSession, monkeypatch
+    async_client, async_session: AsyncSession, monkeypatch, sandbox_stubber
 ):
     monkeypatch.setenv("DEV_AUTH_BYPASS", "1")
+    sandbox_stubber()
 
     recruiter_email = "recruiterA@simuhire.com"
     await seed_recruiter(

--- a/tests/factories/models.py
+++ b/tests/factories/models.py
@@ -123,6 +123,7 @@ async def create_submission(
     tests_failed: int | None = None,
     test_output: str | None = None,
     code_repo_path: str | None = None,
+    last_run_at: datetime | None = None,
 ) -> Submission:
     submission = Submission(
         candidate_session_id=candidate_session.id,
@@ -134,6 +135,7 @@ async def create_submission(
         tests_passed=tests_passed,
         tests_failed=tests_failed,
         test_output=test_output,
+        last_run_at=last_run_at,
     )
     session.add(submission)
     await session.flush()

--- a/tests/unit/test_candidate_submissions_errors.py
+++ b/tests/unit/test_candidate_submissions_errors.py
@@ -1,0 +1,71 @@
+import pytest
+
+from app.api.routes.candidate import submissions as candidate_submissions
+from app.domain.submissions.schemas import RunTestsRequest, SubmissionCreateRequest
+from app.services.sandbox_client import SandboxError
+from tests.factories import (
+    create_candidate_session,
+    create_recruiter,
+    create_simulation,
+    create_submission,
+)
+
+
+class RaisingSandboxClient:
+    def __init__(self, exc: Exception):
+        self._exc = exc
+
+    async def run_tests(self, **_kwargs):
+        raise self._exc
+
+
+@pytest.mark.asyncio
+async def test_submit_task_sandbox_error_returns_502(async_session):
+    recruiter = await create_recruiter(async_session, email="err@sim.com")
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session, simulation=sim, status="in_progress"
+    )
+    # Seed day 1 so day 2 (code) becomes current
+    await create_submission(
+        async_session, candidate_session=cs, task=tasks[0], content_text="day1"
+    )
+    await async_session.commit()
+
+    with pytest.raises(Exception) as excinfo:
+        await candidate_submissions.submit_task(
+            task_id=tasks[1].id,
+            payload=SubmissionCreateRequest(codeBlob="print('x')"),
+            x_candidate_token=cs.token,
+            x_candidate_session_id=cs.id,
+            db=async_session,
+            sandbox_client=RaisingSandboxClient(SandboxError("boom")),
+        )
+    assert hasattr(excinfo.value, "status_code")
+    assert excinfo.value.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_run_task_tests_sandbox_error_returns_502(async_session):
+    recruiter = await create_recruiter(async_session, email="runerr@sim.com")
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session, simulation=sim, status="in_progress"
+    )
+    # Seed day 1 so day 2 is current for run
+    await create_submission(
+        async_session, candidate_session=cs, task=tasks[0], content_text="day1"
+    )
+    await async_session.commit()
+
+    with pytest.raises(Exception) as excinfo:
+        await candidate_submissions.run_task_tests(
+            task_id=tasks[1].id,
+            payload=RunTestsRequest(codeBlob="print('x')"),
+            db=async_session,
+            sandbox_client=RaisingSandboxClient(SandboxError("boom")),
+            x_candidate_token=cs.token,
+            x_candidate_session_id=cs.id,
+        )
+    assert hasattr(excinfo.value, "status_code")
+    assert excinfo.value.status_code == 502

--- a/tests/unit/test_extra_branches.py
+++ b/tests/unit/test_extra_branches.py
@@ -9,12 +9,30 @@ from app.api.routes.recruiter import simulations, submissions
 from app.core.security import current_user
 from app.domain import Task
 from app.domain.simulations.schemas import SimulationCreate
+from app.services.sandbox_client import SandboxRunResult
 from tests.factories import (
     create_candidate_session,
     create_recruiter,
     create_simulation,
     create_submission,
 )
+
+
+class StubSandboxClient:
+    def __init__(self, result: SandboxRunResult | None = None):
+        self._result = result or SandboxRunResult(
+            status="passed",
+            passed=0,
+            failed=0,
+            total=0,
+            stdout="",
+            stderr="",
+            duration_ms=None,
+            raw=None,
+        )
+
+    async def run_tests(self, **_kwargs):
+        return self._result
 
 
 @pytest.mark.asyncio
@@ -187,6 +205,7 @@ async def test_tasks_submit_wrong_simulation(async_session):
             x_candidate_token=cs.token,
             x_candidate_session_id=cs.id,
             db=async_session,
+            sandbox_client=StubSandboxClient(),
         )
     assert exc.value.status_code == 404
 
@@ -228,6 +247,7 @@ async def test_tasks_submit_duplicate_and_outcomes(async_session, monkeypatch):
             x_candidate_token=cs.token,
             x_candidate_session_id=cs.id,
             db=async_session,
+            sandbox_client=StubSandboxClient(),
         )
     assert exc.value.status_code == 409
 
@@ -243,6 +263,7 @@ async def test_tasks_submit_duplicate_and_outcomes(async_session, monkeypatch):
             x_candidate_token=cs.token,
             x_candidate_session_id=cs.id,
             db=async_session,
+            sandbox_client=StubSandboxClient(),
         )
     assert exc.value.status_code == 409
 
@@ -267,6 +288,7 @@ async def test_tasks_submit_out_of_order_and_validation(async_session, monkeypat
             x_candidate_token=cs.token,
             x_candidate_session_id=cs.id,
             db=async_session,
+            sandbox_client=StubSandboxClient(),
         )
     assert exc.value.status_code == 400
 
@@ -284,6 +306,7 @@ async def test_tasks_submit_out_of_order_and_validation(async_session, monkeypat
             x_candidate_token=cs.token,
             x_candidate_session_id=cs.id,
             db=async_session,
+            sandbox_client=StubSandboxClient(),
         )
     assert exc.value.status_code == 400
 
@@ -297,6 +320,7 @@ async def test_tasks_submit_out_of_order_and_validation(async_session, monkeypat
             x_candidate_token=cs.token,
             x_candidate_session_id=cs.id,
             db=async_session,
+            sandbox_client=StubSandboxClient(),
         )
     assert exc.value.status_code == 400
 
@@ -311,6 +335,7 @@ async def test_tasks_submit_out_of_order_and_validation(async_session, monkeypat
             x_candidate_token=cs.token,
             x_candidate_session_id=cs.id,
             db=async_session,
+            sandbox_client=StubSandboxClient(),
         )
     assert exc.value.status_code == 409
 
@@ -341,6 +366,7 @@ async def test_tasks_submit_integrity_error(monkeypatch, async_session):
             x_candidate_token=cs.token,
             x_candidate_session_id=cs.id,
             db=async_session,
+            sandbox_client=StubSandboxClient(),
         )
     assert exc.value.status_code == 409
 

--- a/tests/unit/test_submissions_schema_columns.py
+++ b/tests/unit/test_submissions_schema_columns.py
@@ -1,0 +1,13 @@
+import pytest
+from sqlalchemy import inspect
+
+
+@pytest.mark.asyncio
+async def test_submissions_table_has_test_result_columns(db_engine):
+    async with db_engine.begin() as conn:
+        columns = await conn.run_sync(
+            lambda sync_conn: inspect(sync_conn).get_columns("submissions")
+        )
+    names = {col["name"] for col in columns}
+    required = {"tests_passed", "tests_failed", "test_output", "last_run_at"}
+    assert required.issubset(names)

--- a/tests/unit/test_submissions_serialization.py
+++ b/tests/unit/test_submissions_serialization.py
@@ -1,0 +1,53 @@
+import json
+
+import pytest
+from fastapi import HTTPException
+
+from app.domain.submissions import service_candidate, service_recruiter
+from app.services.sandbox_client import SandboxRunResult
+
+
+def test_serialize_sandbox_result_produces_json_and_counts():
+    result = SandboxRunResult(
+        status="failed",
+        passed=1,
+        failed=2,
+        total=3,
+        stdout="out",
+        stderr="err",
+        duration_ms=None,
+        raw=None,
+    )
+    payload = service_candidate.serialize_sandbox_result(result)
+
+    assert payload["tests_passed"] == 1
+    assert payload["tests_failed"] == 2
+    assert payload["last_run_at"] is not None
+    parsed = json.loads(payload["test_output"])
+    assert parsed["status"] == "failed"
+    assert parsed["passed"] == 1
+    assert parsed["failed"] == 2
+    assert parsed["total"] == 3
+    assert parsed["stdout"] == "out"
+    assert parsed["stderr"] == "err"
+    assert parsed["timeout"] is False
+
+
+def test_validate_run_payload_rejects_non_code_task():
+    class DummyTask:
+        type = "design"
+
+    dummy_payload = type("p", (), {"codeBlob": "x", "files": None})
+    with pytest.raises(HTTPException) as exc:
+        service_candidate.validate_run_payload(DummyTask(), dummy_payload)
+    assert exc.value.status_code == 400
+
+
+def test_parse_test_output_handles_json_and_fallback():
+    raw = json.dumps({"status": "passed", "passed": 1, "failed": 0})
+    parsed = service_recruiter.parse_test_output(raw)
+    assert isinstance(parsed, dict)
+    assert parsed["status"] == "passed"
+
+    non_json = "stdout:\nhello"
+    assert service_recruiter.parse_test_output(non_json) == non_json


### PR DESCRIPTION
## Summary

This PR extends the `submissions` data model to persist sandbox test results and updates the **final code submission** flow so that **submitting a code/debug task runs tests and stores the final results** on the `submissions` row. It also keeps recruiter-facing reads compatible and improves test infrastructure to avoid external sandbox calls.

## Why

Recruiters need to inspect **what happened when candidate code was run** (pass/fail counts and output). Storing results on the submission enables:
- Recruiter review and auditing
- Execution Profile scoring downstream (M2/M3)
- Consistent data retrieval without re-running tests

---

## What changed

### 1) Database: `submissions` now stores test run metadata

Added/confirmed the following nullable fields on `submissions`:

- `tests_passed` (integer, nullable)
- `tests_failed` (integer, nullable)
- `test_output` (text; stores JSON string payload or legacy string, nullable)
- `last_run_at` (timestamp with timezone, nullable)

**Migration**
- Added Alembic migration: `3d7f8c5b6b8c_add_last_run_at_to_submissions.py`
  - Adds `last_run_at` column.

> Note: `tests_passed`, `tests_failed`, and `test_output` already existed in the base schema/migrations; this PR ensures they remain nullable and adds coverage/tests that these columns exist.

---

### 2) Candidate final submit runs sandbox tests and persists results

Updated `POST /api/tasks/{taskId}/submit`:

- For **code/debug tasks**:
  - validates payload
  - runs sandbox tests using the same taskRef mapping as `/run`
  - persists results on the `Submission` row:
    - `tests_passed`, `tests_failed`
    - `test_output` = JSON string containing:
      ```json
      {
        "status": "passed|failed|timeout|error",
        "passed": 1,
        "failed": 0,
        "total": 1,
        "stdout": "...",
        "stderr": "...",
        "timeout": false
      }
      ```
    - `last_run_at` set to submission time

- For **non-code tasks**:
  - does **not** run sandbox
  - keeps test fields **null**

**Error behavior**
- If sandbox fails on submit:
  - returns `502 Sandbox unavailable. Please try again.`
  - **does not persist** a submission row

---

### 3) Recruiter read paths support structured test output

Updated recruiter submission detail (`GET /api/submissions/{submissionId}`) to:
- Parse `test_output` if it is JSON and return it as a structured `dict`
- Fall back to legacy string output if parsing fails
- Derive `testResults.status` using:
  - structured status / timeout flag if present
  - else counts-based fallback
- Include `lastRunAt` in `testResults`

Schema update:
- `testResults.output` now supports `dict | str | None`

---

### 4) Shared helpers & service-layer cleanup

Added shared helpers under `domain/submissions/service_candidate.py` and `service_recruiter.py`:

Candidate:
- `is_code_task(task)` – identifies code/debug tasks
- `run_sandbox_tests(db, task, payload, sandbox_client)` – shared sandbox runner
- `serialize_sandbox_result(result, now=...)` – stores standardized JSON output into submission fields
- `create_submission(..., sandbox_result=...)` – persists sandbox result fields on insert

Recruiter:
- `parse_test_output(test_output)` – JSON -> dict when possible
- `derive_test_status(passed, failed, output)` – robust status derivation supporting dict/string

---

## Files changed (high level)

- `alembic/versions/3d7f8c5b6b8c_add_last_run_at_to_submissions.py`
- `app/domain/submissions/submission.py` (model: nullable flags + last_run_at)
- `app/domain/submissions/service_candidate.py` (store sandbox results + helpers)
- `app/domain/submissions/service_recruiter.py` (parse/derive status for structured output)
- `app/api/routes/recruiter/submissions.py` (surface parsed output + lastRunAt)
- `app/domain/submissions/schemas.py` (output supports dict|string)
- `tests/conftest.py` (fixture-scoped `sandbox_stubber` dependency override)
- `tests/api/test_tasks_api.py` (submit persists sandbox results; sandbox error returns 502 + no row)
- `tests/api/test_task_submit.py` (uses sandbox stub to avoid external calls)
- `tests/api/test_recruiter_submissions_get.py` (structured output parsing test)
- `tests/test_submissions_schema_columns.py` (schema inspection coverage)

---

## API behavior notes

### Candidate
- `POST /api/tasks/{taskId}/run`
  - Still runs tests without persisting to DB.
- `POST /api/tasks/{taskId}/submit`
  - For code/debug tasks:
    - runs tests
    - persists results on submission
  - For text tasks:
    - persists submission only

### Recruiter
- `GET /api/submissions/{submissionId}`
  - `testResults` now may include structured `output` (dict) if stored JSON is present:
    ```json
    "testResults": {
      "status": "failed",
      "passed": 1,
      "failed": 2,
      "total": 3,
      "output": { "stdout": "...", "stderr": "...", ... },
      "lastRunAt": "2025-12-25T..."
    }
    ```

---

## Test coverage

Run:
```bash
poetry run pytest
./precommit.sh
```

Added/updated tests include:

- **Migration/schema**
  - `test_submissions_schema_columns.py` verifies required columns exist:
    - `tests_passed`, `tests_failed`, `test_output`, `last_run_at`

- **Candidate submit persistence**
  - Submitting a code task persists:
    - `tests_passed`, `tests_failed`, `test_output` (JSON), `last_run_at`
  - Submitting a text task leaves these fields null
  - Sandbox error on submit returns 502 and no submission row is created

- **Recruiter structured output**
  - Recruiter endpoint parses JSON `test_output` into dict and surfaces it in response

- **Sandbox stubbing**
  - Added `sandbox_stubber` fixture to override `get_sandbox_client` dependency per-test to avoid external sandbox calls.

---

## Manual QA (recommended checklist)

1) Apply migrations:
```bash
alembic upgrade head
```

2) Create simulation + invite a candidate.
3) Submit Day 1 (design) → verify submission created, `testResults` absent or null.
4) Run tests on Day 2 (code) via `/run` → verify 200 and output.
5) Submit Day 2 (code) via `/submit` → verify 201 and then:
   - recruiter fetch submission detail includes `testResults`
   - `testResults.lastRunAt` exists
   - `testResults.output` includes `stdout/stderr` and counts

6) Verify that attempting to submit code when sandbox is down returns 502 and does not create a submission.

---

## Rollout / env vars

No new env vars for this issue beyond existing sandbox integration from Issue #11.

**Make sure** production/staging applies:
```bash
alembic upgrade head
```

---

## Acceptance criteria mapping (Issue #12)

- ✅ Added fields to submissions: `tests_passed`, `tests_failed`, `test_output`, `last_run_at`
- ✅ Final code submission runs tests and stores final results in submission record
- ✅ Shared logic between `/run` and submit flow (`run_sandbox_tests`, taskRef mapping)
- ✅ Migration applies cleanly (plus schema-column test coverage)
- ✅ Successful run persists non-null fields for code submissions
- ✅ Failing test run sets `tests_failed > 0` and stores output
- ✅ Non-code tasks keep test fields null

---

## Follow-ups (not required for this PR)

- Store sandbox `duration_ms` in DB (optional)
- Capture a stable sandbox `run_id` for traceability (optional)
- Add explicit recruiter submissions list endpoint test assertions for `testResults` when present


Fixes #12 