### PR TITLE
Enhanced Testing Suite to 100% Coverage Until Milestone 1 Beginngng

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,3 +209,4 @@ __marimo__/
 # macOS system files
 .DS_Store
 local.db
+setEnvVar.sh

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,15 +48,6 @@ build-backend = "poetry.core.masonry.api"
 [tool.coverage.run]
 omit = [
     "app/models/core.py",  # legacy models not used; conflicts with current ORM setup
-    "**/services/github/*",
-    "**/domain/workspaces/*",
-    "**/api/routes/candidate/submissions.py",
-    "**/domain/submissions/service_candidate.py",
-    "**/api/routes/candidate/sessions.py",
-    "**/domain/simulations/service.py",
-    "**/core/security/dependencies.py",
-    "**/domain/submissions/service_recruiter.py",
-    "**/api/routes/recruiter/submissions.py",
 ]
 source = ["app"]
 

--- a/tests/api/test_recruiter_submissions_get.py
+++ b/tests/api/test_recruiter_submissions_get.py
@@ -184,7 +184,9 @@ async def test_recruiter_list_includes_links(async_client, async_session: AsyncS
         headers={"x-dev-user-email": recruiter.email},
     )
     assert resp.status_code == 200, resp.text
-    items = resp.json()["items"]
+    body = resp.json()
+    assert set(body.keys()) == {"items"}
+    items = body["items"]
     found = next(i for i in items if i["submissionId"] == sub.id)
     assert found["repoFullName"] == "org/repo"
     assert found["workflowRunId"] == "555"

--- a/tests/api/test_task_run.py
+++ b/tests/api/test_task_run.py
@@ -1,8 +1,14 @@
+from datetime import UTC, datetime
+
 import pytest
+from sqlalchemy import select
 
 from app.api.routes.candidate import submissions as candidate_submissions
+from app.domain.workspaces import repository as workspace_repo
+from app.domain.workspaces.workspace import Workspace
 from app.main import app
 from app.services.github.actions import ActionsRunResult
+from app.services.github.client import GithubError
 from tests.factories import (
     create_candidate_session,
     create_recruiter,
@@ -82,6 +88,121 @@ async def test_codespace_init_missing_template_repo_returns_500(
 
 
 @pytest.mark.asyncio
+async def test_codespace_init_reuses_existing_workspace_and_skips_github(
+    async_client, async_session, candidate_header_factory
+):
+    recruiter = await create_recruiter(async_session, email="reuse@sim.com")
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session, simulation=sim, status="in_progress"
+    )
+    # Complete day 1 to unlock day 2 code task
+    await create_submission(
+        async_session, candidate_session=cs, task=tasks[0], content_text="day1"
+    )
+    await async_session.commit()
+
+    existing = await workspace_repo.create_workspace(
+        async_session,
+        candidate_session_id=cs.id,
+        task_id=tasks[1].id,
+        template_repo_full_name=tasks[1].template_repo or "",
+        repo_full_name="org/precreated-repo",
+        repo_id=321,
+        default_branch="main",
+        base_template_sha="base-precreated",
+        created_at=datetime.now(UTC),
+    )
+
+    calls: dict[str, int] = {"generate": 0}
+
+    class CountingGithubClient:
+        async def generate_repo_from_template(
+            self,
+            *,
+            template_full_name: str,
+            new_repo_name: str,
+            owner=None,
+            private=True,
+        ):
+            calls["generate"] += 1
+            raise AssertionError("generate_repo_from_template should not be called")
+
+        async def add_collaborator(
+            self, repo_full_name: str, username: str, *, permission: str = "push"
+        ):
+            calls.setdefault("collab", 0)
+            calls["collab"] += 1
+
+        async def get_branch(self, repo_full_name: str, branch: str):
+            return {}
+
+        async def get_compare(self, repo_full_name: str, base: str, head: str):
+            return {}
+
+    app.dependency_overrides[candidate_submissions.get_github_client] = (
+        lambda: CountingGithubClient()
+    )
+    try:
+        headers = candidate_header_factory(cs.id, cs.token)
+        resp = await async_client.post(
+            f"/api/tasks/{tasks[1].id}/codespace/init",
+            headers=headers,
+            json={"githubUsername": "octocat"},
+        )
+    finally:
+        app.dependency_overrides.pop(candidate_submissions.get_github_client, None)
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["workspaceId"] == existing.id
+    assert body["repoFullName"] == existing.repo_full_name
+    assert calls["generate"] == 0
+
+    rows = await async_session.execute(
+        select(Workspace).where(
+            Workspace.candidate_session_id == cs.id, Workspace.task_id == tasks[1].id
+        )
+    )
+    assert len(list(rows.scalars())) == 1
+
+
+@pytest.mark.asyncio
+async def test_codespace_init_maps_github_errors_to_502(
+    async_client, async_session, candidate_header_factory
+):
+    recruiter = await create_recruiter(async_session, email="gh-error@sim.com")
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session, simulation=sim, status="in_progress"
+    )
+    await create_submission(
+        async_session, candidate_session=cs, task=tasks[0], content_text="day1"
+    )
+    await async_session.commit()
+
+    class ErrorGithubClient:
+        async def generate_repo_from_template(self, **_kwargs):
+            raise GithubError("Bad credentials", status_code=403)
+
+    app.dependency_overrides[candidate_submissions.get_github_client] = (
+        lambda: ErrorGithubClient()
+    )
+    try:
+        headers = candidate_header_factory(cs.id, cs.token)
+        resp = await async_client.post(
+            f"/api/tasks/{tasks[1].id}/codespace/init",
+            headers=headers,
+            json={"githubUsername": "octocat"},
+        )
+    finally:
+        app.dependency_overrides.pop(candidate_submissions.get_github_client, None)
+
+    assert resp.status_code == 502
+    assert "GitHub unavailable" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
 async def test_run_tests_returns_actions_result(
     async_client, async_session, candidate_header_factory, actions_stubber
 ):
@@ -136,6 +257,53 @@ async def test_run_tests_returns_actions_result(
     assert body["status"] == "failed"
     assert body["runId"] == 111
     assert body["commitSha"] == "abc123"
+    assert body["timeout"] is False
+
+
+@pytest.mark.asyncio
+async def test_run_tests_rate_limited_when_prod_env(
+    async_client, async_session, candidate_header_factory, actions_stubber, monkeypatch
+):
+    monkeypatch.setattr(candidate_submissions.settings, "ENV", "prod")
+    candidate_submissions._RATE_LIMIT_STORE.clear()
+    original_rule = dict(candidate_submissions._RATE_LIMIT_RULE)
+    candidate_submissions._RATE_LIMIT_RULE["run"] = (1, 60.0)
+
+    recruiter = await create_recruiter(async_session, email="rate@sim.com")
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session, simulation=sim, status="in_progress"
+    )
+    await create_submission(
+        async_session, candidate_session=cs, task=tasks[0], content_text="day1"
+    )
+    await async_session.commit()
+
+    actions_stubber()
+    headers = candidate_header_factory(cs.id, cs.token)
+    await async_client.post(
+        f"/api/tasks/{tasks[1].id}/codespace/init",
+        headers=headers,
+        json={"githubUsername": "octocat"},
+    )
+
+    first = await async_client.post(
+        f"/api/tasks/{tasks[1].id}/run",
+        headers=headers,
+        json={},
+    )
+    assert first.status_code == 200, first.text
+
+    second = await async_client.post(
+        f"/api/tasks/{tasks[1].id}/run",
+        headers=headers,
+        json={},
+    )
+    assert second.status_code == 429
+
+    # reset ENV/rules to avoid bleed
+    monkeypatch.setattr(candidate_submissions.settings, "ENV", "local")
+    candidate_submissions._RATE_LIMIT_RULE.update(original_rule)
 
 
 @pytest.mark.asyncio
