### PR TITLE
Orchestrate Winoe API and worker startup

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,3 @@
+release: ./runBackend.sh migrate
+web: ./runBackend.sh api
+worker: ./runBackend.sh worker

--- a/README.md
+++ b/README.md
@@ -54,16 +54,40 @@ poetry install
 3. Apply database migrations.
 
 ```bash
-poetry run alembic upgrade head
+./runBackend.sh migrate
 ```
 
-4. Start API server.
+4. Bootstrap the local demo seed data if you are starting from a fresh database.
 
 ```bash
-poetry run uvicorn app.api.main:app --host 0.0.0.0 --port 8000 --reload
+./runBackend.sh bootstrap-local
 ```
 
-5. Smoke check.
+5. Start API server and worker together for local development.
+
+```bash
+./runBackend.sh
+```
+
+6. Start API only.
+
+```bash
+./runBackend.sh api
+```
+
+7. Start worker only.
+
+```bash
+./runBackend.sh worker
+```
+
+8. Retry dead-letter Winoe jobs after schema repair.
+
+```bash
+./runBackend.sh retry-dead-jobs
+```
+
+9. Smoke check.
 
 ```bash
 curl -s http://localhost:8000/health
@@ -76,6 +100,7 @@ Canonical env keys are summarized below by primary group.
 | Group | Primary Keys |
 |---|---|
 | Core runtime | `WINOE_ENV`, `WINOE_API_PREFIX`, `DEV_AUTH_BYPASS`, `WINOE_DEV_AUTH_BYPASS`, `WINOE_RATE_LIMIT_ENABLED`, `WINOE_MAX_REQUEST_BODY_BYTES` |
+| Jobs runtime | `WINOE_WORKER_HEARTBEAT_INTERVAL_SECONDS`, `WINOE_WORKER_HEARTBEAT_STALE_SECONDS` |
 | Perf / diagnostics | `WINOE_DEBUG_PERF`, `WINOE_PERF_SPANS_ENABLED`, `WINOE_PERF_SQL_FINGERPRINTS_ENABLED`, `WINOE_PERF_SPAN_SAMPLE_RATE` |
 | Demo/admin mode | `WINOE_DEMO_MODE`, `WINOE_SCENARIO_DEMO_MODE`, `WINOE_DEMO_ADMIN_ALLOWLIST_*` |
 | Database | `WINOE_DATABASE_URL`, `WINOE_DATABASE_URL_SYNC` |
@@ -182,6 +207,16 @@ Detailed schema-level API docs are generated at [`docs/api.md`](docs/api.md).
 - Talent Partner/candidate authorization is dependency-based; admin template endpoints use explicit API key dependency.
 - GitHub integration keeps transport/client/actions/artifact parsing concerns separated for testability.
 - Durable job status uses polling endpoints plus worker handlers for async side effects.
+- Worker health is tracked through a persisted heartbeat row per worker instance, which later readiness checks can inspect.
+
+## Runtime Commands
+
+- `./runBackend.sh` or `./runBackend.sh up`: start the API server and Winoe worker with local supervision.
+- `./runBackend.sh api`: start the API server only.
+- `./runBackend.sh worker`: start the Winoe worker only.
+- `./runBackend.sh migrate`: load environment values and run Alembic migrations.
+- `./runBackend.sh bootstrap-local`: seed the local demo Talent Partner accounts and repair missing company links.
+- `./runBackend.sh retry-dead-jobs`: requeue dead-letter Winoe jobs after schema repair.
 
 ## Tests and Verification
 

--- a/alembic/versions/202604140001_add_worker_heartbeats_table.py
+++ b/alembic/versions/202604140001_add_worker_heartbeats_table.py
@@ -1,0 +1,104 @@
+"""Add worker heartbeats table.
+
+Revision ID: 202604140001
+Revises: 202604130001
+Create Date: 2026-04-14 00:01:00.000000
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "202604140001"
+down_revision: str | Sequence[str] | None = "202604130001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE_NAME = "worker_heartbeats"
+_INDEX_NAME = "ix_worker_heartbeats_service_last_heartbeat"
+_REQUIRED_COLUMNS = {
+    "service_name",
+    "instance_id",
+    "status",
+    "started_at",
+    "last_heartbeat_at",
+    "created_at",
+    "updated_at",
+}
+_EXPECTED_PRIMARY_KEY_COLUMNS = ["service_name", "instance_id"]
+
+
+def _has_table(table_name: str) -> bool:
+    return sa.inspect(op.get_bind()).has_table(table_name)
+
+
+def _has_index(table_name: str, index_name: str) -> bool:
+    indexes = sa.inspect(op.get_bind()).get_indexes(table_name)
+    return any(index.get("name") == index_name for index in indexes)
+
+
+def _validate_existing_worker_heartbeats_table() -> None:
+    inspector = sa.inspect(op.get_bind())
+    columns = inspector.get_columns(_TABLE_NAME)
+    column_names = {column["name"] for column in columns}
+    missing_columns = sorted(_REQUIRED_COLUMNS - column_names)
+    primary_key = inspector.get_pk_constraint(_TABLE_NAME).get("constrained_columns") or []
+
+    if missing_columns or primary_key != _EXPECTED_PRIMARY_KEY_COLUMNS:
+        raise RuntimeError(
+            "worker_heartbeats already exists but does not match the expected schema. "
+            "Repair local schema drift manually before applying revision 202604140001. "
+            f"missing_columns={missing_columns or '[]'} "
+            f"primary_key={primary_key!r} "
+            f"expected_primary_key={_EXPECTED_PRIMARY_KEY_COLUMNS!r}"
+        )
+
+
+def upgrade() -> None:
+    if not _has_table(_TABLE_NAME):
+        op.create_table(
+            _TABLE_NAME,
+            sa.Column("service_name", sa.String(length=100), nullable=False),
+            sa.Column("instance_id", sa.String(length=255), nullable=False),
+            sa.Column(
+                "status",
+                sa.String(length=32),
+                nullable=False,
+                server_default=sa.text("'running'"),
+            ),
+            sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("last_heartbeat_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.func.now(),
+            ),
+            sa.PrimaryKeyConstraint("service_name", "instance_id"),
+        )
+    else:
+        _validate_existing_worker_heartbeats_table()
+
+    if not _has_index(_TABLE_NAME, _INDEX_NAME):
+        op.create_index(
+            _INDEX_NAME,
+            _TABLE_NAME,
+            ["service_name", "last_heartbeat_at"],
+            unique=False,
+        )
+
+
+def downgrade() -> None:
+    if not _has_table(_TABLE_NAME):
+        return
+    if _has_index(_TABLE_NAME, _INDEX_NAME):
+        op.drop_index(_INDEX_NAME, table_name=_TABLE_NAME)
+    op.drop_table(_TABLE_NAME)

--- a/app/config/config_settings_fields_config.py
+++ b/app/config/config_settings_fields_config.py
@@ -40,6 +40,8 @@ class SettingsFields(BaseSettings):
         default_factory=list
     )
     DEMO_ADMIN_JOB_STALE_SECONDS: int = 900
+    WORKER_HEARTBEAT_INTERVAL_SECONDS: int = 15
+    WORKER_HEARTBEAT_STALE_SECONDS: int = 60
     AI_RUNTIME_MODE: str = "real"
     DEV_AUTH_BYPASS: str | None = Field(
         default=None,

--- a/app/shared/database/shared_database_models_model.py
+++ b/app/shared/database/shared_database_models_model.py
@@ -14,6 +14,9 @@ from app.media.repositories.transcripts.media_repositories_transcripts_media_tra
 )
 from app.shared.database.shared_database_base_model import Base, TimestampMixin
 from app.shared.jobs.repositories.shared_jobs_repositories_models_repository import Job
+from app.shared.jobs.repositories.shared_jobs_repositories_worker_heartbeats_repository_model import (
+    WorkerHeartbeat,
+)
 from app.submissions.repositories.github_native.workspaces.submissions_repositories_github_native_workspaces_submissions_github_native_workspaces_core_model import (
     Workspace,
     WorkspaceGroup,
@@ -60,6 +63,7 @@ __all__ = [
     "EvaluationDayScore",
     "EvaluationRun",
     "Job",
+    "WorkerHeartbeat",
     "PrecommitBundle",
     "RecordingAsset",
     "ScenarioEditAudit",

--- a/app/shared/jobs/__init__.py
+++ b/app/shared/jobs/__init__.py
@@ -6,9 +6,12 @@ from app.shared.utils.shared_utils_lazy_module_aliases_utils import (
 )
 
 _MODULE_ALIASES = {
+    "dead_letter_retry": "app.shared.jobs.shared_jobs_dead_letter_retry_service",
     "handlers": "app.shared.jobs.handlers",
+    "heartbeat": "app.shared.jobs.shared_jobs_worker_heartbeat_service",
     "repositories": "app.shared.jobs.repositories",
     "schemas": "app.shared.jobs.schemas",
+    "worker_cli": "app.shared.jobs.shared_jobs_worker_cli_service",
     "worker": "app.shared.jobs.shared_jobs_worker_service",
     "worker_runtime": "app.shared.jobs.worker_runtime",
 }

--- a/app/shared/jobs/repositories/shared_jobs_repositories_repository.py
+++ b/app/shared/jobs/repositories/shared_jobs_repositories_repository.py
@@ -17,6 +17,9 @@ from app.shared.jobs.repositories import (
 from app.shared.jobs.repositories.shared_jobs_repositories_repository_claim_repository import (
     claim_next_runnable,
 )
+from app.shared.jobs.repositories.shared_jobs_repositories_repository_dead_letter_repository import (
+    requeue_dead_letter_jobs,
+)
 from app.shared.jobs.repositories.shared_jobs_repositories_repository_lookup_repository import (
     get_by_id,
     get_by_id_for_principal,
@@ -43,6 +46,11 @@ from app.shared.jobs.repositories.shared_jobs_repositories_repository_status_rep
     mark_dead_letter,
     mark_failed_and_reschedule,
     mark_succeeded,
+)
+from app.shared.jobs.repositories.shared_jobs_repositories_worker_heartbeats_repository import (
+    get_latest_worker_heartbeat,
+    mark_worker_stopped,
+    upsert_worker_heartbeat,
 )
 
 
@@ -83,11 +91,15 @@ __all__ = [
     "create_or_update_many_idempotent",
     "get_by_id",
     "get_by_id_for_principal",
+    "get_latest_worker_heartbeat",
     "mark_dead_letter",
     "mark_failed_and_reschedule",
+    "mark_worker_stopped",
     "mark_succeeded",
     "requeue_nonterminal_idempotent_job",
+    "requeue_dead_letter_jobs",
     "sanitize_error",
+    "upsert_worker_heartbeat",
     "_job_from_spec",
     "_load_idempotent_job",
     "_load_idempotent_jobs_for_keys",

--- a/app/shared/jobs/repositories/shared_jobs_repositories_repository_dead_letter_repository.py
+++ b/app/shared/jobs/repositories/shared_jobs_repositories_repository_dead_letter_repository.py
@@ -1,0 +1,45 @@
+"""Application module for dead-letter job recovery repository workflows."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.shared.jobs.repositories.shared_jobs_repositories_models_repository import (
+    JOB_STATUS_DEAD_LETTER,
+    JOB_STATUS_QUEUED,
+    Job,
+)
+
+
+async def requeue_dead_letter_jobs(
+    db: AsyncSession,
+    *,
+    now: datetime,
+    job_ids: list[str] | None = None,
+) -> int:
+    """Requeue dead-letter jobs."""
+    stmt = select(Job).where(Job.status == JOB_STATUS_DEAD_LETTER)
+    if job_ids:
+        normalized_ids = [job_id.strip() for job_id in job_ids if job_id.strip()]
+        if not normalized_ids:
+            return 0
+        stmt = stmt.where(Job.id.in_(normalized_ids))
+    jobs = (await db.execute(stmt.order_by(Job.created_at.asc()))).scalars().all()
+    if not jobs:
+        return 0
+    for job in jobs:
+        job.status = JOB_STATUS_QUEUED
+        job.next_run_at = now
+        job.locked_at = None
+        job.locked_by = None
+        job.last_error = None
+        job.result_json = None
+        job.updated_at = now
+    await db.commit()
+    return len(jobs)
+
+
+__all__ = ["requeue_dead_letter_jobs"]

--- a/app/shared/jobs/repositories/shared_jobs_repositories_worker_heartbeats_repository.py
+++ b/app/shared/jobs/repositories/shared_jobs_repositories_worker_heartbeats_repository.py
@@ -1,0 +1,114 @@
+"""Application module for job worker heartbeat repository workflows."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.shared.jobs.repositories.shared_jobs_repositories_worker_heartbeats_repository_model import (
+    WORKER_HEARTBEAT_STATUS_RUNNING,
+    WORKER_HEARTBEAT_STATUS_STOPPED,
+    WorkerHeartbeat,
+)
+
+
+def _normalize_text(value: str, *, field_name: str, max_length: int) -> str:
+    normalized = value.strip()
+    if not normalized:
+        raise ValueError(f"{field_name} is required")
+    if len(normalized) > max_length:
+        raise ValueError(f"{field_name} exceeds {max_length} characters")
+    return normalized
+
+
+async def upsert_worker_heartbeat(
+    db: AsyncSession,
+    *,
+    service_name: str,
+    instance_id: str,
+    now: datetime,
+    status: str = WORKER_HEARTBEAT_STATUS_RUNNING,
+) -> WorkerHeartbeat:
+    """Create or update a worker heartbeat row."""
+    normalized_service_name = _normalize_text(
+        service_name, field_name="service_name", max_length=100
+    )
+    normalized_instance_id = _normalize_text(
+        instance_id, field_name="instance_id", max_length=255
+    )
+    normalized_status = _normalize_text(status, field_name="status", max_length=32)
+
+    heartbeat = (
+        await db.execute(
+            select(WorkerHeartbeat).where(
+                WorkerHeartbeat.service_name == normalized_service_name,
+                WorkerHeartbeat.instance_id == normalized_instance_id,
+            )
+        )
+    ).scalar_one_or_none()
+    if heartbeat is None:
+        heartbeat = WorkerHeartbeat(
+            service_name=normalized_service_name,
+            instance_id=normalized_instance_id,
+            status=normalized_status,
+            started_at=now,
+            last_heartbeat_at=now,
+        )
+        db.add(heartbeat)
+    else:
+        heartbeat.status = normalized_status
+        heartbeat.last_heartbeat_at = now
+    await db.flush()
+    await db.commit()
+    return heartbeat
+
+
+async def mark_worker_stopped(
+    db: AsyncSession,
+    *,
+    service_name: str,
+    instance_id: str,
+    now: datetime,
+) -> WorkerHeartbeat:
+    """Mark a worker heartbeat row stopped."""
+    return await upsert_worker_heartbeat(
+        db,
+        service_name=service_name,
+        instance_id=instance_id,
+        now=now,
+        status=WORKER_HEARTBEAT_STATUS_STOPPED,
+    )
+
+
+async def get_latest_worker_heartbeat(
+    db: AsyncSession,
+    *,
+    service_name: str,
+) -> WorkerHeartbeat | None:
+    """Return the latest heartbeat for a service name."""
+    normalized_service_name = _normalize_text(
+        service_name, field_name="service_name", max_length=100
+    )
+    return (
+        (
+            await db.execute(
+                select(WorkerHeartbeat)
+                .where(WorkerHeartbeat.service_name == normalized_service_name)
+                .order_by(
+                    WorkerHeartbeat.last_heartbeat_at.desc(),
+                    WorkerHeartbeat.created_at.desc(),
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+
+
+__all__ = [
+    "get_latest_worker_heartbeat",
+    "mark_worker_stopped",
+    "upsert_worker_heartbeat",
+]

--- a/app/shared/jobs/repositories/shared_jobs_repositories_worker_heartbeats_repository_model.py
+++ b/app/shared/jobs/repositories/shared_jobs_repositories_worker_heartbeats_repository_model.py
@@ -1,0 +1,54 @@
+"""Application module for job worker heartbeat repository models workflows."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Index, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.shared.database.shared_database_base_model import Base
+
+WORKER_HEARTBEAT_STATUS_RUNNING = "running"
+WORKER_HEARTBEAT_STATUS_STOPPED = "stopped"
+
+
+class WorkerHeartbeat(Base):
+    """Persisted worker heartbeat row."""
+
+    __tablename__ = "worker_heartbeats"
+    __table_args__ = (
+        Index(
+            "ix_worker_heartbeats_service_last_heartbeat",
+            "service_name",
+            "last_heartbeat_at",
+        ),
+    )
+
+    service_name: Mapped[str] = mapped_column(String(100), primary_key=True)
+    instance_id: Mapped[str] = mapped_column(String(255), primary_key=True)
+    status: Mapped[str] = mapped_column(
+        String(32), nullable=False, server_default=WORKER_HEARTBEAT_STATUS_RUNNING
+    )
+    started_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    last_heartbeat_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        server_default=func.now(),
+        onupdate=func.now(),
+    )
+
+
+__all__ = [
+    "WORKER_HEARTBEAT_STATUS_RUNNING",
+    "WORKER_HEARTBEAT_STATUS_STOPPED",
+    "WorkerHeartbeat",
+]

--- a/app/shared/jobs/shared_jobs_dead_letter_retry_service.py
+++ b/app/shared/jobs/shared_jobs_dead_letter_retry_service.py
@@ -1,0 +1,29 @@
+"""Application module for dead-letter job retry service workflows."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.shared.database import async_session_maker
+from app.shared.jobs.repositories import repository as jobs_repo
+
+
+async def retry_dead_letter_jobs(
+    *,
+    session_maker: async_sessionmaker[AsyncSession] = async_session_maker,
+    job_ids: list[str] | None = None,
+    now: datetime | None = None,
+) -> int:
+    """Retry dead-letter jobs."""
+    resolved_now = now or datetime.now(UTC)
+    async with session_maker() as db:
+        return await jobs_repo.requeue_dead_letter_jobs(
+            db,
+            now=resolved_now,
+            job_ids=job_ids,
+        )
+
+
+__all__ = ["retry_dead_letter_jobs"]

--- a/app/shared/jobs/shared_jobs_worker_cli_service.py
+++ b/app/shared/jobs/shared_jobs_worker_cli_service.py
@@ -1,0 +1,102 @@
+"""Application module for Winoe worker CLI workflows."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import logging
+from datetime import UTC, datetime
+
+from app.config import settings
+from app.shared.database import async_session_maker
+from app.shared.jobs import shared_jobs_dead_letter_retry_service as dead_letter_retry
+from app.shared.jobs import shared_jobs_worker_heartbeat_service as heartbeat_service
+from app.shared.jobs import shared_jobs_worker_service as worker_service
+
+logger = logging.getLogger(__name__)
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Winoe worker CLI")
+    subparsers = parser.add_subparsers(dest="command")
+
+    _worker_parser = subparsers.add_parser("worker", help="Run the Winoe worker")
+    _worker_parser.add_argument(
+        "--service-name",
+        default=heartbeat_service.DEFAULT_WORKER_SERVICE_NAME,
+        help="Heartbeat service name",
+    )
+    _worker_parser.add_argument(
+        "--worker-id",
+        default=None,
+        help="Worker instance identifier",
+    )
+    _worker_parser.add_argument(
+        "--idle-sleep-seconds",
+        type=float,
+        default=worker_service.DEFAULT_IDLE_SLEEP_SECONDS,
+        help="Sleep between idle queue polls",
+    )
+    _worker_parser.add_argument(
+        "--heartbeat-interval-seconds",
+        type=int,
+        default=settings.WORKER_HEARTBEAT_INTERVAL_SECONDS,
+        help="Heartbeat write interval",
+    )
+
+    _retry_parser = subparsers.add_parser(
+        "retry-dead-jobs", help="Retry dead-letter Winoe jobs"
+    )
+    _retry_parser.add_argument(
+        "--job-id",
+        action="append",
+        dest="job_ids",
+        default=None,
+        help="Retry only the specified job id; repeat to target multiple jobs",
+    )
+
+    parser.set_defaults(command="worker")
+    return parser
+
+
+async def run_worker(args: argparse.Namespace) -> None:
+    """Run the Winoe worker command."""
+    worker_service.register_builtin_handlers()
+    await heartbeat_service.run_worker_forever(
+        session_maker=async_session_maker,
+        service_name=args.service_name,
+        instance_id=args.worker_id,
+        idle_sleep_seconds=args.idle_sleep_seconds,
+        heartbeat_interval_seconds=args.heartbeat_interval_seconds,
+    )
+
+
+async def retry_dead_jobs(args: argparse.Namespace) -> int:
+    """Retry dead-letter jobs command."""
+    job_count = await dead_letter_retry.retry_dead_letter_jobs(
+        session_maker=async_session_maker,
+        job_ids=args.job_ids,
+        now=datetime.now(UTC),
+    )
+    logger.info(
+        "winoe_dead_letter_jobs_retried",
+        extra={
+            "job_count": job_count,
+            "job_ids_provided": bool(args.job_ids),
+        },
+    )
+    return job_count
+
+
+def main(argv: list[str] | None = None) -> None:  # pragma: no cover - thin CLI
+    """Execute the worker CLI."""
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "retry-dead-jobs":
+        asyncio.run(retry_dead_jobs(args))
+        return
+    asyncio.run(run_worker(args))
+
+
+if __name__ == "__main__":  # pragma: no cover - module entrypoint
+    main()

--- a/app/shared/jobs/shared_jobs_worker_heartbeat_service.py
+++ b/app/shared/jobs/shared_jobs_worker_heartbeat_service.py
@@ -1,0 +1,241 @@
+"""Application module for worker heartbeat service workflows."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import socket
+from contextlib import suppress
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.config import settings
+from app.shared.database import async_session_maker
+from app.shared.jobs import shared_jobs_worker_service as worker_service
+from app.shared.jobs.repositories import repository as jobs_repo
+from app.shared.jobs.repositories.shared_jobs_repositories_worker_heartbeats_repository_model import (
+    WORKER_HEARTBEAT_STATUS_STOPPED,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_WORKER_SERVICE_NAME = "winoe-worker"
+
+
+def _build_worker_instance_id() -> str:
+    return f"{socket.gethostname()}:{os.getpid()}"
+
+
+def is_worker_heartbeat_fresh(
+    heartbeat: object,
+    *,
+    now: datetime | None = None,
+    stale_after_seconds: int | None = None,
+) -> bool:
+    """Return whether a worker heartbeat is fresh enough for readiness checks."""
+    observed_now = now or datetime.now(UTC)
+    observed_stale_after_seconds = (
+        stale_after_seconds
+        if stale_after_seconds is not None
+        else settings.WORKER_HEARTBEAT_STALE_SECONDS
+    )
+    last_heartbeat_at = getattr(heartbeat, "last_heartbeat_at", None)
+    if last_heartbeat_at is None:
+        return False
+    if last_heartbeat_at.tzinfo is None:
+        last_heartbeat_at = last_heartbeat_at.replace(tzinfo=UTC)
+    return last_heartbeat_at >= observed_now - timedelta(
+        seconds=max(1, observed_stale_after_seconds)
+    )
+
+
+async def _write_heartbeat(
+    *,
+    session_maker: async_sessionmaker[AsyncSession],
+    service_name: str,
+    instance_id: str,
+    now: datetime,
+    running: bool,
+) -> None:
+    async with session_maker() as db:
+        if running:
+            await jobs_repo.upsert_worker_heartbeat(
+                db,
+                service_name=service_name,
+                instance_id=instance_id,
+                now=now,
+            )
+            return
+        await jobs_repo.mark_worker_stopped(
+            db,
+            service_name=service_name,
+            instance_id=instance_id,
+            now=now,
+        )
+
+
+async def _heartbeat_loop(
+    *,
+    session_maker: async_sessionmaker[AsyncSession],
+    service_name: str,
+    instance_id: str,
+    started_at: datetime,
+    stop_event: asyncio.Event,
+    heartbeat_interval_seconds: int,
+) -> None:
+    await _write_heartbeat(
+        session_maker=session_maker,
+        service_name=service_name,
+        instance_id=instance_id,
+        now=started_at,
+        running=True,
+    )
+    while not stop_event.is_set():
+        with suppress(TimeoutError):
+            await asyncio.wait_for(
+                stop_event.wait(), timeout=max(1, heartbeat_interval_seconds)
+            )
+        if stop_event.is_set():
+            break
+        await _write_heartbeat(
+            session_maker=session_maker,
+            service_name=service_name,
+            instance_id=instance_id,
+            now=datetime.now(UTC),
+            running=True,
+        )
+
+
+async def run_worker_forever(
+    *,
+    session_maker: async_sessionmaker[AsyncSession] = async_session_maker,
+    service_name: str = DEFAULT_WORKER_SERVICE_NAME,
+    instance_id: str | None = None,
+    idle_sleep_seconds: float = 1.0,
+    heartbeat_interval_seconds: int | None = None,
+) -> None:
+    """Run the Winoe worker loop forever."""
+    resolved_instance_id = instance_id or _build_worker_instance_id()
+    resolved_heartbeat_interval = (
+        heartbeat_interval_seconds
+        if heartbeat_interval_seconds is not None
+        else settings.WORKER_HEARTBEAT_INTERVAL_SECONDS
+    )
+    started_at = datetime.now(UTC)
+    stop_event = asyncio.Event()
+
+    try:
+        loop = asyncio.get_running_loop()
+        for signum in (signal.SIGINT, signal.SIGTERM):
+            with suppress(NotImplementedError):
+                loop.add_signal_handler(signum, stop_event.set)
+    except RuntimeError:
+        pass
+
+    logger.info(
+        "winoe_worker_started",
+        extra={
+            "service_name": service_name,
+            "instance_id": resolved_instance_id,
+            "heartbeat_interval_seconds": resolved_heartbeat_interval,
+        },
+    )
+    heartbeat_task = asyncio.create_task(
+        _heartbeat_loop(
+            session_maker=session_maker,
+            service_name=service_name,
+            instance_id=resolved_instance_id,
+            started_at=started_at,
+            stop_event=stop_event,
+            heartbeat_interval_seconds=resolved_heartbeat_interval,
+        )
+    )
+    failure: BaseException | None = None
+    try:
+        while not stop_event.is_set():
+            handled = await worker_service.run_once(
+                session_maker=session_maker,
+                worker_id=resolved_instance_id,
+            )
+            if handled:
+                await asyncio.sleep(0)
+            else:
+                try:
+                    await asyncio.wait_for(
+                        stop_event.wait(), timeout=max(0.1, idle_sleep_seconds)
+                    )
+                except TimeoutError:
+                    pass
+            if heartbeat_task.done():
+                try:
+                    heartbeat_task.result()
+                except Exception:
+                    logger.exception(
+                        "winoe_worker_heartbeat_failed",
+                        extra={
+                            "service_name": service_name,
+                            "instance_id": resolved_instance_id,
+                        },
+                    )
+                    raise
+    except BaseException as exc:
+        failure = exc
+    finally:
+        stop_event.set()
+        if not heartbeat_task.done():
+            heartbeat_task.cancel()
+        try:
+            await heartbeat_task
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            if failure is None:
+                failure = exc
+            else:
+                logger.exception(
+                    "winoe_worker_heartbeat_failed_during_shutdown",
+                    extra={
+                        "service_name": service_name,
+                        "instance_id": resolved_instance_id,
+                    },
+                )
+        try:
+            await _write_heartbeat(
+                session_maker=session_maker,
+                service_name=service_name,
+                instance_id=resolved_instance_id,
+                now=datetime.now(UTC),
+                running=False,
+            )
+        except Exception as exc:
+            if failure is None:
+                failure = exc
+            else:
+                logger.exception(
+                    "winoe_worker_stopped_write_failed",
+                    extra={
+                        "service_name": service_name,
+                        "instance_id": resolved_instance_id,
+                    },
+                )
+        logger.info(
+            "winoe_worker_stopped",
+            extra={
+                "service_name": service_name,
+                "instance_id": resolved_instance_id,
+            },
+        )
+    if failure is not None:
+        raise failure
+
+
+__all__ = [
+    "DEFAULT_WORKER_SERVICE_NAME",
+    "_build_worker_instance_id",
+    "WORKER_HEARTBEAT_STATUS_STOPPED",
+    "is_worker_heartbeat_fresh",
+    "run_worker_forever",
+]

--- a/app/shared/jobs/shared_jobs_worker_heartbeat_service.py
+++ b/app/shared/jobs/shared_jobs_worker_heartbeat_service.py
@@ -163,12 +163,10 @@ async def run_worker_forever(
             if handled:
                 await asyncio.sleep(0)
             else:
-                try:
+                with suppress(TimeoutError):
                     await asyncio.wait_for(
                         stop_event.wait(), timeout=max(0.1, idle_sleep_seconds)
                     )
-                except TimeoutError:
-                    pass
             if heartbeat_task.done():
                 try:
                     heartbeat_task.result()

--- a/app/shared/jobs/shared_jobs_worker_service.py
+++ b/app/shared/jobs/shared_jobs_worker_service.py
@@ -65,8 +65,9 @@ async def run_forever(
 
 def main() -> None:  # pragma: no cover - thin CLI wrapper
     """Execute main."""
-    register_builtin_handlers()
-    asyncio.run(run_forever())
+    from app.shared.jobs.shared_jobs_worker_cli_service import main as cli_main
+
+    cli_main(["worker"])
 
 
 __all__ = [

--- a/pr.md
+++ b/pr.md
@@ -1,39 +1,62 @@
-# Summary
-Closes #277.
+# Orchestrate Winoe API and worker startup
+Closes #278.
 
-This PR unifies the backend schema on canonical `trials` records and repairs legacy child foreign keys so upgraded databases match the ORM and runtime expectations again. It adds a reversible schema repair migration, normalizes legacy `simulation` naming to `trial` naming, and hardens migration helpers so split-brain states fail loudly instead of being silently tolerated.
+## TL;DR
+- `./runBackend.sh` now coordinates the local API and worker together so the standard dev entrypoint matches production process topology.
+- `migrate` runs after environment loading, so database commands use the same Winoe configuration bootstrap as the runtime commands.
+- `Procfile` is split into clear `release`, `web`, and `worker` process types for production deployment.
+- Worker heartbeats now persist to the database, providing the first observability and future readiness-check foundation for `#279`.
+- Dead-letter jobs can be retried from the worker CLI, both for targeted job IDs and for the full queue of eligible dead letters.
+- `bootstrap-local` now gives developers a single, repeatable local demo flow that seeds the expected Winoe state.
 
