### PR TITLE
Add recruiter simulation detail endpoint for 5-day plan preview

### DIFF
--- a/app/domains/simulations/schemas.py
+++ b/app/domains/simulations/schemas.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_serializer
 
 from app.domains.common.types import TaskType
 from app.domains.tasks.schemas_public import TaskPublic
@@ -17,6 +17,8 @@ __all__ = [
     "TaskOut",
     "SimulationCreateResponse",
     "SimulationListItem",
+    "SimulationDetailResponse",
+    "SimulationDetailTask",
     "TaskPublic",
 ]
 
@@ -80,3 +82,50 @@ class SimulationListItem(BaseModel):
     templateKey: str
     createdAt: datetime
     numCandidates: int
+
+
+class SimulationDetailTask(BaseModel):
+    """Task summary for recruiter simulation detail view."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    dayIndex: int
+    title: str | None = None
+    type: TaskType | None = None
+    description: str | None = None
+    rubric: str | list[str] | dict | None = None
+    maxScore: int | None = None
+    preProvisioned: bool | None = None
+    templateRepoFullName: str | None = None
+
+    @model_serializer(mode="plain")
+    def _serialize(self):
+        data = {
+            "dayIndex": self.dayIndex,
+            "title": self.title,
+            "type": self.type,
+            "description": self.description,
+            "rubric": self.rubric,
+        }
+        if self.maxScore is not None:
+            data["maxScore"] = self.maxScore
+        if self.preProvisioned is not None:
+            data["preProvisioned"] = self.preProvisioned
+        if self.templateRepoFullName is not None:
+            data["templateRepoFullName"] = self.templateRepoFullName
+        return data
+
+
+class SimulationDetailResponse(BaseModel):
+    """Detail view response for a simulation (recruiter-only)."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: int
+    title: str | None = None
+    templateKey: str | None = None
+    role: str | None = None
+    techStack: str | list[str] | None = None
+    focus: str | list[str] | None = None
+    scenario: str | None = None
+    tasks: list[SimulationDetailTask]

--- a/app/domains/simulations/service.py
+++ b/app/domains/simulations/service.py
@@ -35,6 +35,18 @@ async def require_owned_simulation(
     return sim
 
 
+async def require_owned_simulation_with_tasks(
+    db: AsyncSession, simulation_id: int, user_id: int
+) -> tuple[Simulation, list[Task]]:
+    """Return simulation + tasks if recruiter owns it; otherwise raise 404."""
+    sim, tasks = await sim_repo.get_owned_with_tasks(db, simulation_id, user_id)
+    if sim is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND, detail="Simulation not found"
+        )
+    return sim, tasks
+
+
 async def list_simulations(db: AsyncSession, user_id: int):
     """List simulations with candidate counts for a recruiter."""
     return await sim_repo.list_with_candidate_counts(db, user_id)

--- a/tests/api/test_simulations_detail.py
+++ b/tests/api/test_simulations_detail.py
@@ -1,0 +1,94 @@
+import pytest
+
+from tests.factories import create_recruiter, create_simulation
+
+
+@pytest.mark.asyncio
+async def test_get_simulation_detail_happy_path(
+    async_client, async_session, auth_header_factory
+):
+    recruiter = await create_recruiter(async_session, email="owner-detail@example.com")
+    sim, tasks = await create_simulation(async_session, created_by=recruiter)
+    tasks[1].max_score = 42
+    await async_session.commit()
+
+    res = await async_client.get(
+        f"/api/simulations/{sim.id}", headers=auth_header_factory(recruiter)
+    )
+    assert res.status_code == 200, res.text
+
+    body = res.json()
+    assert body["id"] == sim.id
+    assert body["scenario"] == sim.scenario_template
+    assert body["templateKey"] == sim.template_key
+    assert body["techStack"] == sim.tech_stack
+    assert isinstance(body["tasks"], list)
+    assert [task["dayIndex"] for task in body["tasks"]] == [
+        task.day_index for task in tasks
+    ]
+    assert "dayIndex" in body["tasks"][0]
+    assert "day_index" not in body["tasks"][0]
+    assert "description" in body["tasks"][0]
+    assert "rubric" in body["tasks"][0]
+    assert body["tasks"][0]["rubric"] is None
+
+    day2 = next(task for task in body["tasks"] if task["dayIndex"] == 2)
+    assert "templateRepoFullName" in day2
+    assert day2["templateRepoFullName"]
+    assert day2["maxScore"] == 42
+    day1 = next(task for task in body["tasks"] if task["dayIndex"] == 1)
+    assert "templateRepoFullName" not in day1
+    assert "preProvisioned" not in day1
+    assert "maxScore" not in day1
+
+
+@pytest.mark.asyncio
+async def test_get_simulation_detail_not_found(
+    async_client, async_session, auth_header_factory
+):
+    recruiter = await create_recruiter(
+        async_session, email="missing-detail@example.com"
+    )
+    await async_session.commit()
+
+    res = await async_client.get(
+        "/api/simulations/999999", headers=auth_header_factory(recruiter)
+    )
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_simulation_detail_unauthorized(async_client):
+    res = await async_client.get("/api/simulations/1")
+    assert res.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_get_simulation_detail_rejects_unowned(
+    async_client, async_session, auth_header_factory
+):
+    owner = await create_recruiter(async_session, email="owner-sim@example.com")
+    outsider = await create_recruiter(async_session, email="outsider-sim@example.com")
+    sim, _ = await create_simulation(async_session, created_by=owner)
+    await async_session.commit()
+
+    res = await async_client.get(
+        f"/api/simulations/{sim.id}", headers=auth_header_factory(outsider)
+    )
+    assert res.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_simulation_detail_forbidden_for_non_recruiter(
+    async_client, async_session
+):
+    candidate_user = await create_recruiter(
+        async_session, email="candidate-detail@example.com", company_name="CandCo"
+    )
+    candidate_user.role = "candidate"
+    await async_session.commit()
+
+    res = await async_client.get(
+        "/api/simulations/1", headers={"x-dev-user-email": candidate_user.email}
+    )
+    assert res.status_code == 403


