### PR TITLE
Candidate invite email verification + token exchange (invite token not sufficient)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ FastAPI + Postgres backend for SimuHire. Recruiters create 5-day simulations, in
   - `GET /api/submissions` list submissions (filters `candidateSessionId`, `taskId`)
   - `GET /api/submissions/{id}` detail with content/code/test results + repo/commit/workflow/diff URLs
 - Candidate (token headers):
-  - `GET /api/candidate/session/{token}` resolve invite; sets `in_progress`
+  - `POST /api/candidate/session/{token}/verify` verify invite email, start session, issue short-lived candidate token
+  - `GET /api/candidate/session/{token}` responds 401 (verification required; use `/verify`)
   - `GET /api/candidate/session/{id}/current_task` (header `x-candidate-token`) current task/progress; auto-completes when done
   - `POST /api/tasks/{taskId}/codespace/init` create/return workspace repo + Codespace URL (code/debug tasks)
   - `GET /api/tasks/{taskId}/codespace/status` workspace state (repo/default branch/latest run/test summary)
@@ -54,7 +55,7 @@ FastAPI + Postgres backend for SimuHire. Recruiters create 5-day simulations, in
 ## Typical Flow
 
 1) Recruiter authenticates → `POST /api/simulations` → `POST /api/simulations/{id}/invite` to generate candidate link.
-2) Candidate opens invite → resolves token → sees current task → for code/debug tasks calls `/codespace/init` → works in Codespace → `/run` to test → `/submit` to turn in.
+2) Candidate opens invite → verifies email to get candidate token → sees current task → for code/debug tasks calls `/codespace/init` → works in Codespace → `/run` to test → `/submit` to turn in.
 3) Recruiter views submissions list/detail with repo/workflow/commit/diff/test results.
 
 ## Local Development