@@ -204,6 +372,45 @@ async def test_run_tests_handles_actions_error(
 
     assert resp.status_code == 502
     assert "GitHub unavailable" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_codespace_status_returns_summary(
+    async_client, async_session, candidate_header_factory
+):
+    recruiter = await create_recruiter(async_session, email="status@sim.com")
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session, simulation=sim, status="in_progress"
+    )
+    await create_submission(
+        async_session, candidate_session=cs, task=tasks[0], content_text="day1"
+    )
+    await async_session.commit()
+
+    workspace = await workspace_repo.create_workspace(
+        async_session,
+        candidate_session_id=cs.id,
+        task_id=tasks[1].id,
+        template_repo_full_name=tasks[1].template_repo or "",
+        repo_full_name="org/status-repo",
+        repo_id=111,
+        default_branch="main",
+        base_template_sha="base",
+        created_at=datetime.now(UTC),
+    )
+    workspace.last_test_summary_json = "{not-json"
+    await async_session.commit()
+
+    headers = candidate_header_factory(cs.id, cs.token)
+    resp = await async_client.get(
+        f"/api/tasks/{tasks[1].id}/codespace/status",
+        headers=headers,
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["repoFullName"] == "org/status-repo"
+    assert data["lastTestSummary"] is None
 
 
 @pytest.mark.asyncio
@@ -292,3 +499,71 @@ async def test_get_run_result_marks_timeout(
     data = resp.json()
     assert data["timeout"] is True
     assert data["runId"] == timed_out.run_id
+
+
+@pytest.mark.asyncio
+async def test_get_run_result_github_error_maps_to_502(
+    async_client, async_session, candidate_header_factory
+):
+    recruiter = await create_recruiter(async_session, email="run-fetch-err@sim.com")
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session, simulation=sim, status="in_progress"
+    )
+    await create_submission(
+        async_session, candidate_session=cs, task=tasks[0], content_text="day1"
+    )
+    await async_session.commit()
+
+    class ErrorRunner:
+        async def fetch_run_result(self, **_kwargs):
+            raise GithubError("nope")
+
+    class StubGithubClient:
+        async def generate_repo_from_template(
+            self,
+            *,
+            template_full_name: str,
+            new_repo_name: str,
+            owner=None,
+            private=True,
+        ):
+            return {
+                "full_name": f"org/{new_repo_name}",
+                "id": 1,
+                "default_branch": "main",
+            }
+
+        async def add_collaborator(
+            self, repo_full_name: str, username: str, *, permission: str = "push"
+        ):
+            return {"ok": True}
+
+        async def get_branch(self, repo_full_name: str, branch: str):
+            return {"commit": {"sha": "base"}}
+
+        async def get_compare(self, repo_full_name: str, base: str, head: str):
+            return {}
+
+    app.dependency_overrides[candidate_submissions.get_actions_runner] = (
+        lambda: ErrorRunner()
+    )
+    app.dependency_overrides[candidate_submissions.get_github_client] = (
+        lambda: StubGithubClient()
+    )
+    try:
+        headers = candidate_header_factory(cs.id, cs.token)
+        await async_client.post(
+            f"/api/tasks/{tasks[1].id}/codespace/init",
+            headers=headers,
+            json={"githubUsername": "octocat"},
+        )
+        resp = await async_client.get(
+            f"/api/tasks/{tasks[1].id}/run/9999",
+            headers=headers,
+        )
+    finally:
+        app.dependency_overrides.pop(candidate_submissions.get_actions_runner, None)
+        app.dependency_overrides.pop(candidate_submissions.get_github_client, None)
+
+    assert resp.status_code == 502

--- a/tests/security/test_dependencies.py
+++ b/tests/security/test_dependencies.py
@@ -1,0 +1,229 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+
+import pytest
+from fastapi import Request
+from fastapi.security import HTTPAuthorizationCredentials
+
+from app.core.security import dependencies
+from tests.factories import create_recruiter
+
+
+def _make_request(headers: dict[str, str], host: str = "127.0.0.1") -> Request:
+    scope = {
+        "type": "http",
+        "headers": [(k.encode(), v.encode()) for k, v in headers.items()],
+        "client": (host, 1234),
+        "path": "/",
+        "method": "GET",
+        "query_string": b"",
+        "server": ("test", 80),
+    }
+
+    async def _receive():
+        return {"type": "http.request"}
+
+    return Request(scope, _receive)
+
+
+@pytest.mark.asyncio
+async def test_dev_bypass_allows_local_requests(async_session, monkeypatch):
+    user = await create_recruiter(async_session, email="dev@local.test")
+    req = _make_request({"x-dev-user-email": user.email})
+    monkeypatch.setattr(dependencies, "_env_name", lambda: "local")
+    result = await dependencies._dev_bypass_user(req, async_session)
+    assert result.email == user.email
+
+
+@pytest.mark.asyncio
+async def test_dev_bypass_rejects_non_localhost(async_session, monkeypatch):
+    user = await create_recruiter(async_session, email="remote@local.test")
+    req = _make_request({"x-dev-user-email": user.email}, host="10.0.0.1")
+    monkeypatch.setattr(dependencies, "_env_name", lambda: "local")
+    with pytest.raises(Exception) as excinfo:
+        await dependencies._dev_bypass_user(req, async_session)
+    assert "localhost" in str(excinfo.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_dev_bypass_guard_against_prod(monkeypatch):
+    req = _make_request({"x-dev-user-email": "x@example.com"})
+    monkeypatch.setenv("DEV_AUTH_BYPASS", "1")
+    monkeypatch.setattr(dependencies, "_env_name", lambda: "prod")
+    with pytest.raises(RuntimeError):
+        await dependencies._dev_bypass_user(req, None)
+
+
+@pytest.mark.asyncio
+async def test_auth0_user_creates_new_user(async_session, monkeypatch):
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="tok")
+    monkeypatch.setattr(
+        dependencies.auth0,
+        "decode_auth0_token",
+        lambda _t: {"email": "newuser@example.com", "name": "New User"},
+    )
+
+    user = await dependencies._auth0_user(creds, async_session)
+    assert user.email == "newuser@example.com"
+    assert user.role == "recruiter"
+
+
+def test_env_name_override(monkeypatch):
+    override_module = type("m", (), {"_env_name": lambda: "override"})
+    monkeypatch.setitem(
+        dependencies.sys.modules, "app.core.security.current_user", override_module
+    )
+    assert dependencies._env_name() == "override"
+
+
+@pytest.mark.asyncio
+async def test_dev_bypass_returns_none_when_header_missing(monkeypatch):
+    req = _make_request({})
+    monkeypatch.setattr(dependencies, "_env_name", lambda: "local")
+    assert await dependencies._dev_bypass_user(req, None) is None
+
+
+@pytest.mark.asyncio
+async def test_dev_bypass_fallback_session_maker(monkeypatch):
+    req = _make_request({"x-dev-user-email": "missing@example.com"})
+    monkeypatch.setattr(dependencies, "_env_name", lambda: "local")
+
+    class DummySession:
+        async def execute(self, *_a, **_k):
+            class R:
+                def scalar_one_or_none(self):
+                    return None
+
+            return R()
+
+        async def commit(self):
+            return None
+
+    @asynccontextmanager
+    async def dummy_maker():
+        yield DummySession()
+
+    monkeypatch.setitem(
+        dependencies.sys.modules,
+        "app.core.security.current_user",
+        type("mod", (), {"async_session_maker": dummy_maker}),
+    )
+
+    with pytest.raises(Exception) as excinfo:
+        await dependencies._dev_bypass_user(req, None)
+    assert "Dev user not found" in str(excinfo.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_auth0_user_uses_fallback_session(monkeypatch):
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="tok")
+    monkeypatch.setattr(
+        dependencies.auth0,
+        "decode_auth0_token",
+        lambda _t: {"email": "fallback@example.com"},
+    )
+
+    class DummySession:
+        def __init__(self):
+            self.added = False
+            self.committed = False
+            self.refreshed = False
+
+        async def execute(self, *_a, **_k):
+            class R:
+                def scalar_one_or_none(self_inner):
+                    return None
+
+            return R()
+
+        def add(self, _obj):
+            self.added = True
+
+        async def commit(self):
+            self.committed = True
+
+        async def refresh(self, _obj):
+            self.refreshed = True
+
+    @asynccontextmanager
+    async def dummy_maker():
+        yield DummySession()
+
+    monkeypatch.setitem(
+        dependencies.sys.modules,
+        "app.core.security.current_user",
+        type("mod", (), {"async_session_maker": dummy_maker}),
+    )
+
+    user = await dependencies._auth0_user(creds, None)
+    assert user.email == "fallback@example.com"
+    assert user.role == "recruiter"
+
+
+@pytest.mark.asyncio
+async def test_auth0_user_handles_integrity_error(monkeypatch):
+    creds = HTTPAuthorizationCredentials(scheme="Bearer", credentials="tok")
+    monkeypatch.setattr(
+        dependencies.auth0,
+        "decode_auth0_token",
+        lambda _t: {"email": "dup@example.com"},
+    )
+
+    class DummySession:
+        def __init__(self):
+            self.rollback_called = False
+            self.calls = 0
+
+        async def execute(self, *_a, **_k):
+            self.calls += 1
+
+            class R:
+                def scalar_one_or_none(self_inner):
+                    if self.calls == 1:
+                        return None
+                    return type("User", (), {"email": "dup@example.com"})
+
+            return R()
+
+        def add(self, _obj):
+            return None
+
+        async def commit(self):
+            raise dependencies.IntegrityError("", {}, None)
+
+        async def rollback(self):
+            self.rollback_called = True
+
+    session = DummySession()
+    user = await dependencies._auth0_user(creds, session)
+    assert user.email == "dup@example.com"
+    assert session.rollback_called is True
+
+
+@pytest.mark.asyncio
+async def test_get_current_user_prefers_dev_bypass(monkeypatch, async_session):
+    req = _make_request({"x-dev-user-email": "dev@local.test"})
+    dummy_user = object()
+
+    async def _return_user(*_a, **_k):
+        return dummy_user
+
+    monkeypatch.setattr(dependencies, "_dev_bypass_user", _return_user)
+    result = await dependencies.get_current_user(req, None, async_session)
+    assert result is dummy_user
+
+
+def test_env_helpers(monkeypatch):
+    monkeypatch.setattr(dependencies.settings, "ENV", "Prod")
+    assert dependencies._env_name_base() == "prod"
+    # No override module present -> falls back to base env
+    dependencies.sys.modules.pop("app.core.security.current_user", None)
+    assert dependencies._env_name() == "prod"
+
+
+@pytest.mark.asyncio
+async def test_dev_bypass_returns_none_for_prod_env(monkeypatch):
+    req = _make_request({"x-dev-user-email": "prod@local.test"})
+    monkeypatch.setattr(dependencies, "_env_name", lambda: "prod")
+    assert await dependencies._dev_bypass_user(req, None) is None

--- a/tests/unit/test_app_internals.py
+++ b/tests/unit/test_app_internals.py
@@ -93,3 +93,19 @@ def test_create_app_adds_proxy_headers(monkeypatch):
 
     create_app()
     assert "ProxyHeadersMiddleware" in calls
+
+
+@pytest.mark.asyncio
+async def test_lifespan_calls_init_db(monkeypatch):
+    from app.api import main as api_main
+
+    called = False
+
+    async def fake_init():
+        nonlocal called
+        called = True
+
+    monkeypatch.setattr(api_main, "init_db_if_needed", fake_init)
+    async with api_main.lifespan(create_app()):
+        pass
+    assert called is True

--- a/tests/unit/test_candidate_session_service.py
+++ b/tests/unit/test_candidate_session_service.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi import HTTPException
+
+from app.domain.candidate_sessions import service as cs_service
+from tests.factories import (
+    create_candidate_session,
+    create_recruiter,
+    create_simulation,
+)
+
+
+@pytest.mark.asyncio
+async def test_fetch_by_token_404(async_session):
+    with pytest.raises(HTTPException) as excinfo:
+        await cs_service.fetch_by_token(async_session, "missing-token")
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_fetch_by_token_expired(async_session):
+    recruiter = await create_recruiter(async_session, email="expire@sim.com")
+    sim, _ = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session,
+        simulation=sim,
+        status="in_progress",
+        expires_in_days=-1,
+    )
+    now = datetime.now(UTC)
+    with pytest.raises(HTTPException) as excinfo:
+        await cs_service.fetch_by_token(async_session, cs.token, now=now)
+    assert excinfo.value.status_code == 410
+
+
+@pytest.mark.asyncio
+async def test_fetch_by_id_and_token_mismatch(async_session):
+    recruiter = await create_recruiter(async_session, email="mismatch@sim.com")
+    sim, _ = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session, simulation=sim, status="in_progress"
+    )
+    with pytest.raises(HTTPException) as excinfo:
+        await cs_service.fetch_by_id_and_token(async_session, cs.id, "wrong-token")
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_load_tasks_empty(async_session):
+    recruiter = await create_recruiter(async_session, email="empty@sim.com")
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    for t in tasks:
+        await async_session.delete(t)
+    await async_session.commit()
+    with pytest.raises(HTTPException) as excinfo:
+        await cs_service.load_tasks(async_session, sim.id)
+    assert excinfo.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_fetch_by_token_success(async_session):
+    recruiter = await create_recruiter(async_session, email="ok@sim.com")
+    sim, _ = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session, simulation=sim, status="in_progress"
+    )
+    loaded = await cs_service.fetch_by_token(async_session, cs.token)
+    assert loaded.id == cs.id
+
+
+@pytest.mark.asyncio
+async def test_fetch_by_id_and_token_success(async_session):
+    recruiter = await create_recruiter(async_session, email="ok2@sim.com")
+    sim, _ = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session, simulation=sim, status="in_progress"
+    )
+    loaded = await cs_service.fetch_by_id_and_token(async_session, cs.id, cs.token)
+    assert loaded.id == cs.id

