### PR TITLE
Implemented Email Invite URL Candidate Service

### DIFF
--- a/alembic/versions/202505050001_add_email_delivery_fields.py
+++ b/alembic/versions/202505050001_add_email_delivery_fields.py
@@ -1,0 +1,74 @@
+"""add email delivery + verification fields
+
+Revision ID: 202505050001
+Revises: 202504250001_add_candidate_auth0_identity
+Create Date: 2025-05-05 00:01:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "202505050001"
+down_revision: Union[str, None] = "202504250001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "candidate_sessions",
+        sa.Column("invite_email_status", sa.String(length=50), nullable=True),
+    )
+    op.add_column(
+        "candidate_sessions",
+        sa.Column("invite_email_error", sa.String(length=500), nullable=True),
+    )
+    op.add_column(
+        "candidate_sessions",
+        sa.Column("invite_email_last_attempt_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "candidate_sessions",
+        sa.Column("invite_email_sent_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "candidate_sessions",
+        sa.Column("verification_code", sa.String(length=20), nullable=True),
+    )
+    op.add_column(
+        "candidate_sessions",
+        sa.Column("verification_code_sent_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "candidate_sessions",
+        sa.Column("verification_code_expires_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "candidate_sessions",
+        sa.Column("verification_email_status", sa.String(length=50), nullable=True),
+    )
+    op.add_column(
+        "candidate_sessions",
+        sa.Column("verification_email_error", sa.String(length=500), nullable=True),
+    )
+    op.add_column(
+        "candidate_sessions",
+        sa.Column("verification_email_last_attempt_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("candidate_sessions", "verification_email_last_attempt_at")
+    op.drop_column("candidate_sessions", "verification_email_error")
+    op.drop_column("candidate_sessions", "verification_email_status")
+    op.drop_column("candidate_sessions", "verification_code_expires_at")
+    op.drop_column("candidate_sessions", "verification_code_sent_at")
+    op.drop_column("candidate_sessions", "verification_code")
+    op.drop_column("candidate_sessions", "invite_email_sent_at")
+    op.drop_column("candidate_sessions", "invite_email_last_attempt_at")
+    op.drop_column("candidate_sessions", "invite_email_error")
+    op.drop_column("candidate_sessions", "invite_email_status")

--- a/alembic/versions/202505050002_add_invite_email_verified_at.py
+++ b/alembic/versions/202505050002_add_invite_email_verified_at.py
@@ -1,0 +1,29 @@
+"""add invite_email_verified_at
+
+Revision ID: 202505050002
+Revises: 202505050001
+Create Date: 2025-05-05 00:10:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "202505050002"
+down_revision: Union[str, None] = "202505050001"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "candidate_sessions",
+        sa.Column("invite_email_verified_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("candidate_sessions", "invite_email_verified_at")

--- a/alembic/versions/202505050003_add_candidate_access_tokens.py
+++ b/alembic/versions/202505050003_add_candidate_access_tokens.py
@@ -1,0 +1,53 @@
+"""add candidate access token fields
+
+Revision ID: 202505050003
+Revises: 202505050002
+Create Date: 2025-05-05 01:10:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "202505050003"
+down_revision: Union[str, None] = "202505050002"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "candidate_sessions",
+        sa.Column("candidate_access_token_hash", sa.String(length=128), nullable=True),
+    )
+    op.add_column(
+        "candidate_sessions",
+        sa.Column(
+            "candidate_access_token_expires_at", sa.DateTime(timezone=True), nullable=True
+        ),
+    )
+    op.add_column(
+        "candidate_sessions",
+        sa.Column(
+            "candidate_access_token_issued_at", sa.DateTime(timezone=True), nullable=True
+        ),
+    )
+    op.create_index(
+        "ix_candidate_sessions_candidate_access_token_hash",
+        "candidate_sessions",
+        ["candidate_access_token_hash"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_candidate_sessions_candidate_access_token_hash",
+        table_name="candidate_sessions",
+    )
+    op.drop_column("candidate_sessions", "candidate_access_token_issued_at")
+    op.drop_column("candidate_sessions", "candidate_access_token_expires_at")
+    op.drop_column("candidate_sessions", "candidate_access_token_hash")

--- a/app/api/dependencies/candidate_sessions.py
+++ b/app/api/dependencies/candidate_sessions.py
@@ -8,9 +8,11 @@ from fastapi import Depends, Header, HTTPException, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.domains import CandidateSession
+from app.domains.candidate_sessions import repository as cs_repo
 from app.domains.candidate_sessions import service as cs_service
 from app.infra.db import get_session
-from app.infra.security.principal import Principal, require_permissions
+from app.infra.security.candidate_access import require_candidate_principal
+from app.infra.security.principal import Principal
 
 
 @dataclass(frozen=True)
@@ -49,7 +51,7 @@ async def fetch_candidate_session(
 
 
 async def candidate_session_from_headers(
-    principal: Annotated[Principal, Depends(require_permissions(["candidate:access"]))],
+    principal: Annotated[Principal, Depends(require_candidate_principal)],
     x_candidate_session_id: Annotated[
         int | None, Header(alias="x-candidate-session-id")
     ] = None,
@@ -61,6 +63,23 @@ async def candidate_session_from_headers(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Missing candidate session headers",
         )
+    now = datetime.now(UTC)
+    claimed_session_id = principal.claims.get("candidate_session_id")
+    if claimed_session_id is not None:
+        if int(claimed_session_id) != int(x_candidate_session_id):
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Not authorized for this invite",
+            )
+        cs = await cs_repo.get_by_id(db, int(x_candidate_session_id))
+        if cs is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Candidate session not found",
+            )
+        cs_service._ensure_not_expired(cs, now=now)  # type: ignore[attr-defined]
+        return cs
+
     return await cs_service.fetch_owned_session(
-        db, int(x_candidate_session_id), principal, now=datetime.now(UTC)
+        db, int(x_candidate_session_id), principal, now=now
     )

--- a/app/api/dependencies/notifications.py
+++ b/app/api/dependencies/notifications.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from functools import lru_cache
+
+from app.infra.config import settings
+from app.infra.notifications.email_provider import (
+    ConsoleEmailProvider,
+    EmailProvider,
+    ResendEmailProvider,
+    SendGridEmailProvider,
+    SMTPEmailProvider,
+)
+from app.services.email import EmailService
+
+
+def _build_provider() -> EmailProvider:
+    email_cfg = settings.email
+    provider_name = (email_cfg.EMAIL_PROVIDER or "console").strip().lower()
+    sender = email_cfg.EMAIL_FROM or "SimuHire <notifications@simuhire.com>"
+
+    if provider_name == "resend":
+        return ResendEmailProvider(
+            email_cfg.RESEND_API_KEY, sender=sender, transport=None
+        )
+    if provider_name == "sendgrid":
+        return SendGridEmailProvider(
+            email_cfg.SENDGRID_API_KEY, sender=sender, transport=None
+        )
+    if provider_name == "smtp":
+        return SMTPEmailProvider(
+            email_cfg.SMTP_HOST,
+            email_cfg.SMTP_PORT,
+            username=email_cfg.SMTP_USERNAME,
+            password=email_cfg.SMTP_PASSWORD,
+            use_tls=bool(email_cfg.SMTP_TLS),
+            sender=sender,
+        )
+
+    return ConsoleEmailProvider(sender=sender)
+
+
+@lru_cache
+def get_email_service() -> EmailService:
+    """Build a singleton EmailService using configured provider."""
+    provider = _build_provider()
+    sender = settings.email.EMAIL_FROM or "SimuHire <notifications@simuhire.com>"
+    return EmailService(provider, sender=sender, max_attempts=2)

--- a/app/api/routes/candidate_sessions.py
+++ b/app/api/routes/candidate_sessions.py
@@ -1,28 +1,46 @@
 from datetime import UTC, datetime
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Path, status
+from fastapi import APIRouter, Depends, HTTPException, Path, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.api.dependencies.notifications import get_email_service
 from app.domains.candidate_sessions import service as cs_service
+from app.domains.candidate_sessions.auth_tokens import mint_token
 from app.domains.candidate_sessions.schemas import (
     CandidateInviteListItem,
     CandidateSessionResolveResponse,
     CandidateSimulationSummary,
+    CandidateVerificationConfirmRequest,
+    CandidateVerificationConfirmResponse,
+    CandidateVerificationSendResponse,
     CurrentTaskResponse,
     ProgressSummary,
 )
+from app.domains.notifications import service as notification_service
+from app.domains.simulations import service as sim_service
 from app.domains.tasks.schemas_public import TaskPublic
 from app.infra.db import get_session
-from app.infra.security.principal import Principal, require_permissions
+from app.infra.security.candidate_access import require_candidate_principal
+from app.infra.security.principal import Principal
+from app.services.email import EmailService
 
 router = APIRouter()
+
+
+def _mask_email(email: str) -> str:
+    """Simple masking to avoid leaking full candidate email."""
+    if not email:
+        return ""
+    local, sep, domain = email.partition("@")
+    masked_local = (local[0] + "***") if len(local) > 1 else "*"
+    return masked_local + (sep + domain if domain else "")
 
 
 @router.get("/session/{token}", response_model=CandidateSessionResolveResponse)
 async def resolve_candidate_session(
     token: Annotated[str, Path(..., min_length=20, max_length=255)],
-    principal: Annotated[Principal, Depends(require_permissions(["candidate:access"]))],
+    principal: Annotated[Principal, Depends(require_candidate_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> CandidateSessionResolveResponse:
     """Claim an invite token for the authenticated candidate."""
@@ -46,6 +64,86 @@ async def resolve_candidate_session(
 
 
 @router.post(
+    "/session/{token}/verification/code/send",
+    response_model=CandidateVerificationSendResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def send_verification_code(
+    token: Annotated[str, Path(..., min_length=20, max_length=255)],
+    db: Annotated[AsyncSession, Depends(get_session)],
+    email_service: Annotated[EmailService, Depends(get_email_service)],
+):
+    """Send a verification code email for a candidate invite token."""
+    now = datetime.now(UTC)
+    cs = await cs_service.fetch_by_token(db, token, now=now)
+    await db.refresh(cs, attribute_names=["simulation"])
+    result = await notification_service.send_verification_email(
+        db,
+        candidate_session=cs,
+        invite_url=sim_service.invite_url(cs.token),
+        email_service=email_service,
+        now=now,
+    )
+    status_value = getattr(cs, "verification_email_status", None) or result.status
+    expires_at = getattr(cs, "verification_code_expires_at", None)
+    return CandidateVerificationSendResponse(
+        status=status_value,
+        maskedEmail=_mask_email(cs.invite_email),
+        expiresAt=expires_at,
+    )
+
+
+@router.post(
+    "/session/{token}/verification/code/confirm",
+    response_model=CandidateVerificationConfirmResponse,
+    status_code=status.HTTP_200_OK,
+)
+async def confirm_verification_code(
+    token: Annotated[str, Path(..., min_length=20, max_length=255)],
+    payload: CandidateVerificationConfirmRequest,
+    db: Annotated[AsyncSession, Depends(get_session)],
+):
+    """Confirm a previously sent verification code."""
+    code = payload.code.strip()
+    if len(code) != 6 or not code.isdigit():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid code format"
+        )
+
+    now = datetime.now(UTC)
+    cs = await cs_service.fetch_by_token(db, token, now=now)
+    expires_at = getattr(cs, "verification_code_expires_at", None)
+    if (
+        expires_at is None
+        or (expires_at.replace(tzinfo=UTC) if expires_at.tzinfo is None else expires_at)
+        < now
+    ):
+        raise HTTPException(
+            status_code=status.HTTP_410_GONE, detail="Verification code expired"
+        )
+
+    if getattr(cs, "verification_code", None) != code:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN, detail="Invalid verification code"
+        )
+
+    cs.invite_email_verified_at = now
+    cs.verification_code = None
+    cs.verification_code_sent_at = None
+    cs.verification_code_expires_at = None
+    token, token_hash, expires_at, issued_at = mint_token(now)
+    cs.candidate_access_token_hash = token_hash
+    cs.candidate_access_token_expires_at = expires_at
+    cs.candidate_access_token_issued_at = issued_at
+    await db.commit()
+    await db.refresh(cs)
+
+    return CandidateVerificationConfirmResponse(
+        verified=True, candidateAccessToken=token, expiresAt=expires_at
+    )
+
+
+@router.post(
     "/session/{token}/claim",
     response_model=CandidateSessionResolveResponse,
     status_code=status.HTTP_200_OK,
@@ -58,7 +156,7 @@ async def resolve_candidate_session(
 async def claim_candidate_session(
     token: Annotated[str, Path(..., min_length=20, max_length=255)],
     db: Annotated[AsyncSession, Depends(get_session)],
-    principal: Annotated[Principal, Depends(require_permissions(["candidate:access"]))],
+    principal: Annotated[Principal, Depends(require_candidate_principal)],
 ) -> CandidateSessionResolveResponse:
     """Idempotent claim endpoint for authenticated candidates (no email body required)."""
     now = datetime.now(UTC)
@@ -86,7 +184,7 @@ async def claim_candidate_session(
 )
 async def get_current_task(
     candidate_session_id: int,
-    principal: Annotated[Principal, Depends(require_permissions(["candidate:access"]))],
+    principal: Annotated[Principal, Depends(require_candidate_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> CurrentTaskResponse:
     """Return the current task for a candidate session.
@@ -137,7 +235,7 @@ async def get_current_task(
 
 @router.get("/invites", response_model=list[CandidateInviteListItem])
 async def list_candidate_invites(
-    principal: Annotated[Principal, Depends(require_permissions(["candidate:access"]))],
+    principal: Annotated[Principal, Depends(require_candidate_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> list[CandidateInviteListItem]:
     """List all invites for the authenticated candidate email."""

--- a/app/domains/candidate_sessions/auth_tokens.py
+++ b/app/domains/candidate_sessions/auth_tokens.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import hashlib
+import secrets
+from datetime import UTC, datetime, timedelta
+
+TOKEN_TTL_MINUTES = 60
+
+
+def hash_token(token: str) -> str:
+    """Return a hex digest for the candidate access token."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+def mint_token(now: datetime | None = None, ttl_minutes: int = TOKEN_TTL_MINUTES):
+    """Generate a new candidate token and metadata."""
+    now = now or datetime.now(UTC)
+    if now.tzinfo is None:
+        now = now.replace(tzinfo=UTC)
+    token = secrets.token_urlsafe(32)
+    token_hash = hash_token(token)
+    expires_at = now + timedelta(minutes=ttl_minutes)
+    return token, token_hash, expires_at, now

--- a/app/domains/candidate_sessions/models.py
+++ b/app/domains/candidate_sessions/models.py
@@ -54,6 +54,44 @@ class CandidateSession(Base):
         DateTime(timezone=True), nullable=True
     )
 
+    invite_email_status: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    invite_email_error: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    invite_email_last_attempt_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    invite_email_sent_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    invite_email_verified_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    candidate_access_token_hash: Mapped[str | None] = mapped_column(
+        String(128), nullable=True, index=True
+    )
+    candidate_access_token_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    candidate_access_token_issued_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    verification_code: Mapped[str | None] = mapped_column(String(20), nullable=True)
+    verification_code_sent_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    verification_code_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    verification_email_status: Mapped[str | None] = mapped_column(
+        String(50), nullable=True
+    )
+    verification_email_error: Mapped[str | None] = mapped_column(
+        String(500), nullable=True
+    )
+    verification_email_last_attempt_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     simulation = relationship("Simulation", back_populates="candidate_sessions")
     candidate_user = relationship("User", back_populates="candidate_sessions")
     submissions = relationship(

--- a/app/domains/candidate_sessions/repository.py
+++ b/app/domains/candidate_sessions/repository.py
@@ -29,6 +29,18 @@ async def get_by_id(db: AsyncSession, session_id: int) -> CandidateSession | Non
     return res.scalar_one_or_none()
 
 
+async def get_by_access_token_hash(
+    db: AsyncSession, token_hash: str
+) -> CandidateSession | None:
+    """Lookup a candidate session by access token hash."""
+    res = await db.execute(
+        select(CandidateSession).where(
+            CandidateSession.candidate_access_token_hash == token_hash
+        )
+    )
+    return res.scalar_one_or_none()
+
+
 async def tasks_for_simulation(db: AsyncSession, simulation_id: int) -> list[Task]:
     """Return tasks ordered by day_index for a simulation."""
     tasks_stmt = (

--- a/app/domains/candidate_sessions/schemas.py
+++ b/app/domains/candidate_sessions/schemas.py
@@ -53,6 +53,28 @@ class CandidateSessionVerifyResponse(CandidateSessionResolveResponse):
     pass
 
 
+class CandidateVerificationSendResponse(APIModel):
+    """Response for sending a verification code to the candidate."""
+
+    status: str
+    maskedEmail: str
+    expiresAt: datetime | None
+
+
+class CandidateVerificationConfirmRequest(APIModel):
+    """Request body for confirming a verification code."""
+
+    code: str
+
+
+class CandidateVerificationConfirmResponse(APIModel):
+    """Response after successful verification code confirmation."""
+
+    verified: bool
+    candidateAccessToken: str
+    expiresAt: datetime
+
+
 class ProgressSummary(APIModel):
     """Summary of progress for the candidate session."""
 
@@ -99,3 +121,6 @@ class CandidateSessionListItem(APIModel):
     startedAt: datetime | None
     completedAt: datetime | None
     hasReport: bool
+    inviteEmailStatus: str | None = None
+    inviteEmailSentAt: datetime | None = None
+    inviteEmailError: str | None = None

--- a/app/domains/candidate_sessions/service.py
+++ b/app/domains/candidate_sessions/service.py
@@ -63,6 +63,8 @@ def _ensure_sub_match(
     candidate_session: CandidateSession, principal: Principal
 ) -> None:
     """Block access when a different Auth0 subject attempts to reuse an invite."""
+    if principal.sub.startswith("candidate-access:"):
+        return
     stored_sub = getattr(candidate_session, "candidate_auth0_sub", None)
     if stored_sub and stored_sub != principal.sub:
         raise HTTPException(

--- a/app/domains/notifications/__init__.py
+++ b/app/domains/notifications/__init__.py
@@ -1,0 +1,1 @@
+"""Notification domain helpers (email delivery, templates)."""

--- a/app/domains/notifications/service.py
+++ b/app/domains/notifications/service.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+import secrets
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domains import CandidateSession, Simulation
+from app.services.email import EmailSendResult, EmailService
+
+INVITE_EMAIL_RATE_LIMIT_SECONDS = 30
+VERIFICATION_EMAIL_RATE_LIMIT_SECONDS = 60
+VERIFICATION_CODE_TTL_MINUTES = 15
+
+
+def _utc_now(now: datetime | None) -> datetime:
+    resolved = now or datetime.now(UTC)
+    if resolved.tzinfo is None:
+        return resolved.replace(tzinfo=UTC)
+    return resolved
+
+
+def _rate_limited(
+    last_attempt: datetime | None, now: datetime, window_seconds: int
+) -> bool:
+    if last_attempt is None:
+        return False
+    last = last_attempt
+    if last.tzinfo is None:
+        last = last.replace(tzinfo=UTC)
+    return (now - last).total_seconds() < window_seconds
+
+
+def _sanitize_error(err: str | None) -> str | None:
+    if not err:
+        return None
+    return err[:200]
+
+
+def _invite_email_content(
+    *,
+    candidate_name: str,
+    invite_url: str,
+    simulation: Simulation,
+    expires_at: datetime | None,
+) -> tuple[str, str, str]:
+    if expires_at and expires_at.tzinfo is None:
+        expires_at = expires_at.replace(tzinfo=UTC)
+    expires_text = (
+        expires_at.astimezone(UTC).strftime("%Y-%m-%d") if expires_at else "soon"
+    )
+    subject = f"You're invited: {simulation.title}"
+    text = (
+        f"Hi {candidate_name},\n\n"
+        f"You've been invited to complete the {simulation.role} simulation.\n"
+        f"Simulation: {simulation.title}\n"
+        f"Role: {simulation.role}\n\n"
+        f"Start here: {invite_url}\n\n"
+        f"Your invite expires on {expires_text}. "
+        "If you did not expect this email, you can ignore it."
+    )
+    html = (
+        f"<p>Hi {candidate_name},</p>"
+        f"<p>You have been invited to complete the <strong>{simulation.role}</strong> simulation.</p>"
+        f"<p><strong>Simulation:</strong> {simulation.title}<br>"
+        f"<strong>Role:</strong> {simulation.role}</p>"
+        f'<p><a href="{invite_url}">Open your invite</a></p>'
+        f"<p>This invite expires on {expires_text}.</p>"
+    )
+    return subject, text, html
+
+
+def _verification_email_content(
+    *,
+    candidate_name: str,
+    invite_url: str,
+    code: str,
+    expires_at: datetime,
+) -> tuple[str, str, str]:
+    expires_text = expires_at.astimezone(UTC).strftime("%Y-%m-%d %H:%M UTC")
+    subject = "Your SimuHire verification code"
+    text = (
+        f"Hi {candidate_name},\n\n"
+        f"Use this code to verify your invite: {code}\n"
+        f"Verification code expires at {expires_text}.\n\n"
+        f"You can also open your invite directly: {invite_url}\n"
+        "If you did not request this, you can ignore this email."
+    )
+    html = (
+        f"<p>Hi {candidate_name},</p>"
+        f"<p>Use this code to verify your invite:</p>"
+        f"<h2>{code}</h2>"
+        f"<p>This code expires at {expires_text}.</p>"
+        f'<p><a href="{invite_url}">Open your invite</a></p>'
+        "<p>If you did not request this, you can ignore this email.</p>"
+    )
+    return subject, text, html
+
+
+async def send_invite_email(
+    db: AsyncSession,
+    *,
+    candidate_session: CandidateSession,
+    simulation: Simulation,
+    invite_url: str,
+    email_service: EmailService,
+    now: datetime | None = None,
+) -> EmailSendResult:
+    """Send an invite email and persist delivery status."""
+    now = _utc_now(now)
+    if _rate_limited(
+        candidate_session.invite_email_last_attempt_at,
+        now,
+        INVITE_EMAIL_RATE_LIMIT_SECONDS,
+    ):
+        candidate_session.invite_email_status = "rate_limited"
+        candidate_session.invite_email_last_attempt_at = now
+        candidate_session.invite_email_error = "Rate limited"
+        await db.commit()
+        await db.refresh(candidate_session)
+        return EmailSendResult(status="rate_limited", error="Rate limited")
+
+    subject, text, html = _invite_email_content(
+        candidate_name=candidate_session.candidate_name,
+        invite_url=invite_url,
+        simulation=simulation,
+        expires_at=candidate_session.expires_at,
+    )
+    result = await email_service.send_email(
+        to=candidate_session.invite_email,
+        subject=subject,
+        text=text,
+        html=html,
+    )
+
+    candidate_session.invite_email_last_attempt_at = now
+    if result.status == "sent":
+        candidate_session.invite_email_status = "sent"
+        candidate_session.invite_email_sent_at = now
+        candidate_session.invite_email_error = None
+    else:
+        candidate_session.invite_email_status = result.status
+        candidate_session.invite_email_error = _sanitize_error(result.error)
+
+    await db.commit()
+    await db.refresh(candidate_session)
+    return result
+
+
+async def send_verification_email(
+    db: AsyncSession,
+    *,
+    candidate_session: CandidateSession,
+    invite_url: str,
+    email_service: EmailService,
+    now: datetime | None = None,
+) -> EmailSendResult:
+    """Generate and send a verification code email, respecting rate limits."""
+    now = _utc_now(now)
+    if _rate_limited(
+        candidate_session.verification_email_last_attempt_at,
+        now,
+        VERIFICATION_EMAIL_RATE_LIMIT_SECONDS,
+    ):
+        candidate_session.verification_email_status = "rate_limited"
+        candidate_session.verification_email_last_attempt_at = now
+        candidate_session.verification_email_error = "Rate limited"
+        await db.commit()
+        await db.refresh(candidate_session)
+        return EmailSendResult(status="rate_limited", error="Rate limited")
+
+    code = f"{secrets.randbelow(1_000_000):06d}"
+    expires_at = now + timedelta(minutes=VERIFICATION_CODE_TTL_MINUTES)
+    subject, text, html = _verification_email_content(
+        candidate_name=candidate_session.candidate_name,
+        invite_url=invite_url,
+        code=code,
+        expires_at=expires_at,
+    )
+    candidate_session.verification_code = code
+    candidate_session.verification_code_sent_at = now
+    candidate_session.verification_code_expires_at = expires_at
+
+    result = await email_service.send_email(
+        to=candidate_session.invite_email,
+        subject=subject,
+        text=text,
+        html=html,
+    )
+
+    candidate_session.verification_email_last_attempt_at = now
+    if result.status == "sent":
+        candidate_session.verification_email_status = "sent"
+        candidate_session.verification_email_error = None
+    else:
+        candidate_session.verification_email_status = result.status
+        candidate_session.verification_email_error = _sanitize_error(result.error)
+
+    await db.commit()
+    await db.refresh(candidate_session)
+    return result

--- a/app/infra/notifications/__init__.py
+++ b/app/infra/notifications/__init__.py
@@ -1,0 +1,1 @@
+"""Notification infrastructure components (email providers, templates, etc.)."""

--- a/app/infra/notifications/email_provider.py
+++ b/app/infra/notifications/email_provider.py
@@ -1,0 +1,273 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import smtplib
+import ssl
+from dataclasses import dataclass
+from email.message import EmailMessage as StdEmailMessage
+from typing import Protocol
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_sender(value: str) -> tuple[str, str | None]:
+    """Split 'Name <email@x>' into (email, name)."""
+    if not value:
+        return "", None
+    text = value.strip()
+    if "<" in text and ">" in text:
+        name_part, _, rest = text.partition("<")
+        email = rest.split(">", 1)[0].strip()
+        name = name_part.strip().strip('"') or None
+        return email, name
+    return text, None
+
+
+@dataclass
+class EmailMessage:
+    """Normalized email payload for providers."""
+
+    to: str
+    subject: str
+    text: str
+    html: str | None = None
+    sender: str | None = None
+
+
+class EmailSendError(Exception):
+    """Raised when an email provider fails to send."""
+
+    def __init__(self, message: str, *, retryable: bool = True):
+        super().__init__(message)
+        self.retryable = retryable
+
+
+class EmailProvider(Protocol):
+    """Protocol implemented by email providers."""
+
+    async def send(
+        self, message: EmailMessage
+    ) -> str | None:  # pragma: no cover - protocol
+        """Send an email message and return provider message id if available."""
+
+
+class ConsoleEmailProvider:
+    """Local/dev provider that logs metadata without sending."""
+
+    def __init__(self, *, sender: str | None = None):
+        self.sender = sender
+
+    async def send(self, message: EmailMessage) -> str | None:
+        """Log email metadata instead of sending."""
+        logger.info(
+            "email_console_send",
+            extra={
+                "to": message.to,
+                "subject": message.subject,
+                "sender": message.sender or self.sender,
+            },
+        )
+        return "console"
+
+
+class MemoryEmailProvider:
+    """Test helper that captures sent messages in memory."""
+
+    def __init__(self):
+        self.sent: list[EmailMessage] = []
+
+    async def send(self, message: EmailMessage) -> str | None:
+        """Capture message for assertions."""
+        self.sent.append(message)
+        return f"memory-{len(self.sent)}"
+
+
+class ResendEmailProvider:
+    """HTTP-based provider for Resend."""
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        sender: str,
+        transport: httpx.BaseTransport | None = None,
+    ):
+        """Instantiate a Resend provider."""
+        if not api_key:
+            raise ValueError("RESEND_API_KEY is required for Resend provider")
+        self.api_key = api_key
+        self.sender = sender
+        self.transport = transport
+
+    async def send(self, message: EmailMessage) -> str | None:
+        """Send via Resend API."""
+        payload = {
+            "from": message.sender or self.sender,
+            "to": [message.to],
+            "subject": message.subject,
+            "text": message.text,
+        }
+        if message.html:
+            payload["html"] = message.html
+
+        try:
+            async with httpx.AsyncClient(
+                base_url="https://api.resend.com",
+                timeout=10.0,
+                transport=self.transport,
+            ) as client:
+                resp = await client.post(
+                    "/emails",
+                    json=payload,
+                    headers={"Authorization": f"Bearer {self.api_key}"},
+                )
+        except httpx.HTTPError as exc:  # pragma: no cover - network
+            logger.error(
+                "email_send_failed",
+                extra={"provider": "resend", "error": str(exc)},
+            )
+            raise EmailSendError("Email provider request failed") from exc
+
+        if resp.status_code >= 400:
+            logger.error(
+                "email_send_failed",
+                extra={
+                    "provider": "resend",
+                    "status_code": resp.status_code,
+                },
+            )
+            retryable = resp.status_code >= 500
+            raise EmailSendError(
+                f"Email provider error ({resp.status_code})", retryable=retryable
+            )
+
+        try:
+            data = resp.json()
+        except ValueError:
+            data = {}
+        message_id = data.get("id") or data.get("message") or None
+        return str(message_id) if message_id else None
+
+
+class SendGridEmailProvider:
+    """HTTP-based provider for SendGrid."""
+
+    def __init__(
+        self,
+        api_key: str,
+        *,
+        sender: str,
+        transport: httpx.BaseTransport | None = None,
+    ):
+        """Instantiate a SendGrid provider."""
+        if not api_key:
+            raise ValueError("SENDGRID_API_KEY is required for SendGrid provider")
+        self.api_key = api_key
+        self.sender = sender
+        self.transport = transport
+
+    async def send(self, message: EmailMessage) -> str | None:
+        """Send via SendGrid v3 API."""
+        from_email, from_name = _parse_sender(message.sender or self.sender)
+        from_obj = {"email": from_email}
+        if from_name:
+            from_obj["name"] = from_name
+        payload = {
+            "personalizations": [{"to": [{"email": message.to}]}],
+            "from": from_obj,
+            "subject": message.subject,
+            "content": [
+                {"type": "text/plain", "value": message.text},
+            ],
+        }
+        if message.html:
+            payload["content"].append({"type": "text/html", "value": message.html})
+
+        headers = {
+            "Authorization": f"Bearer {self.api_key}",
+            "Content-Type": "application/json",
+        }
+        try:
+            async with httpx.AsyncClient(
+                base_url="https://api.sendgrid.com",
+                timeout=10.0,
+                transport=self.transport,
+            ) as client:
+                resp = await client.post("/v3/mail/send", json=payload, headers=headers)
+        except httpx.HTTPError as exc:  # pragma: no cover - network
+            logger.error(
+                "email_send_failed",
+                extra={"provider": "sendgrid", "error": str(exc)},
+            )
+            raise EmailSendError("Email provider request failed") from exc
+
+        if resp.status_code >= 400:
+            logger.error(
+                "email_send_failed",
+                extra={
+                    "provider": "sendgrid",
+                    "status_code": resp.status_code,
+                },
+            )
+            retryable = resp.status_code >= 500
+            raise EmailSendError(
+                f"Email provider error ({resp.status_code})", retryable=retryable
+            )
+        return resp.headers.get("X-Message-Id") or None
+
+
+class SMTPEmailProvider:
+    """SMTP provider using the standard library."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int = 587,
+        *,
+        username: str | None = None,
+        password: str | None = None,
+        use_tls: bool = True,
+        sender: str | None = None,
+    ):
+        """Instantiate SMTP provider."""
+        if not host:
+            raise ValueError("SMTP_HOST is required for SMTP provider")
+        self.host = host
+        self.port = port
+        self.username = username or ""
+        self.password = password or ""
+        self.use_tls = use_tls
+        self.sender = sender
+
+    async def send(self, message: EmailMessage) -> str | None:
+        """Send via SMTP with optional TLS and auth."""
+        email = StdEmailMessage()
+        email["Subject"] = message.subject
+        email["From"] = message.sender or self.sender or self.username
+        email["To"] = message.to
+        email.set_content(message.text)
+        if message.html:
+            email.add_alternative(message.html, subtype="html")
+
+        def _send_sync():
+            with smtplib.SMTP(self.host, self.port, timeout=10) as server:
+                server.ehlo()
+                if self.use_tls:
+                    context = ssl.create_default_context()
+                    server.starttls(context=context)
+                if self.username:
+                    server.login(self.username, self.password)
+                server.send_message(email)
+
+        try:
+            await asyncio.to_thread(_send_sync)
+        except Exception as exc:  # pragma: no cover - network
+            logger.error(
+                "email_send_failed",
+                extra={"provider": "smtp", "error": str(exc)},
+            )
+            raise EmailSendError("SMTP send failed") from exc
+        return None

--- a/app/infra/security/candidate_access.py
+++ b/app/infra/security/candidate_access.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Annotated
+
+from fastapi import Depends, HTTPException, status
+from fastapi.security import HTTPAuthorizationCredentials
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.domains import CandidateSession
+from app.domains.candidate_sessions import repository as cs_repo
+from app.domains.candidate_sessions.auth_tokens import hash_token
+from app.infra.db import get_session
+from app.infra.security.principal import Principal, bearer_scheme, get_principal
+
+
+def _is_expired(dt: datetime | None, *, now: datetime) -> bool:
+    if dt is None:
+        return True
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=UTC)
+    return dt < now
+
+
+async def _lookup_candidate_token(
+    db: AsyncSession, token: str, *, now: datetime
+) -> CandidateSession | None:
+    """Return candidate session if token is valid and unexpired."""
+    token_hash = hash_token(token)
+    cs = await cs_repo.get_by_access_token_hash(db, token_hash)
+    if cs is None:
+        return None
+    if _is_expired(getattr(cs, "candidate_access_token_expires_at", None), now=now):
+        return None
+    return cs
+
+
+async def require_candidate_principal(
+    credentials: Annotated[HTTPAuthorizationCredentials, Depends(bearer_scheme)],
+    db: Annotated[AsyncSession, Depends(get_session)],
+) -> Principal:
+    """Allow either candidate access token or Auth0 candidate bearer."""
+    if credentials is None:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Not authenticated"
+        )
+    token = credentials.credentials or ""
+    now = datetime.now(UTC)
+
+    # Candidate access tokens are opaque without a colon.
+    if ":" not in token:
+        cs = await _lookup_candidate_token(db, token, now=now)
+        if cs is not None:
+            return Principal(
+                sub=f"candidate-access:{cs.id}",
+                email=cs.invite_email,
+                name=cs.candidate_name or (cs.invite_email.split("@")[0]),
+                roles=[],
+                permissions=["candidate:access"],
+                claims={
+                    "sub": f"candidate-access:{cs.id}",
+                    "email": cs.invite_email,
+                    "https://simuhire.com/email": cs.invite_email,
+                    "permissions": ["candidate:access"],
+                    "candidate_session_id": cs.id,
+                },
+            )
+
+    if ":" in token:
+        kind, value = token.split(":", 1)
+        if kind == "candidate" and value:
+            email = value.strip()
+            return Principal(
+                sub=f"candidate-stub:{email}",
+                email=email,
+                name=email.split("@")[0],
+                roles=[],
+                permissions=["candidate:access"],
+                claims={
+                    "sub": f"candidate-stub:{email}",
+                    "email": email,
+                    "https://simuhire.com/email": email,
+                    "permissions": ["candidate:access"],
+                },
+            )
+
+    # Fallback to Auth0 / existing principal handling.
+    principal = await get_principal(credentials)
+    if "candidate:access" not in principal.permissions:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Candidate access required",
+        )
+    return principal

--- a/app/services/email.py
+++ b/app/services/email.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Literal
+
+from app.infra.notifications.email_provider import (
+    EmailMessage,
+    EmailProvider,
+    EmailSendError,
+)
+
+EmailStatus = Literal["sent", "failed", "rate_limited"]
+
+
+@dataclass
+class EmailSendResult:
+    """Result of attempting to send an email."""
+
+    status: EmailStatus
+    message_id: str | None = None
+    error: str | None = None
+
+
+class EmailService:
+    """High-level email sender with retry support."""
+
+    def __init__(
+        self,
+        provider: EmailProvider,
+        *,
+        sender: str,
+        max_attempts: int = 2,
+    ):
+        self.provider = provider
+        self.sender = sender
+        self.max_attempts = max(1, max_attempts)
+
+    async def send_email(
+        self, *, to: str, subject: str, text: str, html: str | None = None
+    ) -> EmailSendResult:
+        """Send an email with minimal retry support."""
+        last_error: EmailSendError | None = None
+
+        for attempt in range(self.max_attempts):
+            try:
+                message_id = await self.provider.send(
+                    EmailMessage(
+                        to=to,
+                        subject=subject,
+                        text=text,
+                        html=html,
+                        sender=self.sender,
+                    )
+                )
+                return EmailSendResult(status="sent", message_id=message_id)
+            except EmailSendError as exc:
+                last_error = exc
+                should_retry = exc.retryable and attempt < self.max_attempts - 1
+                if not should_retry:
+                    break
+                # Minimal cooperative backoff without blocking event loop.
+                await asyncio.sleep(0.05 * (attempt + 1))
+
+        return EmailSendResult(
+            status="failed",
+            message_id=None,
+            error=str(last_error) if last_error else "Email send failed",
+        )

--- a/tests/api/test_candidate_verification_api.py
+++ b/tests/api/test_candidate_verification_api.py
@@ -1,0 +1,229 @@
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.api.dependencies.notifications import get_email_service
+from app.domains.candidate_sessions.auth_tokens import hash_token
+from app.infra.notifications.email_provider import MemoryEmailProvider
+from app.services.email import EmailService
+from tests.factories import (
+    create_candidate_session,
+    create_recruiter,
+    create_simulation,
+)
+
+
+async def _seed_candidate_session(async_session):
+    recruiter = await create_recruiter(async_session, email="verify-seed@test.com")
+    sim, _ = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(async_session, simulation=sim)
+    return recruiter, sim, cs
+
+
+@pytest.mark.asyncio
+async def test_send_verification_code_and_rate_limit(
+    async_client, async_session, override_dependencies
+):
+    recruiter, sim, cs = await _seed_candidate_session(async_session)
+    provider = MemoryEmailProvider()
+    email_service = EmailService(provider, sender="SimuHire <noreply@test.com>")
+
+    with override_dependencies({get_email_service: lambda: email_service}):
+        res = await async_client.post(
+            f"/api/candidate/session/{cs.token}/verification/code/send"
+        )
+        assert res.status_code == 200, res.text
+        body = res.json()
+        assert body["status"] == "sent"
+        assert body["maskedEmail"].endswith("@example.com")
+
+        await async_session.refresh(cs)
+        assert cs.verification_code is not None
+        assert cs.verification_code_expires_at is not None
+        assert len(provider.sent) == 1
+
+        res2 = await async_client.post(
+            f"/api/candidate/session/{cs.token}/verification/code/send"
+        )
+        assert res2.status_code == 200, res2.text
+        body2 = res2.json()
+        assert body2["status"] == "rate_limited"
+        await async_session.refresh(cs)
+        assert cs.verification_email_status == "rate_limited"
+        assert len(provider.sent) == 1  # no extra email
+
+
+@pytest.mark.asyncio
+async def test_confirm_verification_code_success(
+    async_client, async_session, override_dependencies
+):
+    recruiter, sim, cs = await _seed_candidate_session(async_session)
+    provider = MemoryEmailProvider()
+    email_service = EmailService(provider, sender="noreply@test.com")
+
+    with override_dependencies({get_email_service: lambda: email_service}):
+        await async_client.post(
+            f"/api/candidate/session/{cs.token}/verification/code/send"
+        )
+
+    await async_session.refresh(cs)
+    code = cs.verification_code
+    res = await async_client.post(
+        f"/api/candidate/session/{cs.token}/verification/code/confirm",
+        json={"code": code},
+    )
+    assert res.status_code == 200, res.text
+    await async_session.refresh(cs)
+    assert res.json()["verified"] is True
+    assert res.json()["candidateAccessToken"]
+    assert res.json()["expiresAt"]
+    assert cs.invite_email_verified_at is not None
+    assert cs.verification_code is None
+    assert cs.verification_code_expires_at is None
+    assert cs.candidate_access_token_hash == hash_token(
+        res.json()["candidateAccessToken"]
+    )
+    assert cs.candidate_access_token_expires_at is not None
+
+
+@pytest.mark.asyncio
+async def test_confirm_verification_code_wrong_code(async_client, async_session):
+    recruiter = await create_recruiter(async_session, email="wrong@test.com")
+    sim, _ = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session,
+        simulation=sim,
+        verification_code="123456",
+        verification_code_expires_at=datetime.now(UTC) + timedelta(minutes=10),
+    )
+
+    res = await async_client.post(
+        f"/api/candidate/session/{cs.token}/verification/code/confirm",
+        json={"code": "999999"},
+    )
+    assert res.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_confirm_verification_code_expired(async_client, async_session):
+    recruiter = await create_recruiter(async_session, email="expired@test.com")
+    sim, _ = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session,
+        simulation=sim,
+        verification_code="123456",
+        verification_code_expires_at=datetime.now(UTC) - timedelta(minutes=1),
+    )
+
+    res = await async_client.post(
+        f"/api/candidate/session/{cs.token}/verification/code/confirm",
+        json={"code": "123456"},
+    )
+    assert res.status_code == 410
+
+
+@pytest.mark.asyncio
+async def test_confirm_verification_code_invalid_format(async_client, async_session):
+    recruiter = await create_recruiter(async_session, email="format@test.com")
+    sim, _ = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(
+        async_session,
+        simulation=sim,
+        verification_code="123456",
+        verification_code_expires_at=datetime.now(UTC) + timedelta(minutes=10),
+    )
+
+    res = await async_client.post(
+        f"/api/candidate/session/{cs.token}/verification/code/confirm",
+        json={"code": "12ab"},
+    )
+    assert res.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_current_task_with_candidate_access_token(
+    async_client, async_session, override_dependencies
+):
+    recruiter, sim, cs = await _seed_candidate_session(async_session)
+    provider = MemoryEmailProvider()
+    email_service = EmailService(provider, sender="noreply@test.com")
+
+    with override_dependencies({get_email_service: lambda: email_service}):
+        verify_res = await async_client.post(
+            f"/api/candidate/session/{cs.token}/verification/code/send"
+        )
+        assert verify_res.status_code == 200
+        await async_session.refresh(cs)
+        confirm_res = await async_client.post(
+            f"/api/candidate/session/{cs.token}/verification/code/confirm",
+            json={"code": cs.verification_code},
+        )
+    assert confirm_res.status_code == 200
+    token = confirm_res.json()["candidateAccessToken"]
+
+    res = await async_client.get(
+        f"/api/candidate/session/{cs.id}/current_task",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "x-candidate-session-id": str(cs.id),
+        },
+    )
+    assert res.status_code == 200, res.text
+
+    # Missing auth rejected
+    res_unauth = await async_client.get(
+        f"/api/candidate/session/{cs.id}/current_task",
+        headers={"x-candidate-session-id": str(cs.id)},
+    )
+    assert res_unauth.status_code == 401
+
+    res_invite_token = await async_client.get(
+        f"/api/candidate/session/{cs.id}/current_task",
+        headers={
+            "Authorization": f"Bearer {cs.token}",
+            "x-candidate-session-id": str(cs.id),
+        },
+    )
+    assert res_invite_token.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_candidate_access_token_expired(async_client, async_session):
+    recruiter = await create_recruiter(async_session, email="expired-token@test.com")
+    sim, _ = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(async_session, simulation=sim)
+    token = "expiredtoken"
+    cs.candidate_access_token_hash = hash_token(token)
+    cs.candidate_access_token_expires_at = datetime.now(UTC) - timedelta(minutes=1)
+    await async_session.commit()
+
+    res = await async_client.get(
+        f"/api/candidate/session/{cs.id}/current_task",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "x-candidate-session-id": str(cs.id),
+        },
+    )
+    assert res.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_resend_invite_endpoint(
+    async_client, async_session, override_dependencies, auth_header_factory
+):
+    recruiter = await create_recruiter(async_session, email="resend@test.com")
+    sim, _ = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(async_session, simulation=sim)
+
+    provider = MemoryEmailProvider()
+    email_service = EmailService(provider, sender="noreply@test.com")
+    with override_dependencies({get_email_service: lambda: email_service}):
+        res = await async_client.post(
+            f"/api/simulations/{sim.id}/candidates/{cs.id}/invite/resend",
+            headers=auth_header_factory(recruiter),
+        )
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["inviteEmailStatus"] == "sent"
+    assert body["inviteEmailSentAt"] is not None
+    assert len(provider.sent) == 1