-# Problem
-- Upgraded databases could still have a legacy `simulations` parent table while application code already reads and writes `trials`.
-- Child tables such as `scenario_versions`, `candidate_sessions`, and `tasks` could still expose `simulation_id` while the ORM expects `trial_id`.
-- That mismatch caused scenario-generation failures, inconsistent foreign key state, and candidate/session isolation problems across mixed legacy and canonical rows.
+## Problem
+Issue `#278` was needed because the backend could not be started and verified as a complete Winoe system. The API and worker were not orchestrated together in the normal launch path, migrations did not consistently run after the environment was loaded, and production startup still lacked a clean split between release, web, and worker responsibilities. That left the local demo path incomplete and made it hard to validate worker health, dead-letter recovery, and bootstrap data in the same run.
 
-# What Changed
-- Added Alembic migration `202604130001_unify_trials_schema_and_child_fks.py`.
-- Canonicalized the parent table to `trials`, merged safe legacy `simulations` rows into canonical rows, and removed `simulations` once no child foreign keys still reference it.
-- Canonicalized direct child foreign keys on `scenario_versions`, `candidate_sessions`, and `tasks` to `trial_id`, including backfills for partially repaired schemas where both `trial_id` and `simulation_id` briefly coexist.
-- Renamed or recreated legacy `simulation`-named indexes, unique constraints, and foreign keys with canonical `trial` naming.
-- Mapped legacy parent column `terminated_by_recruiter_id` onto canonical `terminated_by_talent_partner_id` during repair.
-- Derived missing `active_scenario_version_id` values from version-1 `scenario_versions` rows when trial status requires an active scenario, and raised a clear error when derivation is impossible.
-- Backfilled missing version-1 `scenario_versions` rows and `candidate_sessions.scenario_version_id` links for canonical rows that still needed them after repair.
-- Added downgrade support to restore legacy `simulations` and `simulation_id` naming for the migration surface.
-- Updated `app/core/db/migrations/shared_trial_schema_compat.py` to raise on split parent tables or split child FK columns instead of silently choosing one side.
-- Added focused migration coverage for fresh canonical, legacy-only, partially repaired, safe split-parent, unsafe split-parent, FK rename, loud-failure, and downgrade paths.
+## What changed
+### `runBackend.sh`
+- Added a supervised default startup mode that launches both the API and worker, watches both processes, and shuts the pair down cleanly on signal or child failure.
+- Kept `api`, `worker`, `migrate`, `bootstrap-local`, `retry-dead-jobs`, and `test` as explicit subcommands so the script still supports narrow workflows.
+- Moved environment loading and Winoe local defaults into the commands that need them, including `migrate` and `bootstrap-local`.
+- Added direct worker heartbeat and dead-letter retry command wiring through the same backend entrypoint.
 