### PR DESCRIPTION
## Context
**Issue:** recruiter-portal: simulation detail view shows generated 5-day scenario + tasks before inviting (#53)  
**Problem discovered in QA:** Frontend’s new plan preview called `GET /api/simulations/{id}` but the backend **did not implement** this endpoint, resulting in **404 Not Found**.

This PR adds a recruiter-only simulation detail endpoint returning simulation summary + ordered tasks so the recruiter UI can preview the plan before inviting candidates.

> Non-negotiables preserved:
> - GitHub-native execution remains the only Day2/Day3 code execution path.
> - No token logging / safe auth behavior.
> - Cross-tenant access does not leak existence (safe 404 for unowned simulations).

---

## What changed

### 1) New endpoint: GET /api/simulations/{simulation_id}
- Added recruiter-authorized route:
  - `GET /api/simulations/{simulation_id}`
- Behavior:
  - **200** for owned simulation
  - **404** for non-existent OR not-owned simulation (prevents existence leakage)
  - **401/403** according to existing auth/permission rules

### 2) Response shape for recruiter simulation preview
Returns:
- `id`, `title`, `templateKey`, `role`, `techStack`, `focus`
- `scenario`: populated from `Simulation.scenario_template`
- `tasks`: ordered by `dayIndex` ascending, each including:
  - `dayIndex`, `title`, `type`, `description`
  - `rubric`: **present but null** (truthful; Task model does not store rubric)
  - `templateRepoFullName`: included only when it truly exists **and** only for Day 2/3
  - `maxScore`: optional field included only when present (if stored on Task)

### 3) Repository/service-layer fetching (minimal + consistent)
- Implemented a repository method to fetch:
  - owned simulation + tasks ordered by day index
- Implemented a service function:
  - `require_owned_simulation_with_tasks(...)` which raises safe 404 when not owned/found

### 4) Serialization rules (avoid lying)
- `templateRepoFullName` omitted unless real data exists.
- `preProvisioned` omitted unless real boolean exists (not guessed).
- `rubric` remains null (no fabrication).

---

## Files changed
- `app/api/routes/simulations.py`
  - Added `GET /api/simulations/{id}` route
  - Added mapping to SimulationDetailResponse
- `app/domains/simulations/repository.py`
  - Added owned simulation + tasks fetch, ordered
- `app/domains/simulations/service.py`
  - Added `require_owned_simulation_with_tasks`
- `app/domains/simulations/schemas.py`
  - Added `SimulationDetailResponse` / `SimulationDetailTask`
  - Added serializer behavior for optional fields
- `tests/test_simulations_detail.py`
  - Added coverage for happy path + safe 404 behavior + scenario mapping + ordering

---

## Tests
All checks passed:
- `precommit.sh` (ruff check/format + pytest)
- Total: 305 tests passed (per CI/local run)

---

## Manual QA (Postman/curl)

### 1) Create a simulation
```bash
curl -X POST "http://localhost:8000/api/simulations" \
  -H "x-dev-user-email: recruiter@example.com" \
  -H "content-type: application/json" \
  -d '{"title":"Sim","role":"Backend","techStack":"Python","seniority":"Mid","focus":"5-day plan"}'
```

### 2) Fetch simulation detail
```bash
curl -X GET "http://localhost:8000/api/simulations/{id}" \
  -H "x-dev-user-email: recruiter@example.com"
```

Verify:
- `scenario` is populated from `scenario_template`
- `tasks[*].dayIndex` are ordered
- `templateRepoFullName` appears only for Day 2/3 when Task.template_repo exists
- `rubric` is null (truthful)

### 3) Safe 404 for unowned simulation
```bash
curl -X GET "http://localhost:8000/api/simulations/{id}" \
  -H "x-dev-user-email: other@example.com"
```
Expect **404** (no existence leakage).

### 4) Missing auth
```bash
curl -X GET "http://localhost:8000/api/simulations/{id}"
```
Expect **401** (or repo-standard auth response).

---

## Notes / Follow-ups
- **Rubrics are not stored in the current Task model**, so this endpoint cannot return real rubric content yet.
  - If rubric display becomes a hard requirement, follow-up work is needed:
    - Add rubric storage to Task (json/text column) and wire it through.
- Pre-provisioning status is intentionally omitted unless backed by real data.
  - If/when pre-provisioning is implemented, add a boolean field to tasks response and update UI labels.

---

## Impact
- Unblocks frontend issue #53 by making `/api/simulations/{id}` return 200 with plan data.
- Enables recruiter UI to preview the 5-day plan before sending invites.