--- a/tests/factories/models.py
+++ b/tests/factories/models.py
@@ -106,6 +106,8 @@ async def create_candidate_session(
     claimed_at: datetime | None = None,
     access_token: str | None = None,
     access_token_expires_in_minutes: int = 60,
+    verification_code: str | None = None,
+    verification_code_expires_at: datetime | None = None,
 ) -> CandidateSession:
     token = token or secrets.token_urlsafe(16)
     expires_at = datetime.now(UTC) + timedelta(days=expires_in_days)
@@ -123,6 +125,8 @@ async def create_candidate_session(
         expires_at=expires_at,
         started_at=started_at,
         completed_at=completed_at,
+        verification_code=verification_code,
+        verification_code_expires_at=verification_code_expires_at,
     )
     session.add(cs)
     await session.flush()

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -54,6 +54,7 @@ def test_auth0_fail_fast_missing_audience():
 
 def test_auth0_fail_fast_missing_issuer(monkeypatch):
     monkeypatch.setenv("AUTH0_DOMAIN", "")
+    monkeypatch.delenv("AUTH0_ISSUER", raising=False)
     with pytest.raises(ValueError) as excinfo:
         Settings(_env_file=None, ENV="prod", AUTH0_API_AUDIENCE="api://aud")
     assert "AUTH0_ISSUER" in str(excinfo.value) or "AUTH0_DOMAIN" in str(excinfo.value)