-# Safety
-- Supports fresh canonical databases.
-- Supports legacy-only upgraded databases.
-- Supports partially repaired databases where both old and new schema surfaces may exist temporarily.
-- Fails loudly for unsafe states instead of guessing:
-  - divergent `trials` vs `simulations` parent rows
-  - conflicting `trial_id` vs `simulation_id` child values
-  - non-null unmapped legacy-only parent columns
-  - required active-scenario pointers that cannot be derived
+### `Procfile`
+- Split production process types into `release`, `web`, and `worker`.
+- Mapped `release` to migrations, `web` to the API, and `worker` to the worker process so deployment startup is explicit.
 
-# Testing
-- `poetry run pytest --no-cov tests/core/db/migrations/test_core_db_migrations_unify_trials_schema_issue_277.py tests/core/db/migrations/test_core_db_migrations_reconcile_helpers_utils.py`
-- `poetry run pytest --no-cov tests/trials/routes/test_trials_scenario_generation_flow_success_routes.py`
+### Worker heartbeat runtime
+- Added the worker heartbeat table, repository, and service layer.
+- The worker now records a `running` heartbeat on startup, refreshes it over time, and marks the row `stopped` on shutdown.
+- Added freshness helpers and logging that establish the observability foundation for follow-up readiness checks.
+- Wired the new heartbeat model into the shared database model registry and config settings.
 