--- a/tests/unit/test_candidate_sessions_router.py
+++ b/tests/unit/test_candidate_sessions_router.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from app.api.routes.candidate import sessions as candidate_sessions
+
+
+class StubSession:
+    def __init__(self):
+        self.committed = False
+        self.refreshed = False
+
+    async def commit(self):
+        self.committed = True
+
+    async def refresh(self, _obj):
+        self.refreshed = True
+
+
+@pytest.mark.asyncio
+async def test_resolve_candidate_session_sets_started(monkeypatch):
+    stub_db = StubSession()
+    cs = SimpleNamespace(
+        id=1,
+        status="not_started",
+        started_at=None,
+        completed_at=None,
+        candidate_name="Jane",
+        simulation=SimpleNamespace(id=10, title="Sim", role="Backend"),
+    )
+
+    async def _return_cs(*_a, **_k):
+        return cs
+
+    monkeypatch.setattr(candidate_sessions.cs_service, "fetch_by_token", _return_cs)
+    result = await candidate_sessions.resolve_candidate_session(
+        token="t" * 24, db=stub_db
+    )
+    assert stub_db.committed is True
+    assert stub_db.refreshed is True
+    assert result.status == "in_progress"
+    assert cs.started_at is not None
+    assert isinstance(result.startedAt, datetime)
+    assert cs.started_at.tzinfo == UTC
+
+
+@pytest.mark.asyncio
+async def test_get_current_task_marks_completed(monkeypatch):
+    stub_db = StubSession()
+    cs = SimpleNamespace(
+        id=2,
+        status="in_progress",
+        completed_at=None,
+        simulation_id=1,
+    )
+    current_task = SimpleNamespace(
+        id=99, day_index=3, title="Task", type="code", description="desc"
+    )
+
+    async def _fetch_by_id(db, session_id, token, now):
+        assert session_id == cs.id
+        return cs
+
+    async def _progress_snapshot(db, candidate_session):
+        return (
+            [current_task],
+            {1, 2, 3},
+            current_task,
+            3,
+            3,
+            True,
+        )
+
+    monkeypatch.setattr(
+        candidate_sessions.cs_service, "fetch_by_id_and_token", _fetch_by_id
+    )
+    monkeypatch.setattr(
+        candidate_sessions.cs_service, "progress_snapshot", _progress_snapshot
+    )
+
+    resp = await candidate_sessions.get_current_task(
+        candidate_session_id=cs.id, x_candidate_token="tok", db=stub_db
+    )
+    assert resp.isComplete is True
+    assert resp.currentDayIndex is None
+    assert cs.status == "completed"
+    assert stub_db.committed is True
+    assert cs.completed_at is not None

--- a/tests/unit/test_db_init.py
+++ b/tests/unit/test_db_init.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from types import SimpleNamespace
+
+import pytest
+
+from app.core import db
+
+
+@pytest.mark.asyncio
+async def test_init_db_if_needed_runs_when_using_sqlite(monkeypatch):
+    conn_called = False
+
+    class StubConn:
+        async def run_sync(self, fn):
+            nonlocal conn_called
+            conn_called = True
+            return None
+
+    @asynccontextmanager
+    async def begin():
+        yield StubConn()
+
+    monkeypatch.setattr(db, "USING_SQLITE_FALLBACK", True)
+    monkeypatch.setattr(db, "engine", SimpleNamespace(begin=begin))
+
+    await db.init_db_if_needed()
+    assert conn_called is True
+
+
+@pytest.mark.asyncio
+async def test_init_db_if_needed_noop_when_not_fallback(monkeypatch):
+    monkeypatch.setattr(db, "USING_SQLITE_FALLBACK", False)
+    called = False
+
+    async def fake_begin():
+        nonlocal called
+        called = True
+        yield None
+
+    monkeypatch.setattr(db, "engine", SimpleNamespace(begin=fake_begin))
+    await db.init_db_if_needed()
+    assert called is False