--- a/tests/unit/test_email_provider.py
+++ b/tests/unit/test_email_provider.py
@@ -1,0 +1,13 @@
+from app.infra.notifications.email_provider import _parse_sender
+
+
+def test_parse_sender_with_name():
+    email, name = _parse_sender("SimuHire <noreply@test.com>")
+    assert email == "noreply@test.com"
+    assert name == "SimuHire"
+
+
+def test_parse_sender_without_name():
+    email, name = _parse_sender("noreply@test.com")
+    assert email == "noreply@test.com"
+    assert name is None

--- a/tests/unit/test_notifications_service.py
+++ b/tests/unit/test_notifications_service.py
@@ -1,0 +1,102 @@
+from datetime import UTC, datetime
+
+import pytest
+
+from app.domains.notifications import service as notification_service
+from app.domains.simulations import service as sim_service
+from app.infra.notifications.email_provider import MemoryEmailProvider
+from app.services.email import EmailService
+from tests.factories import (
+    create_candidate_session,
+    create_recruiter,
+    create_simulation,
+)
+
+
+@pytest.mark.asyncio
+async def test_send_invite_email_tracks_status_and_rate_limit(async_session):
+    recruiter = await create_recruiter(async_session, email="notify@test.com")
+    sim, _ = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(async_session, simulation=sim)
+
+    provider = MemoryEmailProvider()
+    email_service = EmailService(provider, sender="noreply@test.com")
+    now = datetime.now(UTC)
+
+    first = await notification_service.send_invite_email(
+        async_session,
+        candidate_session=cs,
+        simulation=sim,
+        invite_url=sim_service.invite_url(cs.token),
+        email_service=email_service,
+        now=now,
+    )
+    await async_session.refresh(cs)
+
+    assert first.status == "sent"
+    assert cs.invite_email_status == "sent"
+    assert cs.invite_email_sent_at is not None
+    assert cs.invite_email_error is None
+    assert len(provider.sent) == 1
+    sent_message = provider.sent[0]
+    assert sent_message.to == cs.invite_email
+    assert sim.title in sent_message.subject
+
+    # Second send within rate window should be blocked and not call provider.
+    second = await notification_service.send_invite_email(
+        async_session,
+        candidate_session=cs,
+        simulation=sim,
+        invite_url=sim_service.invite_url(cs.token),
+        email_service=email_service,
+        now=now,
+    )
+    await async_session.refresh(cs)
+
+    assert second.status == "rate_limited"
+    assert cs.invite_email_status == "rate_limited"
+    assert cs.invite_email_error == "Rate limited"
+    assert len(provider.sent) == 1  # no extra send
+
+
+@pytest.mark.asyncio
+async def test_send_verification_email_generates_code(async_session):
+    recruiter = await create_recruiter(async_session, email="verify@test.com")
+    sim, _ = await create_simulation(async_session, created_by=recruiter)
+    cs = await create_candidate_session(async_session, simulation=sim)
+
+    provider = MemoryEmailProvider()
+    email_service = EmailService(provider, sender="noreply@test.com")
+    now = datetime.now(UTC)
+
+    result = await notification_service.send_verification_email(
+        async_session,
+        candidate_session=cs,
+        invite_url=sim_service.invite_url(cs.token),
+        email_service=email_service,
+        now=now,
+    )
+    await async_session.refresh(cs)
+
+    assert result.status == "sent"
+    assert cs.verification_code is not None
+    assert cs.verification_email_status == "sent"
+    assert cs.verification_code_sent_at is not None
+    assert cs.verification_code_expires_at is not None
+    assert len(provider.sent) == 1
+    assert cs.verification_code in provider.sent[0].text
+
+    # Rate limit follow-up send
+    result_limited = await notification_service.send_verification_email(
+        async_session,
+        candidate_session=cs,
+        invite_url=sim_service.invite_url(cs.token),
+        email_service=email_service,
+        now=now,
+    )
+    await async_session.refresh(cs)
+
+    assert result_limited.status == "rate_limited"
+    assert cs.verification_email_status == "rate_limited"
+    assert cs.verification_email_error == "Rate limited"
+    assert len(provider.sent) == 1