-# Risks / Notes
-- This session verified the migration matrix and the existing trial scenario-generation smoke path, but it did not run a live PostgreSQL upgrade/downgrade cycle.
-- The migration intentionally blocks ambiguous legacy states. If production data has unexpected split-brain rows, the upgrade will now stop with an explicit error that needs manual cleanup before retry.
+### Dead-letter retry path
+- Added the dead-letter retry service and repository support to requeue eligible jobs.
+- Exposed both targeted retry by job ID and unfiltered retry for all eligible dead-letter jobs through the worker CLI.
+
+### Local bootstrap flow
+- Updated the local bootstrap command to use the same environment and database setup path as the rest of the backend entrypoints.
+- Kept the local seed flow aligned with the Winoe demo data expectations so developers can bring up a complete local environment with one command.
+
+### Tests/docs
+- Added focused coverage for startup scripts, worker heartbeat persistence, dead-letter retry behavior, the heartbeat migration, and the local bootstrap flow.
+- Updated `README.md` so the new startup and bootstrap workflow is documented alongside the backend entrypoint.
+
+## QA / verification
+- `./runBackend.sh migrate` passed
+- `./runBackend.sh bootstrap-local` passed
+- `./runBackend.sh` started both API and worker
+- worker heartbeat row observed in running state and updated over time
+- clean shutdown marked worker heartbeat as `stopped`
+- targeted and unfiltered dead-letter retry verified
+- focused regression suite passed: `26 passed in 2.32s`
+
+## Files changed
+- Startup/orchestration: `runBackend.sh`, `Procfile`
+- Heartbeat foundation: `alembic/versions/202604140001_add_worker_heartbeats_table.py`, `app/config/config_settings_fields_config.py`, `app/shared/database/shared_database_models_model.py`, `app/shared/jobs/__init__.py`, `app/shared/jobs/shared_jobs_worker_cli_service.py`, `app/shared/jobs/shared_jobs_worker_service.py`, `app/shared/jobs/shared_jobs_worker_heartbeat_service.py`, `app/shared/jobs/repositories/shared_jobs_repositories_worker_heartbeats_repository.py`, `app/shared/jobs/repositories/shared_jobs_repositories_worker_heartbeats_repository_model.py`
+- Dead-letter retry: `app/shared/jobs/shared_jobs_dead_letter_retry_service.py`, `app/shared/jobs/repositories/shared_jobs_repositories_repository.py`, `app/shared/jobs/repositories/shared_jobs_repositories_repository_dead_letter_repository.py`
+- Docs: `README.md`
+- Tests: `tests/core/db/migrations/test_core_db_migrations_worker_heartbeats.py`, `tests/scripts/test_run_backend_bootstrap_local_shell.py`, `tests/scripts/test_run_backend_migrate_shell.py`, `tests/shared/jobs/repositories/test_shared_jobs_repository_dead_letter_retry_repository.py`, `tests/shared/jobs/repositories/test_shared_jobs_repository_worker_heartbeats_repository.py`, `tests/shared/jobs/test_shared_jobs_dead_letter_retry_service.py`, `tests/shared/jobs/test_shared_jobs_worker_cli_service.py`, `tests/shared/jobs/test_shared_jobs_worker_heartbeat_service.py`, `tests/trials/routes/test_trials_local_bootstrap_seed_and_create_trial_routes.py`
+
+## Notes / follow-ups
+- `#279` will consume this heartbeat foundation for readiness checks.
+- This PR does not add the readiness endpoint itself; it only lays the worker-heartbeat groundwork needed for that follow-up.

--- a/runBackend.sh
+++ b/runBackend.sh
@@ -1,82 +1,254 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
-echo "🚀 Winoe Backend — Local Runner"
-
-PROJECT_ROOT="$(dirname "$0")"
-cd "$PROJECT_ROOT" || exit 1
-
-# Colors
-GREEN='\033[0;32m'
-NC='\033[0m'
+PROJECT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$PROJECT_ROOT"
 
 POETRY_CMD="poetry"
 USE_POETRY=0
+RUN_PREFIX=()
 
-if command -v "$POETRY_CMD" &> /dev/null; then
+log_info() {
+  printf '%s\n' "$*"
+}
+
+log_error() {
+  printf '%s\n' "$*" >&2
+}
+
+load_environment() {
+  if [[ -f ./setEnvVar.sh ]]; then
+    source ./setEnvVar.sh
+  fi
+}
+
+apply_local_defaults() {
+  if [[ -z "${WINOE_ENV:-}" || "${WINOE_ENV:-}" == "local" ]]; then
+    export WINOE_ENV="${WINOE_ENV:-local}"
+    export DEV_AUTH_BYPASS="${DEV_AUTH_BYPASS:-1}"
+  fi
+}
+
+require_database_config() {
+  if [[ -z "${WINOE_DATABASE_URL:-}" && -z "${WINOE_DATABASE_URL_SYNC:-}" ]]; then
+    log_error "ERROR: Winoe database configuration is missing."
+    exit 1
+  fi
+}
+
+stop_children() {
+  local pid
+  for pid in "${RUNNING_PIDS[@]:-}"; do
+    if [[ -n "${pid:-}" ]] && kill -0 "$pid" 2>/dev/null; then
+      kill "$pid" 2>/dev/null || true
+    fi
+  done
+  for pid in "${RUNNING_PIDS[@]:-}"; do
+    if [[ -n "${pid:-}" ]]; then
+      wait "$pid" 2>/dev/null || true
+    fi
+  done
+}
+
+on_signal() {
+  local exit_code="$1"
+  SUPERVISOR_SHUTTING_DOWN=1
+  SUPERVISOR_EXIT_CODE="$exit_code"
+  stop_children
+}
+
+on_exit() {
+  stop_children
+}
+
+install_poetry_if_needed() {
+  if command -v "$POETRY_CMD" &>/dev/null; then
     USE_POETRY=1
-else
-    echo -e "${GREEN}Poetry not found. Installing...${NC}"
-    install_status=0
-    if command -v pipx &> /dev/null; then
-        pipx install poetry || install_status=$?
-        export PATH="$HOME/.local/bin:$PATH"
-    elif command -v python3 &> /dev/null; then
-        VENV_DIR="${PROJECT_ROOT}/.venv-poetry"
-        python3 -m venv "$VENV_DIR" || install_status=$?
-        if [[ $install_status -eq 0 ]]; then
-            "$VENV_DIR/bin/pip" install poetry || install_status=$?
-        fi
-        POETRY_CMD="$VENV_DIR/bin/poetry"
-    else
-        install_status=1
+    return
+  fi
+
+  log_info "Winoe worker launcher: Poetry not found, attempting install."
+  local install_status=0
+  if command -v pipx &>/dev/null; then
+    pipx install poetry || install_status=$?
+    export PATH="$HOME/.local/bin:$PATH"
+  elif command -v python3 &>/dev/null; then
+    local venv_dir="${PROJECT_ROOT}/.venv-poetry"
+    python3 -m venv "$venv_dir" || install_status=$?
+    if [[ $install_status -eq 0 ]]; then
+      "$venv_dir/bin/pip" install poetry || install_status=$?
+    fi
+    POETRY_CMD="$venv_dir/bin/poetry"
+  else
+    install_status=1
+  fi
+
+  if [[ $install_status -eq 0 ]] && { command -v "$POETRY_CMD" &>/dev/null || [[ -x "$POETRY_CMD" ]]; }; then
+    USE_POETRY=1
+  elif [[ -x "${PROJECT_ROOT}/.venv/bin/python" ]]; then
+    log_info "Winoe worker launcher: using existing .venv."
+    export PATH="${PROJECT_ROOT}/.venv/bin:$PATH"
+  else
+    log_error "ERROR: Poetry install failed and no .venv was found."
+    exit 1
+  fi
+}
+
+configure_runtime() {
+  install_poetry_if_needed
+  if [[ $USE_POETRY -eq 1 ]]; then
+    RUN_PREFIX=("$POETRY_CMD" run)
+  fi
+}
+
+run_api() {
+  load_environment
+  apply_local_defaults
+  require_database_config
+
+  local reload_flag=()
+  if [[ "${WINOE_ENV:-local}" == "local" && "${DISABLE_RELOAD:-0}" != "1" ]]; then
+    reload_flag=(--reload)
+  fi
+
+  log_info "Starting Winoe API server."
+  exec "${RUN_PREFIX[@]}" uvicorn app.api.main:app "${reload_flag[@]}" --host 0.0.0.0 --port 8000
+}
+
+run_worker() {
+  load_environment
+  apply_local_defaults
+  require_database_config
+
+  log_info "Starting Winoe worker."
+  exec "${RUN_PREFIX[@]}" python -m app.shared.jobs.shared_jobs_worker_cli_service worker
+}
+
+run_migrations() {
+  load_environment
+  require_database_config
+
+  log_info "Running Winoe database migrations."
+  exec "${RUN_PREFIX[@]}" alembic upgrade head
+}
+
+run_local_bootstrap() {
+  load_environment
+  apply_local_defaults
+  require_database_config
+
+  log_info "Bootstrapping Winoe local demo seed data."
+  exec "${RUN_PREFIX[@]}" python scripts/seed_local_talent_partners.py
+}
+
+run_dead_letter_retry() {
+  load_environment
+  require_database_config
+
+  log_info "Retrying dead-letter Winoe jobs."
+  exec "${RUN_PREFIX[@]}" python -m app.shared.jobs.shared_jobs_worker_cli_service retry-dead-jobs "$@"
+}
+
+run_tests() {
+  load_environment
+  log_info "Running Winoe tests."
+  exec "${RUN_PREFIX[@]}" pytest -q
+}
+
+run_supervised_local_runtime() {
+  load_environment
+  apply_local_defaults
+  require_database_config
+
+  local api_pid=""
+  local worker_pid=""
+  RUNNING_PIDS=()
+  SUPERVISOR_SHUTTING_DOWN=0
+  SUPERVISOR_EXIT_CODE=0
+
+  trap 'on_signal 130' INT
+  trap 'on_signal 143' TERM
+  trap 'on_exit' EXIT
+
+  log_info "Starting Winoe API server and worker."
+  if [[ "${WINOE_ENV:-local}" == "local" && "${DISABLE_RELOAD:-0}" != "1" ]]; then
+    "${RUN_PREFIX[@]}" uvicorn app.api.main:app --reload --host 0.0.0.0 --port 8000 &
+  else
+    "${RUN_PREFIX[@]}" uvicorn app.api.main:app --host 0.0.0.0 --port 8000 &
+  fi
+  api_pid="$!"
+
+  "${RUN_PREFIX[@]}" python -m app.shared.jobs.shared_jobs_worker_cli_service worker &
+  worker_pid="$!"
+
+  RUNNING_PIDS=("$api_pid" "$worker_pid")
+
+  while true; do
+    if ! kill -0 "$api_pid" 2>/dev/null; then
+      wait "$api_pid" || api_exit_code=$?
+      api_exit_code="${api_exit_code:-0}"
+      if [[ $SUPERVISOR_SHUTTING_DOWN -eq 0 ]]; then
+        log_error "ERROR: Winoe API server exited unexpectedly with status ${api_exit_code}."
+        SUPERVISOR_SHUTTING_DOWN=1
+        SUPERVISOR_EXIT_CODE=1
+        stop_children
+      fi
+      break
     fi
 
-    if [[ $install_status -eq 0 ]] && { command -v "$POETRY_CMD" &> /dev/null || [[ -x "$POETRY_CMD" ]]; }; then
-        USE_POETRY=1
-    else
-        if [[ -x "${PROJECT_ROOT}/.venv/bin/python" ]]; then
-            echo -e "${GREEN}Poetry install failed. Using existing .venv...${NC}"
-            export PATH="${PROJECT_ROOT}/.venv/bin:$PATH"
-        else
-            echo "ERROR: Poetry install failed and no .venv found."
-            exit 1
-        fi
+    if ! kill -0 "$worker_pid" 2>/dev/null; then
+      wait "$worker_pid" || worker_exit_code=$?
+      worker_exit_code="${worker_exit_code:-0}"
+      if [[ $SUPERVISOR_SHUTTING_DOWN -eq 0 ]]; then
+        log_error "ERROR: Winoe worker exited unexpectedly with status ${worker_exit_code}."
+        SUPERVISOR_SHUTTING_DOWN=1
+        SUPERVISOR_EXIT_CODE=1
+        stop_children
+      fi
+      break
     fi
-fi
 
-if [[ $USE_POETRY -eq 1 ]]; then
-    echo -e "${GREEN}Using Poetry environment...${NC}"
-    RUN="$POETRY_CMD run"
-else
-    RUN=""
-fi
+    sleep 1
+  done
 
-if [[ "$1" == "test" ]]; then
-    echo "🧪 Running tests..."
-    $RUN pytest -q
-    exit 0
-fi
+  stop_children
+  exit "$SUPERVISOR_EXIT_CODE"
+}
 