--- a/tests/unit/test_github_actions_runner.py
+++ b/tests/unit/test_github_actions_runner.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.services.github.actions import ActionsRunResult, GithubActionsRunner
+from app.services.github.artifacts import ParsedTestResults
+from app.services.github.client import (
+    GithubClient,
+    GithubError,
+    WorkflowRun,
+)
+
+
+class _StubClient(GithubClient):
+    def __init__(self):
+        super().__init__(base_url="https://api.github.com", token="x")
+        self.dispatched = False
+        self.run_calls = 0
+
+    async def trigger_workflow_dispatch(self, *args, **kwargs):
+        self.dispatched = True
+
+    async def list_workflow_runs(
+        self, repo_full_name, workflow_id_or_file, *, branch=None, per_page=5
+    ):
+        self.run_calls += 1
+        now = datetime.now(UTC).isoformat()
+        return [
+            WorkflowRun(
+                id=1,
+                status="completed",
+                conclusion="success",
+                html_url="https://example.com/run/1",
+                head_sha="abc123",
+                artifact_count=1,
+                event="workflow_dispatch",
+                created_at=now,
+            )
+        ]
+
+    async def get_workflow_run(self, repo_full_name, run_id):
+        now = datetime.now(UTC).isoformat()
+        return WorkflowRun(
+            id=run_id,
+            status="completed",
+            conclusion="failure",
+            html_url="https://example.com/run/2",
+            head_sha="def456",
+            artifact_count=0,
+            event="workflow_dispatch",
+            created_at=now,
+        )
+
+    async def list_artifacts(self, repo_full_name: str, run_id: int):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_dispatch_and_wait_returns_normalized_result(monkeypatch):
+    client = _StubClient()
+    runner = GithubActionsRunner(
+        client,
+        workflow_file="ci.yml",
+        poll_interval_seconds=0.01,
+        max_poll_seconds=0.1,
+    )
+
+    async def fake_parse(repo, run_id):
+        return ParsedTestResults(
+            passed=2, failed=1, total=3, stdout="ok", stderr="", summary={"s": 1}
+        )
+
+    monkeypatch.setattr(runner, "_parse_artifacts", fake_parse)
+
+    result = await runner.dispatch_and_wait(
+        repo_full_name="org/repo", ref="main", inputs={"a": "b"}
+    )
+
+    assert client.dispatched is True
+    assert result.status == "passed"
+    assert result.passed == 2
+    assert result.failed == 1
+    assert result.total == 3
+    assert result.stdout == "ok"
+    assert result.raw and result.raw["summary"]["s"] == 1
+
+
+@pytest.mark.asyncio
+async def test_dispatch_and_wait_times_out_when_no_run(monkeypatch):
+    class EmptyClient(GithubClient):
+        def __init__(self):
+            super().__init__(base_url="https://api.github.com", token="x")
+
+        async def trigger_workflow_dispatch(self, *args, **kwargs):
+            return None
+
+        async def list_workflow_runs(self, *args, **kwargs):
+            return []
+
+    runner = GithubActionsRunner(
+        EmptyClient(),
+        workflow_file="ci.yml",
+        poll_interval_seconds=0.01,
+        max_poll_seconds=0.05,
+    )
+    with pytest.raises(GithubError):
+        await runner.dispatch_and_wait(repo_full_name="org/repo", ref="main")
+
+
+def test_normalize_run_variants():
+    client = _StubClient()
+    runner = GithubActionsRunner(client, workflow_file="ci.yml")
+    success = runner._normalize_run(
+        WorkflowRun(
+            id=1,
+            status="completed",
+            conclusion="success",
+            html_url=None,
+            head_sha="sha",
+        )
+    )
+    assert success.status == "passed"
+
+    failure = runner._normalize_run(
+        WorkflowRun(
+            id=2,
+            status="completed",
+            conclusion="timed_out",
+            html_url=None,
+            head_sha="sha",
+        )
+    )
+    assert failure.status == "failed"
+    assert failure.conclusion == "timed_out"
+
+    running = runner._normalize_run(
+        WorkflowRun(
+            id=3,
+            status="in_progress",
+            conclusion=None,
+            html_url=None,
+            head_sha=None,
+        ),
+        running=True,
+    )
+    assert running.status == "running"
+
+
+@pytest.mark.asyncio
+async def test_dispatch_and_wait_returns_running_when_candidate_never_finishes(
+    monkeypatch,
+):
+    class SlowClient(GithubClient):
+        def __init__(self):
+            super().__init__(base_url="https://api.github.com", token="x")
+            self.calls = 0
+
+        async def trigger_workflow_dispatch(self, *args, **kwargs):
+            return None
+
+        async def list_workflow_runs(self, *_a, **_k):
+            self.calls += 1
+            now = datetime.now(UTC).isoformat()
+            return [
+                WorkflowRun(
+                    id=8,
+                    status="queued",
+                    conclusion=None,
+                    html_url="https://example.com/run/8",
+                    head_sha="sha8",
+                    artifact_count=0,
+                    event="workflow_dispatch",
+                    created_at=now,
+                )
+            ]
+
+    runner = GithubActionsRunner(
+        SlowClient(),
+        workflow_file="ci.yml",
+        poll_interval_seconds=0.01,
+        max_poll_seconds=0.02,
+    )
+    result = await runner.dispatch_and_wait(repo_full_name="org/repo", ref="main")
+    assert result.status == "running"
+
+
+@pytest.mark.asyncio
+async def test_fetch_run_result_and_artifact_parsing_paths(monkeypatch):
+    class ArtifactClient(GithubClient):
+        def __init__(self):
+            super().__init__(base_url="https://api.github.com", token="x")
+
+        async def get_workflow_run(self, *_a, **_k):
+            now = datetime.now(UTC).isoformat()
+            return WorkflowRun(
+                id=12,
+                status="completed",
+                conclusion="failure",
+                html_url="https://example.com/run/12",
+                head_sha="sha12",
+                artifact_count=1,
+                event="workflow_dispatch",
+                created_at=now,
+            )
+
+        async def list_artifacts(self, *_a, **_k):
+            return [
+                {"id": 0, "expired": True},
+                {"id": None},
+                {"id": 99, "name": "other"},
+            ]
+
+        async def download_artifact_zip(self, *_a, **_k):
+            raise GithubError("fail")
+
+    runner = GithubActionsRunner(ArtifactClient(), workflow_file="ci.yml")
+    result = await runner.fetch_run_result(repo_full_name="org/repo", run_id=12)
+    assert result.conclusion == "failure"
+    assert result.raw["artifact_count"] == 1
+
+
+def test_is_dispatched_run_filters_invalid_dates():
+    runner = GithubActionsRunner(
+        GithubClient(base_url="x", token="y"), workflow_file="wf"
+    )
+    run = WorkflowRun(
+        id=1,
+        status="queued",
+        conclusion=None,
+        html_url=None,
+        head_sha=None,
+        event="push",
+        created_at="not-a-date",
+    )
+    assert runner._is_dispatched_run(run, datetime.now(UTC)) is False
+
+
+def test_normalize_run_timed_out_and_queued():
+    runner = GithubActionsRunner(
+        GithubClient(base_url="x", token="y"), workflow_file="wf"
+    )
+    queued = runner._normalize_run(
+        WorkflowRun(
+            id=5,
+            status="queued",
+            conclusion=None,
+            html_url=None,
+            head_sha="sha",
+        )
+    )
+    assert queued.status == "running"
+
+    timed_out = runner._normalize_run(
+        WorkflowRun(
+            id=6, status="completed", conclusion=None, html_url=None, head_sha="sha6"
+        ),
+        timed_out=True,
+    )
+    assert timed_out.status == "running"
+    unknown = runner._normalize_run(
+        WorkflowRun(
+            id=9,
+            status="strange",
+            conclusion=None,
+            html_url=None,
+            head_sha="sha9",
+        )
+    )
+    assert unknown.status == "error"
+
+
+@pytest.mark.asyncio
+async def test_build_result_sets_raw_when_missing(monkeypatch):
+    runner = GithubActionsRunner(
+        GithubClient(base_url="x", token="y"), workflow_file="wf"
+    )
+
+    async def _fake_parse(repo, run_id):
+        return ParsedTestResults(
+            passed=1, failed=0, total=1, stdout="o", stderr=None, summary={"ok": True}
+        )
+
+    monkeypatch.setattr(runner, "_parse_artifacts", _fake_parse)
+
+    # Force _normalize_run to omit raw so branch is covered
+    def _no_raw(run, **_kw):
+        return ActionsRunResult(
+            status="passed",
+            run_id=run.id,
+            conclusion="success",
+            passed=None,
+            failed=None,
+            total=None,
+            stdout=None,
+            stderr=None,
+            head_sha=run.head_sha,
+            html_url=run.html_url,
+            raw=None,
+        )
+
+    monkeypatch.setattr(runner, "_normalize_run", _no_raw)
+
+    # Provide a run with no artifacts to keep raw None
+    run = WorkflowRun(
+        id=7,
+        status="completed",
+        conclusion="success",
+        html_url="url",
+        head_sha="sha",
+        artifact_count=None,
+    )
+    result = await runner._build_result("org/repo", run)
+    assert result.raw and result.raw["summary"]["ok"] is True
+
+
+def test_is_dispatched_run_invalid_created_at(monkeypatch):
+    runner = GithubActionsRunner(
+        GithubClient(base_url="x", token="y"), workflow_file="wf"
+    )
+    run = WorkflowRun(
+        id=8,
+        status="queued",
+        conclusion=None,
+        html_url=None,
+        head_sha=None,
+        event="workflow_dispatch",
+        created_at="bad-date",
+    )
+    assert runner._is_dispatched_run(run, datetime.now(UTC)) is False
+
+
+def test_is_dispatched_run_defaults_false():
+    runner = GithubActionsRunner(
+        GithubClient(base_url="x", token="y"), workflow_file="wf"
+    )
+    run = WorkflowRun(
+        id=10,
+        status="queued",
+        conclusion=None,
+        html_url=None,
+        head_sha=None,
+        event=None,
+        created_at=None,
+    )
+    assert runner._is_dispatched_run(run, datetime.now(UTC)) is False