### PR DESCRIPTION
## Summary

### 1) Email provider integration + retryable EmailService
**New provider implementations**
- `ResendEmailProvider` (HTTP)
- `SendGridEmailProvider` (HTTP)
- `SMTPEmailProvider` (stdlib SMTP)
- `ConsoleEmailProvider` (dev-friendly; logs metadata only)
- `MemoryEmailProvider` (tests)

**Retry logic**
- `EmailService.send_email(...)` implements minimal retry with short backoff for retryable provider errors.

**Key files**
- `app/infra/notifications/email_provider.py`
- `app/services/email.py`
- `app/api/dependencies/notifications.py` (provider selection via settings)

---

### 2) Notification domain: templates, rate limiting, delivery tracking
**Invite email**
- Contains simulation title + role summary and the `inviteUrl`.
- Saves delivery metadata into `candidate_sessions`.

**Verification email (OTP)**
- Generates a 6-digit OTP.
- Stores OTP + expiry.
- Sends email with OTP + invite URL.

**Rate limiting**
- Invite email send rate-limited (per-candidate-session, short window).
- Verification email send rate-limited (per-candidate-session, short window).

**Key files**
- `app/domains/notifications/service.py`

---

### 3) Recruiter invite sends email automatically + recruiter visibility for delivery status
**Invite creation**
- `POST /api/simulations/{simulationId}/invite`
  - Creates candidate session (token)
  - Sends invite email
  - Persists invite delivery status