-if [[ "$1" == "migrate" ]]; then
-    echo "📦 Running Alembic migrations..."
-    $RUN alembic upgrade head
-    exit 0
-fi
+main() {
+  configure_runtime
 
-echo "🌱 Seeding local talent_partners..."
-export ENV=local
-export DEV_AUTH_BYPASS=1
-source ./setEnvVar.sh
+  local command="${1:-up}"
+  shift || true
 
-$RUN python scripts/seed_local_talent_partners.py
+  case "$command" in
+    up|local|default)
+      run_supervised_local_runtime
+      ;;
+    api)
+      run_api
+      ;;
+    worker)
+      run_worker
+      ;;
+    migrate)
+      run_migrations
+      ;;
+    bootstrap-local)
+      run_local_bootstrap
+      ;;
+    retry-dead-jobs)
+      run_dead_letter_retry "$@"
+      ;;
+    test)
+      run_tests
+      ;;
+    *)
+      log_error "Usage: ./runBackend.sh [up|api|worker|migrate|bootstrap-local|retry-dead-jobs|test]"
+      exit 1
+      ;;
+  esac
+}
 
-echo "🔧 Starting FastAPI server..."
-
-RELOAD_FLAG="--reload"
-if [[ "${DISABLE_RELOAD:-0}" == "1" ]]; then
-  RELOAD_FLAG=""
-fi
-
-$RUN uvicorn app.api.main:app ${RELOAD_FLAG} --host 0.0.0.0 --port 8000
+main "$@"