--- a/alembic/versions/202504160001_add_candidate_access_tokens.py
+++ b/alembic/versions/202504160001_add_candidate_access_tokens.py
@@ -1,0 +1,44 @@
+"""Add candidate access tokens for email verification.
+
+Revision ID: 202504160001
+Revises: 202504050001
+Create Date: 2025-04-16 00:00:01.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "202504160001"
+down_revision: Union[str, Sequence[str], None] = "202504050001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "candidate_sessions",
+        sa.Column("access_token", sa.String(length=255), nullable=True),
+    )
+    op.add_column(
+        "candidate_sessions",
+        sa.Column(
+            "access_token_expires_at", sa.DateTime(timezone=True), nullable=True
+        ),
+    )
+    op.create_index(
+        op.f("ix_candidate_sessions_access_token"),
+        "candidate_sessions",
+        ["access_token"],
+        unique=True,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        op.f("ix_candidate_sessions_access_token"),
+        table_name="candidate_sessions",
+    )
+    op.drop_column("candidate_sessions", "access_token_expires_at")
+    op.drop_column("candidate_sessions", "access_token")

--- a/app/domains/candidate_sessions/models.py
+++ b/app/domains/candidate_sessions/models.py
@@ -29,6 +29,13 @@ class CandidateSession(Base):
         String(255), unique=True, index=True, nullable=False
     )
 
+    access_token: Mapped[str | None] = mapped_column(
+        String(255), unique=True, index=True, nullable=True
+    )
+    access_token_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     status: Mapped[str] = mapped_column(String(50), nullable=False)
 
     started_at: Mapped[datetime | None] = mapped_column(

--- a/app/domains/candidate_sessions/schemas.py
+++ b/app/domains/candidate_sessions/schemas.py
@@ -41,6 +41,19 @@ class CandidateSessionResolveResponse(APIModel):
     simulation: CandidateSimulationSummary
 
 
+class CandidateSessionVerifyRequest(APIModel):
+    """Schema for verifying invite email for a candidate session."""
+
+    email: EmailStr
+
+
+class CandidateSessionVerifyResponse(CandidateSessionResolveResponse):
+    """Session details plus a short-lived candidate token."""
+
+    candidateToken: str
+    tokenExpiresAt: datetime
+
+
 class ProgressSummary(APIModel):
     """Summary of progress for the candidate session."""
 

--- a/tests/api/test_candidate_session_resolve.py
+++ b/tests/api/test_candidate_session_resolve.py
@@ -59,8 +59,10 @@ async def _invite_candidate(async_client, sim_id: int, recruiter_email: str) -> 
     return res.json()
 
 
-async def _resolve(async_client, token: str):
-    res = await async_client.get(f"/api/candidate/session/{token}")
+async def _verify(async_client, token: str, email: str = "jane@example.com"):
+    res = await async_client.post(
+        f"/api/candidate/session/{token}/verify", json={"email": email}
+    )
     assert res.status_code == 200, res.text
     return res.json()
 
@@ -78,11 +80,9 @@ async def test_current_task_initial_is_day_1(async_client, async_session):
     sim_id = await _create_simulation(async_client, recruiter_email)
     invite = await _invite_candidate(async_client, sim_id, recruiter_email)
 
-    token = invite["token"]
-    cs_id = invite["candidateSessionId"]
-
-    # Resolve once to start session
-    await _resolve(async_client, token)
+    verification = await _verify(async_client, invite["token"])
+    token = verification["candidateToken"]
+    cs_id = verification["candidateSessionId"]
 
     res = await async_client.get(
         f"/api/candidate/session/{cs_id}/current_task",
@@ -108,10 +108,9 @@ async def test_current_task_advances_after_submission(async_client, async_sessio
     sim_id = await _create_simulation(async_client, recruiter_email)
     invite = await _invite_candidate(async_client, sim_id, recruiter_email)
 
-    token = invite["token"]
-    cs_id = invite["candidateSessionId"]
-
-    await _resolve(async_client, token)
+    verification = await _verify(async_client, invite["token"])
+    token = verification["candidateToken"]
+    cs_id = verification["candidateSessionId"]
 
     # Fetch Day 1 task
     day1_task = (
@@ -150,10 +149,9 @@ async def test_current_task_completed_after_all_tasks(async_client, async_sessio
     sim_id = await _create_simulation(async_client, recruiter_email)
     invite = await _invite_candidate(async_client, sim_id, recruiter_email)
 
-    token = invite["token"]
-    cs_id = invite["candidateSessionId"]
-
-    await _resolve(async_client, token)
+    verification = await _verify(async_client, invite["token"])
+    token = verification["candidateToken"]
+    cs_id = verification["candidateSessionId"]
 
     tasks = (
         (await async_session.execute(select(Task).where(Task.simulation_id == sim_id)))
@@ -205,30 +203,27 @@ async def test_current_task_wrong_token_404(async_client, async_session):
     sim_id = await _create_simulation(async_client, recruiter_email)
     invite = await _invite_candidate(async_client, sim_id, recruiter_email)
 
-    token = invite["token"]
-    cs_id = invite["candidateSessionId"]
-
-    await _resolve(async_client, token)
+    verification = await _verify(async_client, invite["token"])
+    cs_id = verification["candidateSessionId"]
 
     res = await async_client.get(
         f"/api/candidate/session/{cs_id}/current_task",
-        headers={"x-candidate-token": "wrong-token"},
+        headers={"x-candidate-token": invite["token"]},
     )
     assert res.status_code == 404
 
 
 @pytest.mark.asyncio
-async def test_current_task_expired_token_410(async_client, async_session):
+async def test_current_task_expired_token_401(async_client, async_session):
     recruiter_email = "recruiter1@simuhire.com"
     await _seed_recruiter(async_session, recruiter_email)
 
     sim_id = await _create_simulation(async_client, recruiter_email)
     invite = await _invite_candidate(async_client, sim_id, recruiter_email)
 
-    token = invite["token"]
-    cs_id = invite["candidateSessionId"]
-
-    await _resolve(async_client, token)
+    verification = await _verify(async_client, invite["token"])
+    token = verification["candidateToken"]
+    cs_id = verification["candidateSessionId"]
 
     cs = (
         await async_session.execute(
@@ -236,15 +231,15 @@ async def test_current_task_expired_token_410(async_client, async_session):
         )
     ).scalar_one()
 
-    cs.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    cs.access_token_expires_at = datetime.now(UTC) - timedelta(seconds=1)
     await async_session.commit()
 
     res = await async_client.get(
         f"/api/candidate/session/{cs_id}/current_task",
         headers={"x-candidate-token": token},
     )
-    assert res.status_code == 410
-    assert res.json()["detail"] == "Invite token expired"
+    assert res.status_code == 401
+    assert res.json()["detail"] == "Candidate token expired"
 
 
 @pytest.mark.asyncio
@@ -258,11 +253,15 @@ async def test_resolve_transitions_to_in_progress(async_client, async_session):
     token = invite["token"]
     cs_id = invite["candidateSessionId"]
 
-    res = await async_client.get(f"/api/candidate/session/{token}")
+    res = await async_client.post(
+        f"/api/candidate/session/{token}/verify", json={"email": "jane@example.com"}
+    )
     assert res.status_code == 200, res.text
     body = res.json()
     assert body["status"] == "in_progress"
     assert body["startedAt"] is not None
+    assert body["candidateToken"]
+    assert body["tokenExpiresAt"]
 
     cs_after = (
         await async_session.execute(
@@ -295,6 +294,138 @@ async def test_resolve_expired_token_returns_410(async_client, async_session):
     res = await async_client.get(f"/api/candidate/session/{token}")
     assert res.status_code == 410
     assert res.json()["detail"] == "Invite token expired"
+
+
+@pytest.mark.asyncio
+async def test_resolve_requires_email_verification(async_client, async_session):
+    recruiter_email = "recruiter1@simuhire.com"
+    await _seed_recruiter(async_session, recruiter_email)
+
+    sim_id = await _create_simulation(async_client, recruiter_email)
+    invite = await _invite_candidate(async_client, sim_id, recruiter_email)
+
+    res = await async_client.get(f"/api/candidate/session/{invite['token']}")
+    assert res.status_code == 401
+    assert res.json()["detail"] == "Email verification required"
+
+
+@pytest.mark.asyncio
+async def test_verify_wrong_email_returns_401(async_client, async_session):
+    recruiter_email = "recruiter1@simuhire.com"
+    await _seed_recruiter(async_session, recruiter_email)
+
+    sim_id = await _create_simulation(async_client, recruiter_email)
+    invite = await _invite_candidate(async_client, sim_id, recruiter_email)
+
+    res = await async_client.post(
+        f"/api/candidate/session/{invite['token']}/verify",
+        json={"email": "wrong@example.com"},
+    )
+    assert res.status_code == 401
+    assert res.json()["detail"] == "Invite email verification failed"
+
+    cs = (
+        await async_session.execute(
+            select(CandidateSession).where(
+                CandidateSession.id == invite["candidateSessionId"]
+            )
+        )
+    ).scalar_one()
+    assert cs.status == "not_started"
+    assert cs.started_at is None
+    assert cs.access_token is None
+    assert cs.access_token_expires_at is None
+
+
+@pytest.mark.asyncio
+async def test_verify_expired_invite_returns_410(async_client, async_session):
+    recruiter_email = "recruiter1@simuhire.com"
+    await _seed_recruiter(async_session, recruiter_email)
+
+    sim_id = await _create_simulation(async_client, recruiter_email)
+    invite = await _invite_candidate(async_client, sim_id, recruiter_email)
+
+    cs = (
+        await async_session.execute(
+            select(CandidateSession).where(
+                CandidateSession.id == invite["candidateSessionId"]
+            )
+        )
+    ).scalar_one()
+    cs.expires_at = datetime.now(UTC) - timedelta(minutes=1)
+    await async_session.commit()
+
+    res = await async_client.post(
+        f"/api/candidate/session/{invite['token']}/verify",
+        json={"email": "jane@example.com"},
+    )
+    assert res.status_code == 410
+    assert res.json()["detail"] == "Invite token expired"
+
+
+@pytest.mark.asyncio
+async def test_candidate_access_requires_verification(async_client, async_session):
+    recruiter_email = "recruiter1@simuhire.com"
+    await _seed_recruiter(async_session, recruiter_email)
+
+    sim_id = await _create_simulation(async_client, recruiter_email)
+    invite = await _invite_candidate(async_client, sim_id, recruiter_email)
+
+    cs = (
+        await async_session.execute(
+            select(CandidateSession).where(
+                CandidateSession.id == invite["candidateSessionId"]
+            )
+        )
+    ).scalar_one()
+    assert cs.access_token is None
+    assert cs.access_token_expires_at is None
+
+    # Using invite token as access token should fail.
+    res = await async_client.get(
+        f"/api/candidate/session/{cs.id}/current_task",
+        headers={"x-candidate-token": invite["token"]},
+    )
+    assert res.status_code == 404
+
+    # Verify with correct email to issue candidate token.
+    verification = await _verify(async_client, invite["token"])
+    token = verification["candidateToken"]
+
+    ok = await async_client.get(
+        f"/api/candidate/session/{cs.id}/current_task",
+        headers={"x-candidate-token": token},
+    )
+    assert ok.status_code == 200, ok.text
+
+
+@pytest.mark.asyncio
+async def test_reverify_rotates_access_token(async_client, async_session):
+    recruiter_email = "recruiter1@simuhire.com"
+    await _seed_recruiter(async_session, recruiter_email)
+
+    sim_id = await _create_simulation(async_client, recruiter_email)
+    invite = await _invite_candidate(async_client, sim_id, recruiter_email)
+
+    first = await _verify(async_client, invite["token"])
+    token1 = first["candidateToken"]
+    cs_id = first["candidateSessionId"]
+
+    second = await _verify(async_client, invite["token"])
+    token2 = second["candidateToken"]
+    assert token2 != token1
+
+    res_old = await async_client.get(
+        f"/api/candidate/session/{cs_id}/current_task",
+        headers={"x-candidate-token": token1},
+    )
+    assert res_old.status_code == 404
+
+    res_new = await async_client.get(
+        f"/api/candidate/session/{cs_id}/current_task",
+        headers={"x-candidate-token": token2},
+    )
+    assert res_new.status_code == 200, res_new.text
 
 
 @pytest.mark.asyncio

--- a/tests/factories/models.py
+++ b/tests/factories/models.py
@@ -101,9 +101,16 @@ async def create_candidate_session(
     expires_in_days: int = 14,
     started_at: datetime | None = None,
     completed_at: datetime | None = None,
+    access_token: str | None = None,
+    access_token_expires_in_minutes: int = 60,
 ) -> CandidateSession:
     token = token or secrets.token_urlsafe(16)
     expires_at = datetime.now(UTC) + timedelta(days=expires_in_days)
+    access_expires_at = None
+    if access_token:
+        access_expires_at = datetime.now(UTC) + timedelta(
+            minutes=access_token_expires_in_minutes
+        )
 
     cs = CandidateSession(
         simulation_id=simulation.id,
@@ -111,6 +118,8 @@ async def create_candidate_session(
         candidate_name=candidate_name,
         invite_email=invite_email,
         token=token,
+        access_token=access_token,
+        access_token_expires_at=access_expires_at,
         status=status,
         expires_at=expires_at,
         started_at=started_at,

--- a/tests/integration/test_candidate_flow.py
+++ b/tests/integration/test_candidate_flow.py
@@ -37,13 +37,18 @@ async def test_full_flow_invite_through_first_submission(
     assert invite_res.status_code == 201, invite_res.text
     invite = invite_res.json()
 
-    resolve_res = await async_client.get(f"/api/candidate/session/{invite['token']}")
-    assert resolve_res.status_code == 200, resolve_res.text
-    cs_id = resolve_res.json()["candidateSessionId"]
+    verify_res = await async_client.post(
+        f"/api/candidate/session/{invite['token']}/verify",
+        json={"email": "flow@example.com"},
+    )
+    assert verify_res.status_code == 200, verify_res.text
+    verify_body = verify_res.json()
+    cs_id = verify_body["candidateSessionId"]
+    candidate_token = verify_body["candidateToken"]
 
     current_res = await async_client.get(
         f"/api/candidate/session/{cs_id}/current_task",
-        headers={"x-candidate-token": invite["token"]},
+        headers={"x-candidate-token": candidate_token},
     )
     assert current_res.status_code == 200, current_res.text
     assert current_res.json()["currentDayIndex"] == 1
@@ -52,7 +57,7 @@ async def test_full_flow_invite_through_first_submission(
     submit_res = await async_client.post(
         f"/api/tasks/{day1_task_id}/submit",
         headers={
-            "x-candidate-token": invite["token"],
+            "x-candidate-token": candidate_token,
             "x-candidate-session-id": str(cs_id),
         },
         json={"contentText": "Day 1 answer"},


### PR DESCRIPTION
## Summary of changes

### ✅ New/updated candidate auth flow
1. Recruiter invites candidate (existing):
   - `POST /api/simulations/{simulationId}/invite`
   - Response contains:
     - `candidateSessionId`
     - `token` (invite token)
     - `inviteUrl`

2. Candidate must verify email (new):
   - `POST /api/candidate/session/{inviteToken}/verify`
   - Body:
     ```json
     { "email": "candidate@example.com" }
     ```
   - Response returns:
     - `candidateSessionId`
     - `candidateToken` (short-lived access token)
     - `tokenExpiresAt`
     - session metadata (status/startedAt/etc.)

3. All candidate session/task APIs require:
   - Header: `x-candidate-token: <candidateToken>`
   - (and where applicable) `x-candidate-session-id: <candidateSessionId>`

---

## API changes

### 1) Reject invite-token-only access to candidate session resolve
- `GET /api/candidate/session/{inviteToken}`
  - Now returns **401** with `"Email verification required"`
  - This ensures invite token alone cannot access session details.

### 2) Add email verification endpoint to mint candidate token
- `POST /api/candidate/session/{inviteToken}/verify`
  - Validates invite token exists and is not expired
  - Validates provided email matches `invite_email` for the session
  - On success:
    - Transitions `status` from `not_started` -> `in_progress` (if applicable)
    - Sets `started_at` (if unset)
    - Issues **new** `access_token` and `access_token_expires_at`
    - Returns token + expiry

### 3) Candidate endpoints enforce candidate token
Candidate endpoints now require `x-candidate-token` = the issued candidate token.
- If token is missing/mismatched: **404** (safe “not found”, no existence leakage)
- If token is expired: **401** `"Candidate token expired"`
- Invite expiry still returns **410** `"Invite token expired"`

---

## Data model + migrations

### CandidateSession additions
Added fields to `candidate_sessions`:
- `access_token` (nullable, unique, indexed)
- `access_token_expires_at` (nullable timestamp)

**Alembic migration:** adds the above columns + unique index on `access_token`.

### Token issuance semantics
- Tokens are generated using a secure random token generator.
- Access tokens are **short-lived** (configured TTL, e.g., 30 minutes).
- Re-verifying the same invite **rotates** the token:
  - New `candidateToken` is minted
  - Old token becomes invalid immediately (safe 404 on use)

---

## Security + behavior guarantees

### Non-leakage / safe errors
- Using an invite token (or any wrong token) as an access token returns **404** on candidate endpoints (e.g., `current_task`) to avoid leaking resource existence.
- Expired candidate token returns **401** with `"Candidate token expired"`.

### No state mutation on wrong email
Verification with wrong email:
- Returns **401** `"Invite email verification failed"`
- Does **not** transition session status
- Does **not** set `started_at`
- Does **not** issue or persist any access token fields

---

## Tests added/updated

### Coverage highlights
- **Invite token cannot access session details**
  - `GET /api/candidate/session/{inviteToken}` -> 401
- **Wrong email verify fails without DB mutation**
  - `POST /verify` wrong email -> 401
  - session remains `not_started`, `started_at` NULL, tokens NULL
- **Candidate endpoints require candidate token**
  - `current_task` with invite token -> 404
  - `current_task` with candidate token -> 200
- **Token expiry**
  - expired candidate token -> 401 `"Candidate token expired"`
- **Token rotation**
  - second `/verify` returns new token
  - old token no longer works (404), new token works (200)

### Test commands
- `poetry run pytest`
- `./precommit.sh` (confirmed passing)

---

## Manual QA (Postman) — M1 demo-ready checklist

> Assumes backend running locally and recruiter bearer token is available.

1) **Create simulation**
- `POST /api/simulations` (Bearer recruiter token)
- Confirm **201** and capture `simulationId`.

2) **Invite candidate**
- `POST /api/simulations/{simulationId}/invite` (Bearer recruiter token)
- Confirm **201** and capture:
  - `inviteToken` (`token`)
  - `candidateSessionId`

3) **Invite token alone is insufficient**
- `GET /api/candidate/session/{inviteToken}`
- Expect **401** `"Email verification required"`

4) **Wrong email verify**
- `POST /api/candidate/session/{inviteToken}/verify`
  - Body: `{ "email": "wrong@example.com" }`
- Expect **401** `"Invite email verification failed"`
- (Optional DB check) confirm no mutation:
  - status still `not_started`, started_at NULL, access_token NULL

5) **Correct email verify**
- `POST /api/candidate/session/{inviteToken}/verify`
  - Body: `{ "email": "<inviteEmail>" }`
- Expect **200**
- Capture:
  - `candidateToken`
  - `tokenExpiresAt`

6) **Candidate can access current task with candidate token**
- `GET /api/candidate/session/{candidateSessionId}/current_task`
  - Header: `x-candidate-token: <candidateToken>`
- Expect **200** with `currentDayIndex = 1`

7) **Candidate submits Day 1**
- `POST /api/tasks/{day1TaskId}/submit`
  - Headers:
    - `x-candidate-session-id: <candidateSessionId>`
    - `x-candidate-token: <candidateToken>`
- Expect **201** and progress updated

8) **Token rotation**
- Call `/verify` again with correct email
- Expect **200** with a **new** `candidateToken`
- Old token should fail on `current_task` with **404**
- New token should succeed with **200**

---

## Rollout / dev notes
- After pulling this branch, ensure DB migrations are applied:
  - `poetry run alembic upgrade head`
- If local scripts don’t auto-run migrations, add it to the startup runner to prevent schema drift.

---

## Acceptance criteria mapping (Issue #56)

✅ **Invite token alone cannot access session details or tasks**
- `GET /api/candidate/session/{inviteToken}` returns 401
- Candidate task/session APIs require `x-candidate-token` = candidateToken; invite token fails

✅ **Email verification tied to inviteEmail**
- `/verify` compares provided email to stored `invite_email`
- mismatch returns 401 and does not mutate state

✅ **Short-lived candidate access token issued**
- `/verify` returns `candidateToken` + `tokenExpiresAt`
- expired tokens return 401 `"Candidate token expired"`

✅ **Tests cover mismatch/success and enforce token requirements**
- Unit/API tests added/updated for:
  - verification success/failure
  - token enforcement
  - expiry and rotation

---

## Out of scope (future)
- OTP / emailed verification codes (tracked in later milestone issue #65)
- Candidate account/password auth (future)


Fixes #56 