**Recruiter candidate listing now includes delivery fields**
- `GET /api/simulations/{simulationId}/candidates`
  - Returns `inviteEmailStatus`, `inviteEmailSentAt`, `inviteEmailError`

**Resend endpoint**
- `POST /api/simulations/{simulationId}/candidates/{candidateSessionId}/invite/resend`
  - Re-sends invite email (rate limited)
  - Returns updated delivery status fields

**Key files**
- `app/api/routes/simulations.py`
- `app/domains/candidate_sessions/schemas.py`

---

### 4) Candidate OTP flow + token exchange (removes copy/paste dependency)
**Public endpoints**
- `POST /api/candidate/session/{inviteToken}/verification/code/send`
  - Sends OTP email
  - Returns masked email + expiry + status (`sent` or `rate_limited`)

- `POST /api/candidate/session/{inviteToken}/verification/code/confirm`
  - Validates OTP
  - Sets `invite_email_verified_at`
  - Clears OTP fields
  - **Mints and returns a short-lived `candidateAccessToken`** (opaque bearer)
  - Persists only a **hash** of the token in DB + expiry timestamps
  - Rotates token on each successful confirm

**Protected candidate APIs now accept**
- `Authorization: Bearer <candidateAccessToken>` (primary for M1)
- Optional fallback: existing Auth0 candidate bearer with `candidate:access`