--- a/runBackend.sh
+++ b/runBackend.sh
@@ -143,6 +143,8 @@ run_migrations() {
 run_local_bootstrap() {
   load_environment
   apply_local_defaults
+  # Seed data should not depend on auth bypass state from the caller.
+  export DEV_AUTH_BYPASS=0
   require_database_config
 
   log_info "Bootstrapping Winoe local demo seed data."

--- a/runBackend.sh
+++ b/runBackend.sh
@@ -21,6 +21,13 @@ load_environment() {
   if [[ -f ./setEnvVar.sh ]]; then
     source ./setEnvVar.sh
   fi
+  if [[ -n "${ENV_FILE:-}" && -f "${ENV_FILE}" ]]; then
+    # Keep CI/local runtime env overrides available to every child process.
+    set -a
+    # shellcheck disable=SC1090
+    source "${ENV_FILE}"
+    set +a
+  fi
 }
 
 apply_local_defaults() {

--- a/tests/core/db/migrations/test_core_db_migrations_worker_heartbeats.py
+++ b/tests/core/db/migrations/test_core_db_migrations_worker_heartbeats.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import sqlalchemy as sa
+import pytest
+
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+_MIGRATION_PATH = (
+    Path(__file__).resolve().parents[4]
+    / "alembic/versions/202604140001_add_worker_heartbeats_table.py"
+)
+_MIGRATION_SPEC = importlib.util.spec_from_file_location(
+    "worker_heartbeats_migration", _MIGRATION_PATH
+)
+assert _MIGRATION_SPEC and _MIGRATION_SPEC.loader
+worker_heartbeats_migration = importlib.util.module_from_spec(_MIGRATION_SPEC)
+_MIGRATION_SPEC.loader.exec_module(worker_heartbeats_migration)
+
+
+def _operations(bind: sa.Connection) -> Operations:
+    return Operations(MigrationContext.configure(bind))
+
+
+def test_worker_heartbeats_migration_upgrade_and_downgrade() -> None:
+    engine = sa.create_engine("sqlite+pysqlite:///:memory:")
+    with engine.begin() as conn:
+        worker_heartbeats_migration.op = _operations(conn)
+        worker_heartbeats_migration.upgrade()
+
+        inspector = sa.inspect(conn)
+        assert "worker_heartbeats" in inspector.get_table_names()
+        column_names = {
+            column["name"] for column in inspector.get_columns("worker_heartbeats")
+        }
+        assert column_names == {
+            "service_name",
+            "instance_id",
+            "status",
+            "started_at",
+            "last_heartbeat_at",
+            "created_at",
+            "updated_at",
+        }
+        index_names = {
+            index["name"]
+            for index in inspector.get_indexes("worker_heartbeats")
+            if index.get("name")
+        }
+        assert "ix_worker_heartbeats_service_last_heartbeat" in index_names
+
+        worker_heartbeats_migration.downgrade()
+        assert "worker_heartbeats" not in sa.inspect(conn).get_table_names()
+
+
+def test_worker_heartbeats_migration_upgrade_backfills_index_when_table_exists() -> (
+    None
+):
+    engine = sa.create_engine("sqlite+pysqlite:///:memory:")
+    metadata = sa.MetaData()
+    sa.Table(
+        "worker_heartbeats",
+        metadata,
+        sa.Column("service_name", sa.String(length=100), nullable=False),
+        sa.Column("instance_id", sa.String(length=255), nullable=False),
+        sa.Column("status", sa.String(length=32), nullable=False),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("last_heartbeat_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("service_name", "instance_id"),
+    )
+    metadata.create_all(engine)
+
+    with engine.begin() as conn:
+        worker_heartbeats_migration.op = _operations(conn)
+        worker_heartbeats_migration.upgrade()
+
+        index_names = {
+            index["name"]
+            for index in sa.inspect(conn).get_indexes("worker_heartbeats")
+            if index.get("name")
+        }
+        assert "ix_worker_heartbeats_service_last_heartbeat" in index_names
+
+
+@pytest.mark.parametrize(
+    ("table_columns", "expected_error"),
+    [
+        (
+            [
+                sa.Column("service_name", sa.String(length=100), nullable=False),
+                sa.Column("instance_id", sa.String(length=255), nullable=False),
+                sa.Column("status", sa.String(length=32), nullable=False),
+                sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+                sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+                sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+                sa.PrimaryKeyConstraint("service_name", "instance_id"),
+            ],
+            "missing_columns",
+        ),
+        (
+            [
+                sa.Column("service_name", sa.String(length=100), nullable=False),
+                sa.Column("instance_id", sa.String(length=255), nullable=False),
+                sa.Column("status", sa.String(length=32), nullable=False),
+                sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+                sa.Column("last_heartbeat_at", sa.DateTime(timezone=True), nullable=False),
+                sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+                sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+                sa.PrimaryKeyConstraint("service_name"),
+            ],
+            "expected schema",
+        ),
+    ],
+)
+def test_worker_heartbeats_migration_upgrade_rejects_malformed_existing_table(
+    table_columns,
+    expected_error,
+) -> None:
+    engine = sa.create_engine("sqlite+pysqlite:///:memory:")
+    metadata = sa.MetaData()
+    sa.Table("worker_heartbeats", metadata, *table_columns)
+    metadata.create_all(engine)
+
+    with engine.begin() as conn:
+        worker_heartbeats_migration.op = _operations(conn)
+        with pytest.raises(RuntimeError, match=expected_error):
+            worker_heartbeats_migration.upgrade()

--- a/tests/core/db/migrations/test_core_db_migrations_worker_heartbeats.py
+++ b/tests/core/db/migrations/test_core_db_migrations_worker_heartbeats.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import importlib.util
 from pathlib import Path
 
-import sqlalchemy as sa
 import pytest
+import sqlalchemy as sa
 
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
@@ -108,7 +108,9 @@ def test_worker_heartbeats_migration_upgrade_backfills_index_when_table_exists()
                 sa.Column("instance_id", sa.String(length=255), nullable=False),
                 sa.Column("status", sa.String(length=32), nullable=False),
                 sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
-                sa.Column("last_heartbeat_at", sa.DateTime(timezone=True), nullable=False),
+                sa.Column(
+                    "last_heartbeat_at", sa.DateTime(timezone=True), nullable=False
+                ),
                 sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
                 sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
                 sa.PrimaryKeyConstraint("service_name"),

--- a/tests/scripts/test_run_backend_bootstrap_local_shell.py
+++ b/tests/scripts/test_run_backend_bootstrap_local_shell.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_run_backend_bootstrap_local_sources_env_and_runs_seed_script(tmp_path):
+    repo_root = Path(__file__).resolve().parents[2]
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    log_file = tmp_path / "command.log"
+    env_file = tmp_path / "runtime.env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "WINOE_DATABASE_URL=sqlite:///tmp/winoe.db",
+                "WINOE_DATABASE_URL_SYNC=sqlite:///tmp/winoe.db",
+                "WINOE_CUSTOM_MARKER=loaded",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    poetry_script = bin_dir / "poetry"
+    poetry_script.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+echo "poetry:$*" >> "$TEST_COMMAND_LOG"
+shift
+if [[ "${1:-}" == "run" ]]; then
+  shift
+fi
+exec "$@"
+""",
+        encoding="utf-8",
+    )
+    poetry_script.chmod(0o755)
+
+    python_script = bin_dir / "python"
+    python_script.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+{
+  echo "python:$*"
+  echo "marker:${WINOE_CUSTOM_MARKER:-missing}"
+  echo "bypass:${DEV_AUTH_BYPASS:-missing}"
+} >> "$TEST_COMMAND_LOG"
+""",
+        encoding="utf-8",
+    )
+    python_script.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+    env["ENV_FILE"] = str(env_file)
+    env["TEST_COMMAND_LOG"] = str(log_file)
+
+    result = subprocess.run(
+        ["bash", "runBackend.sh", "bootstrap-local"],
+        cwd=repo_root,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    log_output = log_file.read_text(encoding="utf-8")
+    assert "poetry:run python scripts/seed_local_talent_partners.py" in log_output
+    assert "python:scripts/seed_local_talent_partners.py" in log_output
+    assert "marker:loaded" in log_output
+    assert "bypass:0" in log_output

--- a/tests/scripts/test_run_backend_migrate_shell.py
+++ b/tests/scripts/test_run_backend_migrate_shell.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_run_backend_migrate_sources_env_before_alembic(tmp_path):
+    repo_root = Path(__file__).resolve().parents[2]
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    log_file = tmp_path / "command.log"
+    env_file = tmp_path / "runtime.env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "WINOE_DATABASE_URL=sqlite:///tmp/winoe.db",
+                "WINOE_DATABASE_URL_SYNC=sqlite:///tmp/winoe.db",
+                "WINOE_CUSTOM_MARKER=loaded",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    poetry_script = bin_dir / "poetry"
+    poetry_script.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+echo "poetry:$*" >> "$TEST_COMMAND_LOG"
+shift
+if [[ "${1:-}" == "run" ]]; then
+  shift
+fi
+exec "$@"
+""",
+        encoding="utf-8",
+    )
+    poetry_script.chmod(0o755)
+
+    alembic_script = bin_dir / "alembic"
+    alembic_script.write_text(
+        """#!/usr/bin/env bash
+set -euo pipefail
+{
+  echo "alembic:$*"
+  echo "marker:${WINOE_CUSTOM_MARKER:-missing}"
+  echo "database:${WINOE_DATABASE_URL:-missing}"
+} >> "$TEST_COMMAND_LOG"
+""",
+        encoding="utf-8",
+    )
+    alembic_script.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+    env["ENV_FILE"] = str(env_file)
+    env["TEST_COMMAND_LOG"] = str(log_file)
+
+    result = subprocess.run(
+        ["bash", "runBackend.sh", "migrate"],
+        cwd=repo_root,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    log_output = log_file.read_text(encoding="utf-8")
+    assert "poetry:run alembic upgrade head" in log_output
+    assert "alembic:upgrade head" in log_output
+    assert "marker:loaded" in log_output
+    assert "database:sqlite:///tmp/winoe.db" in log_output

--- a/tests/shared/jobs/repositories/test_shared_jobs_repository_dead_letter_retry_repository.py
+++ b/tests/shared/jobs/repositories/test_shared_jobs_repository_dead_letter_retry_repository.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from app.shared.jobs.repositories import repository as jobs_repo
+from app.shared.jobs.repositories.shared_jobs_repositories_models_repository import (
+    JOB_STATUS_DEAD_LETTER,
+    JOB_STATUS_QUEUED,
+)
+from tests.shared.jobs.shared_jobs_worker_utils import create_job
+
+
+def _to_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+@pytest.mark.asyncio
+async def test_requeue_dead_letter_jobs_only_targets_dead_letters(async_session):
+    dead_letter_job = await create_job(
+        async_session,
+        job_type="dead-letter-retry",
+        idempotency_key="dead-letter-1",
+        payload_json={"demo": True},
+    )
+    dead_letter_job.status = JOB_STATUS_DEAD_LETTER
+    dead_letter_job.last_error = "schema repair required"
+    dead_letter_job.result_json = {"failure": True}
+    dead_letter_job.locked_at = datetime(2026, 4, 14, 12, 0, tzinfo=UTC)
+    dead_letter_job.locked_by = "worker-1"
+
+    queued_job = await create_job(
+        async_session,
+        job_type="queued-preserved",
+        idempotency_key="queued-1",
+        payload_json={"demo": True},
+    )
+    queued_job.next_run_at = datetime.now(UTC) + timedelta(minutes=10)
+    await async_session.commit()
+
+    now = datetime(2026, 4, 14, 13, 0, tzinfo=UTC)
+    count = await jobs_repo.requeue_dead_letter_jobs(async_session, now=now)
+    assert count == 1
+
+    refreshed_dead = await jobs_repo.get_by_id(async_session, dead_letter_job.id)
+    assert refreshed_dead is not None
+    assert refreshed_dead.status == JOB_STATUS_QUEUED
+    assert _to_utc(refreshed_dead.next_run_at) == now
+    assert refreshed_dead.locked_at is None
+    assert refreshed_dead.locked_by is None
+    assert refreshed_dead.last_error is None
+    assert refreshed_dead.result_json is None
+
+    refreshed_queued = await jobs_repo.get_by_id(async_session, queued_job.id)
+    assert refreshed_queued is not None
+    assert refreshed_queued.status == JOB_STATUS_QUEUED
+    assert refreshed_queued.next_run_at is not None
+
+
+@pytest.mark.asyncio
+async def test_requeue_dead_letter_jobs_can_target_specific_ids(async_session):
+    first = await create_job(
+        async_session,
+        job_type="dead-letter-retry-target",
+        idempotency_key="dead-letter-target-1",
+        payload_json={"demo": True},
+    )
+    second = await create_job(
+        async_session,
+        job_type="dead-letter-retry-target-2",
+        idempotency_key="dead-letter-target-2",
+        payload_json={"demo": True},
+    )
+    first.status = JOB_STATUS_DEAD_LETTER
+    second.status = JOB_STATUS_DEAD_LETTER
+    await async_session.commit()
+
+    count = await jobs_repo.requeue_dead_letter_jobs(
+        async_session,
+        now=datetime(2026, 4, 14, 13, 30, tzinfo=UTC),
+        job_ids=[first.id],
+    )
+    assert count == 1
+
+    refreshed_first = await jobs_repo.get_by_id(async_session, first.id)
+    refreshed_second = await jobs_repo.get_by_id(async_session, second.id)
+    assert refreshed_first is not None
+    assert refreshed_first.status == JOB_STATUS_QUEUED
+    assert refreshed_second is not None
+    assert refreshed_second.status == JOB_STATUS_DEAD_LETTER
+
+
+@pytest.mark.asyncio
+async def test_requeue_dead_letter_jobs_ignores_blank_targets(async_session):
+    count = await jobs_repo.requeue_dead_letter_jobs(
+        async_session,
+        now=datetime(2026, 4, 14, 13, 45, tzinfo=UTC),
+        job_ids=[" ", "\t"],
+    )
+    assert count == 0
+
+
+@pytest.mark.asyncio
+async def test_requeue_dead_letter_jobs_deduplicates_requested_ids(async_session):
+    job = await create_job(
+        async_session,
+        job_type="dead-letter-retry-dedup",
+        idempotency_key="dead-letter-dedup-1",
+        payload_json={"demo": True},
+    )
+    job.status = JOB_STATUS_DEAD_LETTER
+    await async_session.commit()
+
+    count = await jobs_repo.requeue_dead_letter_jobs(
+        async_session,
+        now=datetime(2026, 4, 14, 14, 0, tzinfo=UTC),
+        job_ids=[job.id, job.id, f" {job.id} "],
+    )
+
+    assert count == 1

--- a/tests/shared/jobs/repositories/test_shared_jobs_repository_worker_heartbeats_repository.py
+++ b/tests/shared/jobs/repositories/test_shared_jobs_repository_worker_heartbeats_repository.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from app.shared.jobs import shared_jobs_worker_heartbeat_service as heartbeat_service
+from app.shared.jobs.repositories import repository as jobs_repo
+
+
+def _to_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=UTC)
+    return value.astimezone(UTC)
+
+
+@pytest.mark.asyncio
+async def test_upsert_worker_heartbeat_creates_and_updates(async_session):
+    started_at = datetime(2026, 4, 14, 12, 0, tzinfo=UTC)
+    first = await jobs_repo.upsert_worker_heartbeat(
+        async_session,
+        service_name="winoe-worker",
+        instance_id="worker-1",
+        now=started_at,
+    )
+
+    assert first.service_name == "winoe-worker"
+    assert first.instance_id == "worker-1"
+    assert first.status == "running"
+    assert _to_utc(first.started_at) == started_at
+    assert _to_utc(first.last_heartbeat_at) == started_at
+
+    updated_at = started_at + timedelta(seconds=30)
+    second = await jobs_repo.upsert_worker_heartbeat(
+        async_session,
+        service_name="winoe-worker",
+        instance_id="worker-1",
+        now=updated_at,
+    )
+
+    assert _to_utc(second.started_at) == started_at
+    assert _to_utc(second.last_heartbeat_at) == updated_at
+    assert second.status == "running"
+
+
+@pytest.mark.asyncio
+async def test_latest_worker_heartbeat_helper_and_freshness(async_session):
+    newer = datetime(2026, 4, 14, 12, 5, tzinfo=UTC)
+    older = newer - timedelta(minutes=5)
+    await jobs_repo.upsert_worker_heartbeat(
+        async_session,
+        service_name="winoe-worker",
+        instance_id="worker-old",
+        now=older,
+    )
+    await jobs_repo.upsert_worker_heartbeat(
+        async_session,
+        service_name="winoe-worker",
+        instance_id="worker-new",
+        now=newer,
+    )
+
+    latest = await jobs_repo.get_latest_worker_heartbeat(
+        async_session, service_name="winoe-worker"
+    )
+    assert latest is not None
+    assert latest.instance_id == "worker-new"
+    assert heartbeat_service.is_worker_heartbeat_fresh(
+        SimpleNamespace(last_heartbeat_at=newer),
+        now=newer + timedelta(seconds=30),
+        stale_after_seconds=60,
+    )
+    assert heartbeat_service.is_worker_heartbeat_fresh(
+        SimpleNamespace(last_heartbeat_at=datetime(2026, 4, 14, 12, 4, 30)),
+        now=newer,
+        stale_after_seconds=60,
+    )
+    assert not heartbeat_service.is_worker_heartbeat_fresh(
+        SimpleNamespace(last_heartbeat_at=older),
+        now=newer,
+        stale_after_seconds=60,
+    )
+
+
+@pytest.mark.asyncio
+async def test_worker_heartbeat_rejects_blank_fields_and_can_mark_stopped(
+    async_session,
+):
+    with pytest.raises(ValueError):
+        await jobs_repo.upsert_worker_heartbeat(
+            async_session,
+            service_name=" ",
+            instance_id="worker-blank",
+            now=datetime(2026, 4, 14, 12, 10, tzinfo=UTC),
+        )
+
+    stopped_at = datetime(2026, 4, 14, 12, 11, tzinfo=UTC)
+    stopped = await jobs_repo.mark_worker_stopped(
+        async_session,
+        service_name="winoe-worker",
+        instance_id="worker-stopped",
+        now=stopped_at,
+    )
+
+    assert stopped.status == heartbeat_service.WORKER_HEARTBEAT_STATUS_STOPPED
+    assert _to_utc(stopped.last_heartbeat_at) == stopped_at

--- a/tests/shared/jobs/test_shared_jobs_dead_letter_retry_service.py
+++ b/tests/shared/jobs/test_shared_jobs_dead_letter_retry_service.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.shared.database import async_session_maker
+from app.shared.jobs import shared_jobs_dead_letter_retry_service as dead_letter_retry
+
+
+@pytest.mark.asyncio
+async def test_retry_dead_letter_jobs_forwards_job_ids(monkeypatch):
+    forwarded: dict[str, object] = {}
+
+    async def fake_requeue_dead_letter_jobs(db, *, now, job_ids):
+        forwarded["db"] = db
+        forwarded["now"] = now
+        forwarded["job_ids"] = job_ids
+        return 7
+
+    monkeypatch.setattr(
+        dead_letter_retry.jobs_repo,
+        "requeue_dead_letter_jobs",
+        fake_requeue_dead_letter_jobs,
+    )
+
+    count = await dead_letter_retry.retry_dead_letter_jobs(
+        session_maker=async_session_maker,
+        job_ids=["job-1", "job-2"],
+        now=datetime(2026, 4, 14, 12, 30, tzinfo=UTC),
+    )
+
+    assert count == 7
+    assert forwarded["job_ids"] == ["job-1", "job-2"]
+    assert forwarded["now"].tzinfo is UTC
+    assert forwarded["db"] is not None

--- a/tests/shared/jobs/test_shared_jobs_worker_cli_service.py
+++ b/tests/shared/jobs/test_shared_jobs_worker_cli_service.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from app.shared.database import async_session_maker
+from app.shared.jobs import shared_jobs_worker_cli_service as worker_cli
+
+
+def test_worker_cli_parser_exposes_worker_and_retry_commands() -> None:
+    parser = worker_cli._build_parser()
+
+    worker_args = parser.parse_args(["worker", "--service-name", "demo-worker"])
+    retry_args = parser.parse_args(
+        ["retry-dead-jobs", "--job-id", "job-1", "--job-id", "job-2"]
+    )
+
+    assert worker_args.command == "worker"
+    assert worker_args.service_name == "demo-worker"
+    assert retry_args.command == "retry-dead-jobs"
+    assert retry_args.job_ids == ["job-1", "job-2"]
+
+
+@pytest.mark.asyncio
+async def test_worker_cli_run_worker_registers_handlers_and_delegates(
+    monkeypatch,
+):
+    register_calls: list[str] = []
+    forwarded: dict[str, object] = {}
+
+    def fake_register_builtin_handlers() -> None:
+        register_calls.append("register")
+
+    async def fake_run_worker_forever(**kwargs):
+        forwarded.update(kwargs)
+
+    monkeypatch.setattr(
+        worker_cli.worker_service,
+        "register_builtin_handlers",
+        fake_register_builtin_handlers,
+    )
+    monkeypatch.setattr(
+        worker_cli.heartbeat_service,
+        "run_worker_forever",
+        fake_run_worker_forever,
+    )
+
+    args = SimpleNamespace(
+        service_name="worker-a",
+        worker_id="instance-a",
+        idle_sleep_seconds=2.5,
+        heartbeat_interval_seconds=17,
+    )
+
+    await worker_cli.run_worker(args)
+
+    assert register_calls == ["register"]
+    assert forwarded["session_maker"] is async_session_maker
+    assert forwarded["service_name"] == "worker-a"
+    assert forwarded["instance_id"] == "instance-a"
+    assert forwarded["idle_sleep_seconds"] == 2.5
+    assert forwarded["heartbeat_interval_seconds"] == 17
+
+
+@pytest.mark.asyncio
+async def test_worker_cli_retry_dead_jobs_forwards_job_ids(monkeypatch):
+    forwarded: dict[str, object] = {}
+
+    async def fake_retry_dead_letter_jobs(**kwargs):
+        forwarded.update(kwargs)
+        return 3
+
+    monkeypatch.setattr(
+        worker_cli.dead_letter_retry,
+        "retry_dead_letter_jobs",
+        fake_retry_dead_letter_jobs,
+    )
+
+    count = await worker_cli.retry_dead_jobs(SimpleNamespace(job_ids=["job-a"]))
+
+    assert count == 3
+    assert forwarded["session_maker"] is async_session_maker
+    assert forwarded["job_ids"] == ["job-a"]
+    assert isinstance(forwarded["now"], datetime)
+    assert forwarded["now"].tzinfo is UTC
+
+
+def test_worker_cli_main_routes_retry_command(monkeypatch):
+    seen: dict[str, str] = {}
+
+    def fake_run(coro):
+        seen["coro_name"] = coro.cr_code.co_name
+        coro.close()
+
+    monkeypatch.setattr(worker_cli.asyncio, "run", fake_run)
+
+    worker_cli.main(["retry-dead-jobs", "--job-id", "job-1"])
+
+    assert seen["coro_name"] == "retry_dead_jobs"
+
+
+def test_worker_cli_main_defaults_to_worker(monkeypatch):
+    seen: dict[str, str] = {}
+
+    def fake_run(coro):
+        seen["coro_name"] = coro.cr_code.co_name
+        coro.close()
+
+    monkeypatch.setattr(worker_cli.asyncio, "run", fake_run)
+
+    worker_cli.main(["worker"])
+
+    assert seen["coro_name"] == "run_worker"

--- a/tests/shared/jobs/test_shared_jobs_worker_heartbeat_service.py
+++ b/tests/shared/jobs/test_shared_jobs_worker_heartbeat_service.py
@@ -1,0 +1,216 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from app.shared.jobs import shared_jobs_worker_heartbeat_service as heartbeat_service
+
+
+class _FakeSessionContext:
+    def __init__(self):
+        self.session = SimpleNamespace(label="fake-session")
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeSessionMaker:
+    def __call__(self):
+        return _FakeSessionContext()
+
+
+def test_build_worker_instance_id_uses_host_and_pid(monkeypatch):
+    monkeypatch.setattr(heartbeat_service.socket, "gethostname", lambda: "demo-host")
+    monkeypatch.setattr(heartbeat_service.os, "getpid", lambda: 4321)
+
+    assert heartbeat_service._build_worker_instance_id() == "demo-host:4321"
+
+
+def test_is_worker_heartbeat_fresh_accepts_naive_timestamps():
+    heartbeat = SimpleNamespace(
+        last_heartbeat_at=datetime(2026, 4, 14, 12, 0, 30),
+    )
+
+    assert heartbeat_service.is_worker_heartbeat_fresh(
+        heartbeat,
+        now=datetime(2026, 4, 14, 12, 1, 0, tzinfo=UTC),
+        stale_after_seconds=60,
+    )
+    assert not heartbeat_service.is_worker_heartbeat_fresh(
+        SimpleNamespace(last_heartbeat_at=None),
+        now=datetime(2026, 4, 14, 12, 1, 0, tzinfo=UTC),
+        stale_after_seconds=60,
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_heartbeat_routes_to_upsert_and_stop(monkeypatch):
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    async def fake_upsert_worker_heartbeat(db, **kwargs):
+        calls.append(("upsert", kwargs))
+        return SimpleNamespace(**kwargs)
+
+    async def fake_mark_worker_stopped(db, **kwargs):
+        calls.append(("stop", kwargs))
+        return SimpleNamespace(**kwargs)
+
+    monkeypatch.setattr(
+        heartbeat_service.jobs_repo,
+        "upsert_worker_heartbeat",
+        fake_upsert_worker_heartbeat,
+    )
+    monkeypatch.setattr(
+        heartbeat_service.jobs_repo,
+        "mark_worker_stopped",
+        fake_mark_worker_stopped,
+    )
+
+    now = datetime(2026, 4, 14, 12, 5, tzinfo=UTC)
+    await heartbeat_service._write_heartbeat(
+        session_maker=_FakeSessionMaker(),
+        service_name="winoe-worker",
+        instance_id="worker-1",
+        now=now,
+        running=True,
+    )
+    await heartbeat_service._write_heartbeat(
+        session_maker=_FakeSessionMaker(),
+        service_name="winoe-worker",
+        instance_id="worker-1",
+        now=now,
+        running=False,
+    )
+
+    assert [kind for kind, _ in calls] == ["upsert", "stop"]
+    assert calls[0][1]["now"] == now
+    assert calls[1][1]["now"] == now
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_loop_writes_initial_and_followup_heartbeats(monkeypatch):
+    stop_event = asyncio.Event()
+    writes: list[datetime] = []
+
+    async def fake_wait_for(awaitable, timeout):
+        awaitable.close()
+        raise TimeoutError
+
+    async def fake_write_heartbeat(
+        *,
+        session_maker,
+        service_name,
+        instance_id,
+        now,
+        running,
+    ):
+        writes.append(now)
+        if len(writes) == 2:
+            stop_event.set()
+
+    monkeypatch.setattr(heartbeat_service.asyncio, "wait_for", fake_wait_for)
+    monkeypatch.setattr(heartbeat_service, "_write_heartbeat", fake_write_heartbeat)
+
+    started_at = datetime(2026, 4, 14, 12, 0, tzinfo=UTC)
+    await heartbeat_service._heartbeat_loop(
+        session_maker=_FakeSessionMaker(),
+        service_name="winoe-worker",
+        instance_id="worker-loop",
+        started_at=started_at,
+        stop_event=stop_event,
+        heartbeat_interval_seconds=1,
+    )
+
+    assert len(writes) == 2
+    assert writes[0] == started_at
+    assert writes[1].tzinfo is UTC
+
+
+@pytest.mark.asyncio
+async def test_run_worker_forever_stops_cleanly_on_cancellation(monkeypatch):
+    run_once_calls: list[str] = []
+    writes: list[bool] = []
+
+    async def fake_run_once(*, session_maker, worker_id):
+        run_once_calls.append(worker_id)
+        return False
+
+    async def fake_heartbeat_loop(**kwargs):
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            raise
+
+    async def fake_write_heartbeat(*, running, **kwargs):
+        writes.append(running)
+
+    monkeypatch.setattr(
+        heartbeat_service.worker_service,
+        "run_once",
+        fake_run_once,
+    )
+    monkeypatch.setattr(heartbeat_service, "_heartbeat_loop", fake_heartbeat_loop)
+    monkeypatch.setattr(heartbeat_service, "_write_heartbeat", fake_write_heartbeat)
+
+    task = asyncio.create_task(
+        heartbeat_service.run_worker_forever(
+            session_maker=_FakeSessionMaker(),
+            service_name="winoe-worker",
+            instance_id="worker-cancel",
+            idle_sleep_seconds=0.01,
+            heartbeat_interval_seconds=1,
+        )
+    )
+    await asyncio.sleep(0)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    assert run_once_calls == ["worker-cancel"]
+    assert writes == [False]
+
+
+@pytest.mark.asyncio
+async def test_run_worker_forever_raises_when_heartbeat_task_fails(monkeypatch):
+    run_once_calls: list[str] = []
+    writes: list[bool] = []
+
+    async def fake_run_once(*, session_maker, worker_id):
+        run_once_calls.append(worker_id)
+        return True
+
+    async def failing_heartbeat_loop(**kwargs):
+        raise RuntimeError("heartbeat exploded")
+
+    async def fake_write_heartbeat(*, running, **kwargs):
+        writes.append(running)
+
+    monkeypatch.setattr(
+        heartbeat_service.worker_service,
+        "run_once",
+        fake_run_once,
+    )
+    monkeypatch.setattr(
+        heartbeat_service,
+        "_heartbeat_loop",
+        failing_heartbeat_loop,
+    )
+    monkeypatch.setattr(heartbeat_service, "_write_heartbeat", fake_write_heartbeat)
+
+    with pytest.raises(RuntimeError, match="heartbeat exploded"):
+        await heartbeat_service.run_worker_forever(
+            session_maker=_FakeSessionMaker(),
+            service_name="winoe-worker",
+            instance_id="worker-error",
+            idle_sleep_seconds=0.01,
+            heartbeat_interval_seconds=1,
+        )
+
+    assert run_once_calls == ["worker-error"]
+    assert writes == [False]

--- a/tests/trials/routes/test_trials_local_bootstrap_seed_and_create_trial_routes.py
+++ b/tests/trials/routes/test_trials_local_bootstrap_seed_and_create_trial_routes.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.shared.database.shared_database_models_model import Base, User
+from scripts import seed_local_talent_partners as seed_local_talent_partners_script
+
+
+class _SharedSessionContext:
+    def __init__(self, session: AsyncSession):
+        self._session = session
+
+    async def __aenter__(self):
+        return self._session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        del exc_type, exc, tb
+        return False
+
+
+class _SharedSessionMaker:
+    def __init__(self, session: AsyncSession):
+        self._session = session
+
+    def __call__(self):
+        return _SharedSessionContext(self._session)
+
+
+def _session_maker(async_session: AsyncSession) -> _SharedSessionMaker:
+    return _SharedSessionMaker(async_session)
+
+
+@pytest.mark.asyncio
+async def test_local_bootstrap_seeds_talent_partner_and_allows_trial_creation(
+    async_client,
+    db_engine,
+    async_session,
+    monkeypatch,
+):
+    monkeypatch.setenv("DEV_AUTH_BYPASS", "1")
+    monkeypatch.setattr(seed_local_talent_partners_script, "engine", db_engine)
+    monkeypatch.setattr(
+        seed_local_talent_partners_script,
+        "async_session_maker",
+        _session_maker(async_session),
+    )
+
+    async with db_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all)
+
+    await seed_local_talent_partners_script.main()
+
+    talent_partner = await async_session.scalar(
+        select(User).where(User.email == "talent_partner1@local.test")
+    )
+    assert talent_partner is not None
+    assert talent_partner.company_id is not None
+
+    response = await async_client.post(
+        "/api/trials",
+        headers={"x-dev-user-email": talent_partner.email},
+        json={
+            "title": "Local Trial",
+            "role": "Backend Engineer",
+            "techStack": "Python, PostgreSQL",
+            "seniority": "Mid",
+            "focus": "Create a local demo trial after bootstrap",
+        },
+    )
+
+    assert response.status_code == 201, response.text
+    assert response.json()["title"] == "Local Trial"


### PR DESCRIPTION
## TL;DR
- `./runBackend.sh` now coordinates the local API and worker together so the standard dev entrypoint matches production process topology.
- `migrate` runs after environment loading, so database commands use the same Winoe configuration bootstrap as the runtime commands.
- `Procfile` is split into clear `release`, `web`, and `worker` process types for production deployment.
- Worker heartbeats now persist to the database, providing the first observability and future readiness-check foundation for `#279`.
- Dead-letter jobs can be retried from the worker CLI, both for targeted job IDs and for the full queue of eligible dead letters.
- `bootstrap-local` now gives developers a single, repeatable local demo flow that seeds the expected Winoe state.

## Problem
Issue `#278` was needed because the backend could not be started and verified as a complete Winoe system. The API and worker were not orchestrated together in the normal launch path, migrations did not consistently run after the environment was loaded, and production startup still lacked a clean split between release, web, and worker responsibilities. That left the local demo path incomplete and made it hard to validate worker health, dead-letter recovery, and bootstrap data in the same run.

## What changed
### `runBackend.sh`
- Added a supervised default startup mode that launches both the API and worker, watches both processes, and shuts the pair down cleanly on signal or child failure.
- Kept `api`, `worker`, `migrate`, `bootstrap-local`, `retry-dead-jobs`, and `test` as explicit subcommands so the script still supports narrow workflows.
- Moved environment loading and Winoe local defaults into the commands that need them, including `migrate` and `bootstrap-local`.
- Added direct worker heartbeat and dead-letter retry command wiring through the same backend entrypoint.

### `Procfile`
- Split production process types into `release`, `web`, and `worker`.
- Mapped `release` to migrations, `web` to the API, and `worker` to the worker process so deployment startup is explicit.

### Worker heartbeat runtime
- Added the worker heartbeat table, repository, and service layer.
- The worker now records a `running` heartbeat on startup, refreshes it over time, and marks the row `stopped` on shutdown.
- Added freshness helpers and logging that establish the observability foundation for follow-up readiness checks.
- Wired the new heartbeat model into the shared database model registry and config settings.

### Dead-letter retry path
- Added the dead-letter retry service and repository support to requeue eligible jobs.
- Exposed both targeted retry by job ID and unfiltered retry for all eligible dead-letter jobs through the worker CLI.

### Local bootstrap flow
- Updated the local bootstrap command to use the same environment and database setup path as the rest of the backend entrypoints.
- Kept the local seed flow aligned with the Winoe demo data expectations so developers can bring up a complete local environment with one command.

### Tests/docs
- Added focused coverage for startup scripts, worker heartbeat persistence, dead-letter retry behavior, the heartbeat migration, and the local bootstrap flow.
- Updated `README.md` so the new startup and bootstrap workflow is documented alongside the backend entrypoint.

## QA / verification
- `./runBackend.sh migrate` passed
- `./runBackend.sh bootstrap-local` passed
- `./runBackend.sh` started both API and worker
- worker heartbeat row observed in running state and updated over time
- clean shutdown marked worker heartbeat as `stopped`
- targeted and unfiltered dead-letter retry verified
- focused regression suite passed: `26 passed in 2.32s`

## Files changed
- Startup/orchestration: `runBackend.sh`, `Procfile`
- Heartbeat foundation: `alembic/versions/202604140001_add_worker_heartbeats_table.py`, `app/config/config_settings_fields_config.py`, `app/shared/database/shared_database_models_model.py`, `app/shared/jobs/__init__.py`, `app/shared/jobs/shared_jobs_worker_cli_service.py`, `app/shared/jobs/shared_jobs_worker_service.py`, `app/shared/jobs/shared_jobs_worker_heartbeat_service.py`, `app/shared/jobs/repositories/shared_jobs_repositories_worker_heartbeats_repository.py`, `app/shared/jobs/repositories/shared_jobs_repositories_worker_heartbeats_repository_model.py`
- Dead-letter retry: `app/shared/jobs/shared_jobs_dead_letter_retry_service.py`, `app/shared/jobs/repositories/shared_jobs_repositories_repository.py`, `app/shared/jobs/repositories/shared_jobs_repositories_repository_dead_letter_repository.py`
- Docs: `README.md`
- Tests: `tests/core/db/migrations/test_core_db_migrations_worker_heartbeats.py`, `tests/scripts/test_run_backend_bootstrap_local_shell.py`, `tests/scripts/test_run_backend_migrate_shell.py`, `tests/shared/jobs/repositories/test_shared_jobs_repository_dead_letter_retry_repository.py`, `tests/shared/jobs/repositories/test_shared_jobs_repository_worker_heartbeats_repository.py`, `tests/shared/jobs/test_shared_jobs_dead_letter_retry_service.py`, `tests/shared/jobs/test_shared_jobs_worker_cli_service.py`, `tests/shared/jobs/test_shared_jobs_worker_heartbeat_service.py`, `tests/trials/routes/test_trials_local_bootstrap_seed_and_create_trial_routes.py`

## Notes / follow-ups
- `#279` will consume this heartbeat foundation for readiness checks.
- This PR does not add the readiness endpoint itself; it only lays the worker-heartbeat groundwork needed for that follow-up.

Closes #278 