--- a/tests/unit/test_github_client.py
+++ b/tests/unit/test_github_client.py
@@ -1,0 +1,177 @@
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from app.services.github.client import GithubClient, GithubError
+
+
+def _mock_client(handler) -> GithubClient:
+    return GithubClient(
+        base_url="https://api.github.com",
+        token="token123",
+        transport=httpx.MockTransport(handler),
+    )
+
+
+@pytest.mark.asyncio
+async def test_github_client_happy_paths():
+    """Exercise the primary REST helpers with a mock transport."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST" and request.url.path.endswith("/generate"):
+            return httpx.Response(201, json={"full_name": "org/new-repo"})
+        if request.method == "PUT" and "/collaborators/" in request.url.path:
+            return httpx.Response(200, json={"ok": True})
+        if request.method == "POST" and "/dispatches" in request.url.path:
+            return httpx.Response(204)
+        if request.method == "GET" and "/branches/" in request.url.path:
+            return httpx.Response(200, json={"name": "main"})
+        if request.method == "GET" and "/compare/" in request.url.path:
+            return httpx.Response(200, json={"ahead_by": 1})
+        if request.method == "GET" and "/zip" in request.url.path:
+            return httpx.Response(
+                200,
+                headers={"Content-Type": "application/zip"},
+                content=b"zip-bytes",
+            )
+        if request.method == "GET" and "/artifacts" in request.url.path:
+            return httpx.Response(200, json={"artifacts": [{"id": 1, "name": "a"}]})
+        return httpx.Response(200, json={"ok": True})
+
+    client = _mock_client(handler)
+
+    repo = await client.generate_repo_from_template(
+        template_full_name="org/template",
+        new_repo_name="new-repo",
+        owner="org",
+    )
+    assert repo["full_name"] == "org/new-repo"
+
+    collab = await client.add_collaborator("org/repo", "octocat")
+    assert collab["ok"] is True
+
+    # No exception raised on 204/expect_body False
+    await client.trigger_workflow_dispatch(
+        "org/repo", "wf.yml", ref="main", inputs={"a": "b"}
+    )
+
+    branch = await client.get_branch("org/repo", "main")
+    assert branch["name"] == "main"
+
+    compare = await client.get_compare("org/repo", "base", "head")
+    assert compare["ahead_by"] == 1
+
+    artifacts = await client.list_artifacts("org/repo", 123)
+    assert artifacts[0]["id"] == 1
+
+    data = await client.download_artifact_zip("org/repo", 1)
+    assert data == b"zip-bytes"
+
+
+@pytest.mark.asyncio
+async def test_github_client_errors_raise_github_error():
+    """4xx/5xx responses should bubble up as GithubError with status codes."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(404, json={"message": "missing"})
+
+    client = _mock_client(handler)
+
+    with pytest.raises(GithubError) as excinfo:
+        await client.list_workflow_runs("org/repo", "ci.yml")
+    assert excinfo.value.status_code == 404
+
+    with pytest.raises(GithubError):
+        client._split_full_name("bad-name")
+
+
+@pytest.mark.asyncio
+async def test_github_client_parses_runs_and_handles_invalid_json():
+    """Ensure list/get run parsing and JSON error handling."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        if path.endswith("/runs/5"):
+            return httpx.Response(
+                200,
+                json={
+                    "id": 5,
+                    "status": "queued",
+                    "conclusion": None,
+                    "html_url": "https://example.com/run/5",
+                    "head_sha": "sha5",
+                    "artifacts_count": 0,
+                    "event": "workflow_dispatch",
+                    "created_at": "2024-01-01T00:00:00Z",
+                },
+            )
+        if "/runs" in path and "workflows" in path:
+            return httpx.Response(
+                200,
+                json={
+                    "workflow_runs": [
+                        {
+                            "id": 6,
+                            "status": "completed",
+                            "conclusion": "success",
+                            "html_url": "https://example.com/run/6",
+                            "head_sha": "sha6",
+                            "artifacts": 2,
+                            "event": "workflow_dispatch",
+                            "created_at": "2024-01-02T00:00:00Z",
+                        }
+                    ]
+                },
+            )
+        if path.endswith("/bad-json"):
+            return httpx.Response(200, text="not-json")
+        return httpx.Response(200, json={})
+
+    client = _mock_client(handler)
+    run = await client.get_workflow_run("org/repo", 5)
+    assert run.id == 5 and run.status == "queued"
+
+    runs = await client.list_workflow_runs("org/repo", "wf.yml")
+    assert runs[0].conclusion == "success"
+
+    with pytest.raises(GithubError):
+        await client._get_json("/bad-json")
+
+
+@pytest.mark.asyncio
+async def test_github_client_branch_param_and_zip_response():
+    seen_branch = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if "runs" in request.url.path and "workflows" in request.url.path:
+            seen_branch["value"] = request.url.params.get("branch")
+            return httpx.Response(200, json={"workflow_runs": []})
+        if request.url.path.endswith("/zip"):
+            return httpx.Response(
+                200, headers={"Content-Type": "application/zip"}, content=b"zipdata"
+            )
+        return httpx.Response(200, json={})
+
+    client = _mock_client(handler)
+    await client.list_workflow_runs("org/repo", "wf.yml", branch="feature")
+    assert seen_branch["value"] == "feature"
+
+    data = await client._request("GET", "/zip")
+    assert data == b"zipdata"
+
+
+def test_split_full_name_rejects_empty_owner_or_repo():
+    client = _mock_client(lambda r: httpx.Response(200, json={}))
+    with pytest.raises(GithubError):
+        client._split_full_name("owner/")
+
+
+@pytest.mark.asyncio
+async def test_github_client_get_bytes_errors():
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(500, text="boom")
+
+    client = _mock_client(handler)
+    with pytest.raises(GithubError):
+        await client.download_artifact_zip("org/repo", 9)

--- a/tests/unit/test_recruiter_submissions_router.py
+++ b/tests/unit/test_recruiter_submissions_router.py
@@ -1,0 +1,167 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from app.api.routes.recruiter import submissions as recruiter_submissions
+
+
+@pytest.mark.asyncio
+async def test_get_submission_detail_builds_links(monkeypatch):
+    user = SimpleNamespace(id=7, role="recruiter")
+    sub = SimpleNamespace(
+        id=1,
+        tests_passed=None,
+        tests_failed=None,
+        test_output=json.dumps({"passed": 2, "failed": 1, "status": "failed"}),
+        diff_summary_json=json.dumps({"base": "main", "head": "feature"}),
+        code_repo_path="org/repo",
+        code_blob=None,
+        content_text=None,
+        last_run_at=datetime.now(UTC),
+        workflow_run_id="44",
+        commit_sha="abc123",
+        submitted_at=datetime.now(UTC),
+    )
+    task = SimpleNamespace(
+        id=2, day_index=1, type="code", title="T", prompt="P", description="D"
+    )
+    cs = SimpleNamespace(id=3)
+    sim = SimpleNamespace(id=4)
+
+    monkeypatch.setattr(
+        recruiter_submissions, "ensure_recruiter", lambda _u: None, raising=False
+    )
+
+    async def _return_detail(*_a, **_k):
+        return (sub, task, cs, sim)
+
+    monkeypatch.setattr(
+        recruiter_submissions.recruiter_sub_service,
+        "fetch_detail",
+        _return_detail,
+    )
+    monkeypatch.setattr(
+        recruiter_submissions.recruiter_sub_service,
+        "parse_test_output",
+        lambda output: json.loads(output),
+    )
+
+    result = await recruiter_submissions.get_submission_detail(
+        submission_id=sub.id, db=None, user=user
+    )
+    assert result.diffUrl == "https://github.com/org/repo/compare/main...feature"
+    assert result.testResults and result.testResults.total == 3
+    assert result.workflowUrl.endswith("/runs/44")
+    assert result.commitUrl.endswith("/commit/abc123")
+
+
+@pytest.mark.asyncio
+async def test_list_submissions_handles_bad_json(monkeypatch):
+    user = SimpleNamespace(id=8)
+    sub = SimpleNamespace(
+        id=11,
+        candidate_session_id=22,
+        task_id=5,
+        submitted_at=datetime.now(UTC),
+        code_repo_path=None,
+        workflow_run_id=None,
+        commit_sha=None,
+        diff_summary_json="{not-json",
+    )
+    task = SimpleNamespace(day_index=2, type="design")
+    cs = SimpleNamespace(id=33)
+    sim = SimpleNamespace(id=44)
+
+    monkeypatch.setattr(recruiter_submissions, "ensure_recruiter", lambda _u: None)
+
+    async def _list_rows(*_a, **_k):
+        return [(sub, task, cs, sim)]
+
+    monkeypatch.setattr(
+        recruiter_submissions.recruiter_sub_service,
+        "list_submissions",
+        _list_rows,
+    )
+
+    result = await recruiter_submissions.list_submissions(
+        db=None, user=user, candidateSessionId=None, taskId=None
+    )
+    assert result.items[0].diffSummary == "{not-json"
+    assert result.items[0].repoUrl is None
+
+
+@pytest.mark.asyncio
+async def test_recruiter_detail_handles_invalid_diff(monkeypatch):
+    user = SimpleNamespace(id=9, role="recruiter")
+    sub = SimpleNamespace(
+        id=22,
+        tests_passed=None,
+        tests_failed=None,
+        test_output="",
+        diff_summary_json="{bad",
+        code_repo_path=None,
+        code_blob=None,
+        content_text="txt",
+        last_run_at=None,
+        workflow_run_id=None,
+        commit_sha=None,
+        submitted_at=datetime.now(UTC),
+    )
+    task = SimpleNamespace(id=3, day_index=1, type="design", title=None, prompt=None)
+    cs = SimpleNamespace(id=4)
+    sim = SimpleNamespace(id=5)
+
+    async def _return_detail(*_a, **_k):
+        return (sub, task, cs, sim)
+
+    monkeypatch.setattr(recruiter_submissions, "ensure_recruiter", lambda _u: None)
+    monkeypatch.setattr(
+        recruiter_submissions.recruiter_sub_service, "fetch_detail", _return_detail
+    )
+    monkeypatch.setattr(
+        recruiter_submissions.recruiter_sub_service,
+        "parse_test_output",
+        lambda output: output,
+    )
+
+    result = await recruiter_submissions.get_submission_detail(
+        submission_id=sub.id, db=None, user=user
+    )
+    assert result.diffSummary == "{bad"
+    assert result.diffUrl is None
+
+
+@pytest.mark.asyncio
+async def test_recruiter_list_builds_diff_url(monkeypatch):
+    user = SimpleNamespace(id=10)
+    sub = SimpleNamespace(
+        id=33,
+        candidate_session_id=44,
+        task_id=5,
+        submitted_at=datetime.now(UTC),
+        code_repo_path="org/repo",
+        workflow_run_id="99",
+        commit_sha="sha",
+        diff_summary_json=json.dumps({"base": "a", "head": "b"}),
+    )
+    task = SimpleNamespace(day_index=2, type="code")
+
+    async def _list_rows(*_a, **_k):
+        return [(sub, task, None, None)]
+
+    monkeypatch.setattr(recruiter_submissions, "ensure_recruiter", lambda _u: None)
+    monkeypatch.setattr(
+        recruiter_submissions.recruiter_sub_service, "list_submissions", _list_rows
+    )
+
+    result = await recruiter_submissions.list_submissions(
+        db=None, user=user, candidateSessionId=None, taskId=None
+    )
+    item = result.items[0]
+    assert item.diffUrl.endswith("a...b")
+    assert item.commitUrl.endswith("/commit/sha")
+    assert item.workflowUrl.endswith("/runs/99")

--- a/tests/unit/test_service_candidate.py
+++ b/tests/unit/test_service_candidate.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+from fastapi import HTTPException
+
+from app.domain.submissions import service_candidate as svc
+from app.domain.workspaces import repository as workspace_repo
+from app.services.github.actions import ActionsRunResult
+from app.services.github.client import GithubError
+from tests.factories import (
+    create_candidate_session,
+    create_recruiter,
+    create_simulation,
+)
+
+
+@pytest.mark.asyncio
+async def test_record_run_result_persists_fields(async_session):
+    recruiter = await create_recruiter(async_session, email="record@sim.com")
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session, simulation=sim, status="in_progress"
+    )
+    now = datetime.now(UTC)
+    workspace = await workspace_repo.create_workspace(
+        async_session,
+        candidate_session_id=cs.id,
+        task_id=tasks[1].id,
+        template_repo_full_name=tasks[1].template_repo or "",
+        repo_full_name="org/record-repo",
+        repo_id=999,
+        default_branch="main",
+        base_template_sha="base",
+        created_at=now,
+    )
+
+    result = ActionsRunResult(
+        status="failed",
+        run_id=777,
+        conclusion="failure",
+        passed=0,
+        failed=1,
+        total=1,
+        stdout="boom",
+        stderr=None,
+        head_sha="newsha",
+        html_url="https://example.com/run/777",
+        raw={"summary": {"status": "failed"}},
+    )
+
+    saved = await svc.record_run_result(async_session, workspace, result)
+    assert saved.last_workflow_run_id == "777"
+    assert saved.last_workflow_conclusion == "failure"
+    assert saved.latest_commit_sha == "newsha"
+    assert saved.last_test_summary_json
+
+
+@pytest.mark.asyncio
+async def test_ensure_workspace_creates_repo(async_session):
+    recruiter = await create_recruiter(async_session, email="ws@sim.com")
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session, simulation=sim, status="in_progress"
+    )
+
+    class StubGithubClient:
+        async def generate_repo_from_template(self, **_kw):
+            return {"full_name": "org/new-repo", "id": 5, "default_branch": "main"}
+
+        async def add_collaborator(
+            self, repo_full_name, username, *, permission="push"
+        ):
+            return {"invited": username}
+
+        async def get_branch(self, repo_full_name, branch):
+            return {"commit": {"sha": "base-sha"}}
+
+    ws = await svc.ensure_workspace(
+        async_session,
+        candidate_session=cs,
+        task=tasks[1],
+        github_client=StubGithubClient(),
+        github_username="octocat",
+        repo_prefix="prefix-",
+        template_default_owner="org",
+        now=datetime.now(UTC),
+    )
+    assert ws.repo_full_name == "org/new-repo"
+    assert ws.base_template_sha == "base-sha"
+
+
+@pytest.mark.asyncio
+async def test_create_submission_conflict_raises(async_session):
+    recruiter = await create_recruiter(async_session, email="dup@sim.com")
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session, simulation=sim, status="in_progress"
+    )
+    payload = SimpleNamespace(contentText="text")
+    # seed one submission
+    await svc.create_submission(
+        async_session,
+        cs,
+        tasks[0],
+        payload,
+        now=datetime.now(UTC),
+    )
+
+    with pytest.raises(HTTPException) as excinfo:
+        await svc.create_submission(
+            async_session,
+            cs,
+            tasks[0],
+            payload,
+            now=datetime.now(UTC),
+        )
+    assert excinfo.value.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_progress_after_submission_marks_complete(async_session):
+    recruiter = await create_recruiter(async_session, email="done@sim.com")
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session,
+        simulation=sim,
+        status="in_progress",
+    )
+    now = datetime.now(UTC)
+    for task in tasks:
+        await svc.create_submission(
+            async_session, cs, task, SimpleNamespace(contentText="x"), now=now
+        )
+
+    completed, total, is_complete = await svc.progress_after_submission(
+        async_session, cs, now=now
+    )
+    assert is_complete is True
+    assert completed == total == 5
+    await async_session.refresh(cs)
+    assert cs.status == "completed"
+
+
+def test_validate_helpers_raise():
+    cs = SimpleNamespace(simulation_id=1)
+    task = SimpleNamespace(id=2, simulation_id=2)
+    with pytest.raises(HTTPException):
+        svc.ensure_task_belongs(task, cs)
+
+    with pytest.raises(HTTPException):
+        svc.ensure_in_order(SimpleNamespace(id=999), target_task_id=1)
+
+    design_task = SimpleNamespace(type="design")
+    with pytest.raises(HTTPException):
+        svc.validate_submission_payload(design_task, SimpleNamespace(contentText=""))
+
+    unknown_task = SimpleNamespace(type="mystery")
+    with pytest.raises(HTTPException):
+        svc.validate_submission_payload(unknown_task, SimpleNamespace(contentText="x"))
+
+    with pytest.raises(HTTPException):
+        svc.validate_github_username("bad user")
+
+    with pytest.raises(HTTPException):
+        svc.validate_repo_full_name("invalid")
+
+    with pytest.raises(HTTPException):
+        svc.validate_branch({"branch": "dict"})
+
+    with pytest.raises(HTTPException):
+        svc.validate_branch("../etc")
+
+
+def test_is_code_task_and_branch_validation():
+    assert svc.is_code_task(SimpleNamespace(type="code")) is True
+    assert svc.is_code_task(SimpleNamespace(type="design")) is False
+    with pytest.raises(HTTPException):
+        svc.validate_branch("~weird")
+    assert svc.validate_branch(None) is None
+
+
+@pytest.mark.asyncio
+async def test_ensure_workspace_existing_and_missing_template(
+    monkeypatch, async_session
+):
+    recruiter = await create_recruiter(async_session, email="exist@sim.com")
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session, simulation=sim, status="in_progress"
+    )
+    now = datetime.now(UTC)
+    existing = await workspace_repo.create_workspace(
+        async_session,
+        candidate_session_id=cs.id,
+        task_id=tasks[0].id,
+        template_repo_full_name=tasks[0].template_repo or "",
+        repo_full_name="org/existing",
+        repo_id=1,
+        default_branch="main",
+        base_template_sha=None,
+        created_at=now,
+    )
+
+    ws = await svc.ensure_workspace(
+        async_session,
+        candidate_session=cs,
+        task=tasks[0],
+        github_client=object(),
+        github_username="",
+        repo_prefix="pref-",
+        template_default_owner="org",
+        now=now,
+    )
+    assert ws.id == existing.id
+
+    bad_task = SimpleNamespace(
+        id=99, template_repo=" ", simulation_id=sim.id, type="code"
+    )
+    with pytest.raises(HTTPException):
+        await svc.ensure_workspace(
+            async_session,
+            candidate_session=cs,
+            task=bad_task,
+            github_client=object(),
+            github_username="octocat",
+            repo_prefix="pref-",
+            template_default_owner="org",
+            now=now,
+        )
+
+
+@pytest.mark.asyncio
+async def test_ensure_workspace_handles_branch_fetch_error(async_session):
+    recruiter = await create_recruiter(async_session, email="branch@sim.com")
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session, simulation=sim, status="in_progress"
+    )
+
+    class StubGithub:
+        async def generate_repo_from_template(self, **_kw):
+            return {"full_name": "org/repo", "default_branch": "main", "id": 1}
+
+        async def get_branch(self, *_a, **_k):
+            raise GithubError("no branch")
+
+        async def add_collaborator(self, *_a, **_k):
+            return None
+
+    ws = await svc.ensure_workspace(
+        async_session,
+        candidate_session=cs,
+        task=tasks[1],
+        github_client=StubGithub(),
+        github_username="",
+        repo_prefix="pref-",
+        template_default_owner="org",
+        now=datetime.now(UTC),
+    )
+    assert ws.base_template_sha is None
+
+
+@pytest.mark.asyncio
+async def test_load_task_or_404_branches(monkeypatch, async_session):
+    class DummyTask:
+        id = 1
+
+    async def _return_task(db, task_id):
+        return DummyTask()
+
+    async def _return_none(db, task_id):
+        return None
+
+    monkeypatch.setattr(svc.tasks_repo, "get_by_id", _return_task)
+    assert await svc.load_task_or_404(async_session, 1) is not None
+
+    monkeypatch.setattr(svc.tasks_repo, "get_by_id", _return_none)
+    with pytest.raises(HTTPException):
+        await svc.load_task_or_404(async_session, 99)
+
+
+@pytest.mark.asyncio
+async def test_ensure_not_duplicate_and_in_order(monkeypatch):
+    async def _dup_true(db, cs_id, task_id):
+        return True
+
+    async def _dup_false(db, cs_id, task_id):
+        return False
+
+    monkeypatch.setattr(svc.submissions_repo, "find_duplicate", _dup_false)
+    # Should not raise
+    svc.ensure_in_order(SimpleNamespace(id=1), target_task_id=1)
+
+    monkeypatch.setattr(svc.submissions_repo, "find_duplicate", _dup_true)
+    with pytest.raises(HTTPException):
+        await svc.ensure_not_duplicate(None, 1, 1)
+
+    with pytest.raises(HTTPException):
+        svc.ensure_in_order(None, target_task_id=1)
+
+    with pytest.raises(HTTPException):
+        svc.ensure_in_order(SimpleNamespace(id=2), target_task_id=1)

--- a/tests/unit/test_service_recruiter.py
+++ b/tests/unit/test_service_recruiter.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import pytest
+
+from app.domain.submissions import service_recruiter as svc
+
+
+def test_derive_test_status_variants():
+    assert svc.derive_test_status(None, None, None) is None
+    assert svc.derive_test_status(1, 0, {}) == "passed"
+    assert svc.derive_test_status(None, 2, {}) == "failed"
+    assert svc.derive_test_status(None, None, {"timeout": True}) == "timeout"
+    assert svc.derive_test_status(None, None, {"status": "error"}) == "error"
+
+
+def test_parse_test_output_fallback():
+    assert svc.parse_test_output(None) is None
+    assert svc.parse_test_output("not-json") == "not-json"
+    assert svc.parse_test_output('{"a": 1}') == {"a": 1}
+
+
+@pytest.mark.asyncio
+async def test_fetch_detail_not_found_raises(monkeypatch):
+    class DummyResult:
+        def first(self):
+            return None
+
+    class DummySession:
+        async def execute(self, *_a, **_k):
+            return DummyResult()
+
+    with pytest.raises(Exception) as excinfo:
+        await svc.fetch_detail(DummySession(), submission_id=1, recruiter_id=2)
+    assert excinfo.value.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_fetch_detail_returns_row(monkeypatch):
+    expected = ("sub", "task", "cs", "sim")
+
+    class DummyResult:
+        def __init__(self, val):
+            self.val = val
+
+        def first(self):
+            return self.val
+
+    class DummySession:
+        async def execute(self, *_a, **_k):
+            return DummyResult(expected)
+
+    row = await svc.fetch_detail(DummySession(), submission_id=1, recruiter_id=2)
+    assert row == expected
+
+
+def test_parse_test_output_non_dict_json():
+    assert svc.parse_test_output("[]") == "[]"
+
+
+@pytest.mark.asyncio
+async def test_list_submissions_applies_filters():
+    class DummyResult:
+        def all(self):
+            return [("row",)]
+
+    class DummySession:
+        def __init__(self):
+            self.received = None
+
+        async def execute(self, stmt):
+            self.received = stmt
+            return DummyResult()
+
+    session = DummySession()
+    rows = await svc.list_submissions(session, 1, candidate_session_id=2, task_id=3)
+    assert rows == [("row",)]
+    assert session.received is not None

--- a/tests/unit/test_simulations_service.py
+++ b/tests/unit/test_simulations_service.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from app.domain import CandidateSession
+from app.domain.simulations import service as sim_service
+from tests.factories import create_recruiter, create_simulation
+
+
+@pytest.mark.asyncio
+async def test_require_owned_simulation_raises(monkeypatch):
+    async def _return_none(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(sim_service.sim_repo, "get_owned", _return_none, raising=False)
+    with pytest.raises(Exception) as excinfo:
+        await sim_service.require_owned_simulation(db=None, simulation_id=1, user_id=2)
+    assert excinfo.value.status_code == 404
+
+
+def test_template_repo_for_task_variants(monkeypatch):
+    monkeypatch.setattr(sim_service.settings.github, "GITHUB_TEMPLATE_OWNER", "owner")
+    monkeypatch.setattr(
+        sim_service, "resolve_template_repo_full_name", lambda _key: "template-only"
+    )
+    repo = sim_service._template_repo_for_task(5, "code", "python-fastapi")
+    assert repo == "template-only"
+    # Day index 2 uses owner override when repo name lacks owner prefix
+    repo_with_owner = sim_service._template_repo_for_task(2, "code", "python-fastapi")
+    assert repo_with_owner.startswith("owner/")
+    assert sim_service._template_repo_for_task(1, "design", "python-fastapi") is None
+
+
+def test_invite_url_uses_portal_base(monkeypatch):
+    monkeypatch.setattr(
+        sim_service.settings, "CANDIDATE_PORTAL_BASE_URL", "https://portal.test"
+    )
+    assert sim_service.invite_url("abc") == "https://portal.test/candidate/session/abc"
+
+
+@pytest.mark.asyncio
+async def test_create_invite_handles_token_collisions(monkeypatch):
+    class StubSession:
+        def __init__(self):
+            self.commits = 0
+            self.rollbacks = 0
+            self.added: CandidateSession | None = None
+
+        def add(self, obj):
+            self.added = obj
+
+        async def commit(self):
+            self.commits += 1
+            raise IntegrityError("", {}, None)
+
+        async def rollback(self):
+            self.rollbacks += 1
+
+    with pytest.raises(Exception) as excinfo:
+        await sim_service.create_invite(
+            StubSession(),
+            simulation_id=1,
+            payload=type("P", (), {"candidateName": "x", "inviteEmail": "y"}),
+        )
+    assert excinfo.value.status_code == 500
+
+
+@pytest.mark.asyncio
+async def test_create_simulation_with_tasks_flow(async_session, monkeypatch):
+    payload = type(
+        "P",
+        (),
+        {
+            "title": "Title",
+            "role": "Role",
+            "techStack": "Python",
+            "seniority": "Mid",
+            "focus": "Build",
+            "templateKey": "python-fastapi",
+        },
+    )()
+    user = type("U", (), {"company_id": 1, "id": 2})
+    sim, tasks = await sim_service.create_simulation_with_tasks(
+        async_session, payload, user
+    )
+    assert sim.id is not None
+    assert len(tasks) == len(sim_service.DEFAULT_5_DAY_BLUEPRINT)
+    # ensure tasks are sorted and refreshed
+    assert tasks[0].day_index == 1
+
+
+@pytest.mark.asyncio
+async def test_create_invite_success(async_session):
+    payload = type(
+        "P", (), {"candidateName": "Jane", "inviteEmail": "jane@example.com"}
+    )
+    cs = await sim_service.create_invite(
+        async_session, simulation_id=1, payload=payload, now=datetime.now(UTC)
+    )
+    assert cs.token
+    assert cs.status == "not_started"
+
+
+@pytest.mark.asyncio
+async def test_require_owned_simulation_success(async_session):
+    recruiter = await create_recruiter(async_session, email="owned@test.com")
+    sim, _ = await create_simulation(async_session, created_by=recruiter)
+    owned = await sim_service.require_owned_simulation(
+        async_session, sim.id, recruiter.id
+    )
+    assert owned.id == sim.id
+
+
+@pytest.mark.asyncio
+async def test_list_with_candidate_counts(async_session):
+    recruiter = await create_recruiter(async_session, email="counts@test.com")
+    sim, _ = await create_simulation(async_session, created_by=recruiter)
+    rows = await sim_service.list_simulations(async_session, recruiter.id)
+    assert rows[0][0].id == sim.id
+
+
+@pytest.mark.asyncio
+async def test_list_candidates_with_profile(async_session):
+    recruiter = await create_recruiter(async_session, email="list@test.com")
+    sim, _ = await create_simulation(async_session, created_by=recruiter)
+    cs = await sim_service.create_invite(
+        async_session,
+        simulation_id=sim.id,
+        payload=type("P", (), {"candidateName": "a", "inviteEmail": "b@example.com"}),
+    )
+    rows = await sim_service.list_candidates_with_profile(async_session, sim.id)
+    assert rows and rows[0][0].id == cs.id

--- a/tests/unit/test_submissions_repository.py
+++ b/tests/unit/test_submissions_repository.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from app.domain.submissions import repository as submissions_repo
+from tests.factories import (
+    create_candidate_session,
+    create_recruiter,
+    create_simulation,
+    create_submission,
+)
+
+
+@pytest.mark.asyncio
+async def test_find_duplicate_false(async_session):
+    recruiter = await create_recruiter(async_session, email="dupfalse@test.com")
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(async_session, simulation=sim)
+    dup = await submissions_repo.find_duplicate(async_session, cs.id, tasks[0].id)
+    assert dup is False
+
+
+@pytest.mark.asyncio
+async def test_find_duplicate_true(async_session):
+    recruiter = await create_recruiter(async_session, email="duptru@test.com")
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(async_session, simulation=sim)
+    await create_submission(async_session, candidate_session=cs, task=tasks[0])
+    dup = await submissions_repo.find_duplicate(async_session, cs.id, tasks[0].id)
+    assert dup is True

--- a/tests/unit/test_tasks_repository.py
+++ b/tests/unit/test_tasks_repository.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from app.domain.simulations import tasks_repository
+from tests.factories import create_recruiter, create_simulation
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_returns_none_when_missing(async_session):
+    result = await tasks_repository.get_by_id(async_session, 9999)
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_get_by_id_returns_task(async_session):
+    recruiter = await create_recruiter(async_session, email="taskrepo@test.com")
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    task = tasks[0]
+    found = await tasks_repository.get_by_id(async_session, task.id)
+    assert found.id == task.id

--- a/tests/unit/test_template_catalog.py
+++ b/tests/unit/test_template_catalog.py
@@ -7,6 +7,7 @@ from app.services.template_catalog import (
     TemplateKeyError,
     normalize_template_repo_value,
     resolve_template_repo_full_name,
+    validate_template_key,
 )
 
 
@@ -76,3 +77,20 @@ def test_normalize_template_repo_value_rewrites_legacy_with_template_key():
         "simuhire-templates/node-day2-api", template_key="node-express-ts"
     )
     assert repo == "simuhire-dev/simuhire-template-node-express-ts"
+
+
+def test_normalize_template_repo_value_returns_none_when_no_hints():
+    assert normalize_template_repo_value("", template_key=None) is None
+
+
+def test_validate_template_key_requires_string():
+    with pytest.raises(TemplateKeyError):
+        validate_template_key(123)  # type: ignore[arg-type]
+
+
+def test_normalize_template_repo_value_invalid_key_and_custom_repo():
+    assert normalize_template_repo_value(None, template_key="invalid-key") is None
+    assert (
+        normalize_template_repo_value("custom/repo", template_key="invalid-key")
+        == "custom/repo"
+    )

--- a/tests/unit/test_validations_and_diff.py
+++ b/tests/unit/test_validations_and_diff.py
@@ -64,3 +64,14 @@ def test_summarize_diff_includes_base_head():
     )
     assert summary["base"] == "base123"
     assert summary["head"] == "head123"
+
+
+def test_validate_run_allowed_blocks_non_code_tasks():
+    class FakeTask:
+        def __init__(self, task_type):
+            self.type = task_type
+
+    with pytest.raises(HTTPException):
+        svc.validate_run_allowed(FakeTask("design"))
+    # code tasks are allowed
+    svc.validate_run_allowed(FakeTask("code"))


### PR DESCRIPTION
<img width="576" height="360" alt="image" src="https://github.com/user-attachments/assets/9f6405da-6490-4702-902f-7e96e8e15c01" />

# Summary
- Added comprehensive test coverage across FastAPI routers, domain services, GitHub integrations, repositories, and configuration helpers to achieve 100% coverage (excluding `app/models/core.py` per config).
- Hardened GitHub artifact parsing and action handling edge cases, added repo/template validation scenarios, and expanded simulation/submission/recruiter flows.
- Ensured pre-commit (Ruff lint/format + full pytest with coverage) passes locally; coverage report now shows 100.00% for `app/` with configured omit.

# Testing
- `./precommit.sh`
- `poetry run pytest --cov=app --cov-report=term-missing`