**Key files**
- `app/api/routes/candidate_sessions.py`
- `app/infra/security/candidate_access.py`
- `app/domains/candidate_sessions/auth_tokens.py`
- `app/domains/candidate_sessions/repository.py`
- `app/domains/candidate_sessions/service.py`

---

## Database changes (Alembic migrations)
### `candidate_sessions` new fields
**Email delivery + verification**
- `invite_email_status`
- `invite_email_error`
- `invite_email_last_attempt_at`
- `invite_email_sent_at`
- `verification_code`
- `verification_code_sent_at`
- `verification_code_expires_at`
- `verification_email_status`
- `verification_email_error`
- `verification_email_last_attempt_at`
- `invite_email_verified_at`

**Candidate access token exchange**
- `candidate_access_token_hash`
- `candidate_access_token_expires_at`
- `candidate_access_token_issued_at`
- index: `ix_candidate_sessions_candidate_access_token_hash`

**Migrations**
- `202505050001_add_email_delivery_fields.py`
- `202505050002_add_invite_email_verified_at.py`
- `202505050003_add_candidate_access_tokens.py`

---

## API summary (new/updated)
### Recruiter
- `POST /api/simulations/{simulationId}/invite` *(updated)*  
  - Now sends invite email and stores delivery status.
- `GET /api/simulations/{simulationId}/candidates` *(updated)*  
  - Adds `inviteEmailStatus`, `inviteEmailSentAt`, `inviteEmailError`.
- `POST /api/simulations/{simulationId}/candidates/{candidateSessionId}/invite/resend` *(new)*  
  - Re-sends invite email + returns delivery status.

### Candidate (public)
- `POST /api/candidate/session/{inviteToken}/verification/code/send` *(new)*  
- `POST /api/candidate/session/{inviteToken}/verification/code/confirm` *(updated)*  
  - Now returns `candidateAccessToken` and `expiresAt`.

---

## Configuration (env vars)
Add to `.env`:

```env
# Email provider selection
EMAIL_PROVIDER=resend|sendgrid|smtp|console
EMAIL_FROM="<onboarding@resend.dev>"   # MUST be quoted because of '< >'

# Resend
RESEND_API_KEY="re_..."

# SendGrid
SENDGRID_API_KEY="SG...."

# SMTP
SMTP_HOST="smtp.example.com"
SMTP_PORT=587
SMTP_USERNAME="..."
SMTP_PASSWORD="..."
SMTP_TLS=true

# Invite URL base
CANDIDATE_PORTAL_BASE_URL=http://localhost:3000
```

Notes:
- Resend restrictions apply when using `onboarding@resend.dev` without a verified domain (can typically only send to your Resend account email until domain verification).

---

## Tests added/updated
- `test_simulations_api.py`
  - invite sends email and tracks `invite_email_status/sent_at`
- `test_notifications_service.py`
  - invite email send rate limiting
  - verification email generates OTP + rate limiting
- `test_candidate_verification_api.py`
  - OTP send + confirm returns `candidateAccessToken`
  - candidateAccessToken can access protected candidate endpoints
  - invite token cannot access protected endpoints
  - expired token rejected
- `test_email_provider.py`
  - SendGrid sender parsing (`"Name <email@...>"`)

All checks:
- `poetry run pytest`
- `./precommit.sh`

---

## Manual QA (Postman)
### A) Invite → email delivered + recruiter visibility
1. `POST /api/simulations/{id}/invite`
2. Verify inbox receives invite email (Resend/SendGrid/SMTP)
3. `GET /api/simulations/{id}/candidates`
   - `inviteEmailStatus=sent`, `inviteEmailSentAt` present

### B) Resend invite + rate limiting
1. `POST /api/simulations/{id}/candidates/{csId}/invite/resend`
2. Verify inbox receives resend
3. Call again immediately → `inviteEmailStatus=rate_limited` and no second email

### C) OTP verification + token exchange
1. `POST /api/candidate/session/{inviteToken}/verification/code/send`
   - returns `status=sent`, masked email, expiry
2. Check inbox for OTP code
3. `POST /api/candidate/session/{inviteToken}/verification/code/confirm` with `{ "code": "XXXXXX" }`
   - returns `{ verified: true, candidateAccessToken, expiresAt }`
4. Call a protected candidate endpoint using:
   - `Authorization: Bearer <candidateAccessToken>`
   - `x-candidate-session-id: <candidateSessionId>`
   - Expect 200
5. Negative:
   - Using invite token as bearer → 401
   - Missing auth → 401
   - Wrong OTP → 403
   - Expired OTP → 410

---

## Acceptance Criteria checklist
- ✅ Recruiter can invite by email; candidate receives link.
- ✅ Verification flow works end-to-end via email (OTP).
- ✅ Provider integration supports Resend/SendGrid/SMTP (+ console/dev).
- ✅ Retry strategy + rate limiting implemented.
- ✅ Delivery status stored and visible to recruiter.
- ✅ Safe logging (no tokens/OTP in logs).

---

## Follow-ups / Notes
- Verify a sending domain in Resend to send to arbitrary recipients (production readiness).
- Ensure any dev-only auth conveniences are gated behind environment flags for production.


Fixes #65 