### PR TITLE
Add readiness endpoint and local demo smoke test

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ FastAPI + PostgreSQL backend for Winoe's async trial platform. Talent Partners c
 - Domain modules: trials, candidate sessions, tasks, submissions, evaluations, media, notifications, talent_partners/admin, and shared runtime infrastructure.
 - GitHub-native flow: workspace repo provisioning from templates, Codespaces init/status, Actions run dispatch/polling, artifact parsing, and persisted run/test/diff metadata.
 - Auth model: bearer-token principal model with talent_partner/candidate permission gates, plus admin key and demo admin dependency paths.
-- Current API surface: 46 HTTP endpoints (generated from live OpenAPI).
+- Current API surface: 57 HTTP endpoints (generated from live OpenAPI).
 
 ## Stack (Poetry Constraints)
 
@@ -93,6 +93,13 @@ poetry install
 curl -s http://localhost:8000/health
 ```
 
+10. Readiness check and local demo smoke test.
+
+```bash
+curl -s http://localhost:8000/ready
+poetry run python scripts/local_demo_smoke_test.py --base-url http://localhost:8000
+```
+
 ## Environment
 
 Canonical env keys are summarized below by primary group.
@@ -132,11 +139,13 @@ Canonical env keys are summarized below by primary group.
 | `qa_verifications/` | QA runner scripts and latest generated QA reports |
 | `scripts/` | Operational tooling, docs audits/exports |
 
-## API Overview (46 Endpoints)
+## API Overview (57 Endpoints)
 
 ### Health / Auth
 
 - `GET /health`
+- `GET /ready`
+- `POST /api/auth/talent-partner-onboarding`
 - `GET /api/auth/me`
 - `POST /api/auth/logout`
 
@@ -144,6 +153,7 @@ Canonical env keys are summarized below by primary group.
 
 - `GET /api/admin/templates/health`
 - `POST /api/admin/templates/health/run`
+- `POST /api/admin/candidate_sessions/{candidate_session_id}/day_windows/control`
 - `POST /api/admin/candidate_sessions/{candidate_session_id}/reset`
 - `POST /api/admin/jobs/{job_id}/requeue`
 - `POST /api/admin/trials/{trial_id}/scenario/use_fallback`
@@ -175,9 +185,17 @@ Canonical env keys are summarized below by primary group.
 - `GET /api/candidate/session/{token}`
 - `POST /api/candidate/session/{token}/claim`
 - `POST /api/candidate/session/{token}/schedule`
+- `GET /api/candidate/session/{token}/review`
 - `GET /api/candidate/session/{candidate_session_id}/current_task`
 - `GET /api/candidate/invites`
 - `POST /api/candidate/session/{candidate_session_id}/privacy/consent`
+
+### Company Config / Media Storage
+
+- `GET /api/companies/me/ai-config`
+- `PUT /api/companies/me/ai-config`
+- `GET /api/recordings/storage/fake/download`
+- `PUT /api/recordings/storage/fake/upload`
 
 ### Candidate Task Execution / Draft / Handoff APIs
 
@@ -188,6 +206,9 @@ Canonical env keys are summarized below by primary group.
 - `POST /api/tasks/{task_id}/submit`
 - `GET /api/tasks/{task_id}/draft`
 - `PUT /api/tasks/{task_id}/draft`
+- `POST /api/tasks/{task_id}/presentation/upload/init`
+- `POST /api/tasks/{task_id}/presentation/upload/complete`
+- `GET /api/tasks/{task_id}/presentation/upload/status`
 - `POST /api/tasks/{task_id}/handoff/upload/init`
 - `POST /api/tasks/{task_id}/handoff/upload/complete`
 - `GET /api/tasks/{task_id}/handoff/status`
@@ -217,6 +238,7 @@ Detailed schema-level API docs are generated at [`docs/api.md`](docs/api.md).
 - `./runBackend.sh migrate`: load environment values and run Alembic migrations.
 - `./runBackend.sh bootstrap-local`: seed the local demo Talent Partner accounts and repair missing company links.
 - `./runBackend.sh retry-dead-jobs`: requeue dead-letter Winoe jobs after schema repair.
+- `poetry run python scripts/local_demo_smoke_test.py`: verify readiness, create a Trial, and wait for scenario generation to reach a ready state.
 
 ## Tests and Verification
 

--- a/app/shared/http/routes/shared_http_routes_health_routes.py
+++ b/app/shared/http/routes/shared_http_routes_health_routes.py
@@ -1,6 +1,10 @@
 """Application module for http routes health routes workflows."""
 
 from fastapi import APIRouter
+from fastapi.responses import JSONResponse
+
+from app.shared.http import shared_http_readiness_service as readiness_service
+from app.shared.http.schemas import ReadinessPayload
 
 router = APIRouter()
 
@@ -16,3 +20,28 @@ router = APIRouter()
 async def health_check():
     """Liveness probe endpoint."""
     return {"status": "ok"}
+
+
+@router.get(
+    "/ready",
+    summary="Readiness Check",
+    description="Readiness probe for database, worker, and integration configuration.",
+    response_model=ReadinessPayload,
+    responses={
+        200: {"description": "System is ready."},
+        503: {
+            "description": "System is not ready.",
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/ReadinessPayload"}
+                }
+            },
+        },
+    },
+)
+async def readiness_check():
+    """Readiness probe endpoint."""
+    payload = await readiness_service.build_readiness_payload()
+    if payload.get("status") != "ready":
+        return JSONResponse(status_code=503, content=payload)
+    return payload

--- a/app/shared/http/schemas/__init__.py
+++ b/app/shared/http/schemas/__init__.py
@@ -1,0 +1,13 @@
+"""Application module for http schemas workflows."""
+
+from app.shared.http.schemas.shared_http_schemas_readiness_schema import (
+    ReadinessCheckItem,
+    ReadinessChecks,
+    ReadinessPayload,
+)
+
+__all__ = [
+    "ReadinessCheckItem",
+    "ReadinessChecks",
+    "ReadinessPayload",
+]

--- a/app/shared/http/schemas/shared_http_schemas_readiness_schema.py
+++ b/app/shared/http/schemas/shared_http_schemas_readiness_schema.py
@@ -1,0 +1,38 @@
+"""Application module for shared http schemas readiness schema workflows."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from app.shared.types.shared_types_base_model import APIModel
+
+ReadinessCheckStatus = Literal["ready", "not_ready", "skipped"]
+ReadinessPayloadStatus = Literal["ready", "not_ready"]
+
+
+class ReadinessCheckItem(APIModel):
+    """Structured result for a single readiness check."""
+
+    status: ReadinessCheckStatus
+    code: str
+    detail: str
+    data: dict[str, Any] | None = None
+
+
+class ReadinessChecks(APIModel):
+    """Structured readiness checks for the public readiness payload."""
+
+    database: ReadinessCheckItem
+    worker: ReadinessCheckItem
+    ai: ReadinessCheckItem
+    github: ReadinessCheckItem
+    email: ReadinessCheckItem
+    media: ReadinessCheckItem
+
+
+class ReadinessPayload(APIModel):
+    """Public readiness payload returned by GET /ready."""
+
+    status: ReadinessPayloadStatus
+    checkedAt: str
+    checks: ReadinessChecks

--- a/app/shared/http/shared_http_readiness_service.py
+++ b/app/shared/http/shared_http_readiness_service.py
@@ -1,0 +1,513 @@
+"""Application module for Winoe readiness checks."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Literal
+
+from sqlalchemy import inspect
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.ai import (
+    allow_demo_or_test_mode,
+    resolve_codespace_specializer_config,
+    resolve_scenario_generation_config,
+    resolve_transcription_config,
+    resolve_winoe_report_aggregator_config,
+    resolve_winoe_report_day1_config,
+    resolve_winoe_report_day4_config,
+    resolve_winoe_report_day5_config,
+    resolve_winoe_report_day23_config,
+)
+from app.ai.ai_provider_clients_service import api_key_configured
+from app.config import settings
+from app.shared.database import async_session_maker, engine
+from app.shared.jobs import shared_jobs_worker_heartbeat_service as heartbeat_service
+from app.shared.jobs.repositories import repository as jobs_repo
+
+ReadinessStatus = Literal["ready", "not_ready", "skipped"]
+
+_AI_FEATURE_RESOLVERS = {
+    "scenarioGeneration": resolve_scenario_generation_config,
+    "codespaceSpecializer": resolve_codespace_specializer_config,
+    "transcription": resolve_transcription_config,
+    "winoeReportDay1": resolve_winoe_report_day1_config,
+    "winoeReportDay23": resolve_winoe_report_day23_config,
+    "winoeReportDay4": resolve_winoe_report_day4_config,
+    "winoeReportDay5": resolve_winoe_report_day5_config,
+    "winoeReportAggregator": resolve_winoe_report_aggregator_config,
+}
+
+_REQUIRED_TABLES = {
+    "candidate_sessions",
+    "jobs",
+    "scenario_versions",
+    "tasks",
+    "trials",
+    "worker_heartbeats",
+}
+
+_REQUIRED_FOREIGN_KEYS = {
+    "candidate_sessions": {
+        ("trial_id", "trials", ("id",)),
+        ("scenario_version_id", "scenario_versions", ("id",)),
+    },
+    "scenario_versions": {
+        ("trial_id", "trials", ("id",)),
+    },
+    "tasks": {
+        ("trial_id", "trials", ("id",)),
+    },
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ReadinessCheck:
+    """Machine-readable readiness check result."""
+
+    status: ReadinessStatus
+    code: str
+    detail: str
+    data: dict[str, Any] | None = None
+
+    def as_dict(self) -> dict[str, Any]:
+        payload: dict[str, Any] = {
+            "status": self.status,
+            "code": self.code,
+            "detail": self.detail,
+        }
+        if self.data:
+            payload["data"] = self.data
+        return payload
+
+
+def _utc_now(now: datetime | None = None) -> datetime:
+    resolved = now or datetime.now(UTC)
+    if resolved.tzinfo is None:
+        return resolved.replace(tzinfo=UTC)
+    return resolved.astimezone(UTC)
+
+
+def _readiness_check(
+    *,
+    status: ReadinessStatus,
+    code: str,
+    detail: str,
+    data: dict[str, Any] | None = None,
+) -> ReadinessCheck:
+    return ReadinessCheck(status=status, code=code, detail=detail, data=data)
+
+
+def _aggregate_status(checks: list[ReadinessCheck]) -> ReadinessStatus:
+    if any(check.status == "not_ready" for check in checks):
+        return "not_ready"
+    if all(check.status == "skipped" for check in checks):
+        return "skipped"
+    return "ready"
+
+
+def _normalize_fks(
+    raw_foreign_keys: list[dict[str, Any]],
+) -> set[tuple[str, str, tuple[str, ...]]]:
+    normalized: set[tuple[str, str, tuple[str, ...]]] = set()
+    for fk in raw_foreign_keys:
+        constrained = tuple(
+            str(column) for column in fk.get("constrained_columns") or ()
+        )
+        referred_table = str(fk.get("referred_table") or "")
+        referred_columns = tuple(
+            str(column) for column in fk.get("referred_columns") or ()
+        )
+        normalized.add(
+            (constrained[0] if constrained else "", referred_table, referred_columns)
+        )
+    return normalized
+
+
+def _inspect_schema(sync_connection) -> ReadinessCheck:
+    inspector = inspect(sync_connection)
+    existing_tables = set(inspector.get_table_names())
+    missing_tables = sorted(_REQUIRED_TABLES - existing_tables)
+    missing_foreign_keys: dict[str, list[str]] = {}
+
+    for table_name, expected_fks in _REQUIRED_FOREIGN_KEYS.items():
+        if table_name not in existing_tables:
+            continue
+        actual_fks = _normalize_fks(inspector.get_foreign_keys(table_name))
+        missing_specs = [
+            f"{column}->{referred_table}.{','.join(referred_columns)}"
+            for column, referred_table, referred_columns in sorted(expected_fks)
+            if (column, referred_table, referred_columns) not in actual_fks
+        ]
+        if missing_specs:
+            missing_foreign_keys[table_name] = missing_specs
+
+    if missing_tables or missing_foreign_keys:
+        data: dict[str, Any] = {}
+        if missing_tables:
+            data["missingTables"] = missing_tables
+        if missing_foreign_keys:
+            data["missingForeignKeys"] = missing_foreign_keys
+        return _readiness_check(
+            status="not_ready",
+            code="schema_mismatch",
+            detail="Required database tables or foreign keys are missing.",
+            data=data,
+        )
+
+    return _readiness_check(
+        status="ready",
+        code="schema_ok",
+        detail="Required database tables and foreign keys are present.",
+    )
+
+
+def _format_heartbeat_age(
+    heartbeat: object,
+    *,
+    now: datetime,
+) -> int | None:
+    last_seen = getattr(heartbeat, "last_heartbeat_at", None)
+    if isinstance(last_seen, datetime):
+        if last_seen.tzinfo is None:
+            last_seen = last_seen.replace(tzinfo=UTC)
+        return max(0, int((now - last_seen).total_seconds()))
+    return None
+
+
+async def check_database_readiness() -> ReadinessCheck:
+    """Validate the database connection and schema shape."""
+    try:
+        async with engine.connect() as conn:
+            return await conn.run_sync(_inspect_schema)
+    except Exception:
+        return _readiness_check(
+            status="not_ready",
+            code="database_unavailable",
+            detail="Database connection or schema inspection failed.",
+        )
+
+
+async def check_worker_readiness(
+    *,
+    session_maker: async_sessionmaker[AsyncSession] = async_session_maker,
+    now: datetime | None = None,
+) -> ReadinessCheck:
+    """Validate that the worker heartbeat is fresh."""
+    resolved_now = _utc_now(now)
+    async with session_maker() as db:
+        heartbeat = await jobs_repo.get_latest_worker_heartbeat(
+            db, service_name=heartbeat_service.DEFAULT_WORKER_SERVICE_NAME
+        )
+    if heartbeat is None:
+        return _readiness_check(
+            status="not_ready",
+            code="heartbeat_missing",
+            detail="No worker heartbeat has been recorded.",
+        )
+    if (
+        getattr(heartbeat, "status", None)
+        == heartbeat_service.WORKER_HEARTBEAT_STATUS_STOPPED
+    ):
+        return _readiness_check(
+            status="not_ready",
+            code="heartbeat_stopped",
+            detail="The latest worker heartbeat is marked stopped.",
+            data={
+                "serviceName": heartbeat.service_name,
+                "instanceId": heartbeat.instance_id,
+            },
+        )
+    if not heartbeat_service.is_worker_heartbeat_fresh(
+        heartbeat,
+        now=resolved_now,
+    ):
+        return _readiness_check(
+            status="not_ready",
+            code="heartbeat_stale",
+            detail="The latest worker heartbeat is stale.",
+            data={
+                "serviceName": heartbeat.service_name,
+                "instanceId": heartbeat.instance_id,
+                "ageSeconds": _format_heartbeat_age(heartbeat, now=resolved_now),
+                "staleAfterSeconds": settings.WORKER_HEARTBEAT_STALE_SECONDS,
+            },
+        )
+    return _readiness_check(
+        status="ready",
+        code="heartbeat_fresh",
+        detail="Worker heartbeat is fresh.",
+        data={
+            "serviceName": heartbeat.service_name,
+            "instanceId": heartbeat.instance_id,
+            "ageSeconds": _format_heartbeat_age(heartbeat, now=resolved_now),
+        },
+    )
+
+
+def _check_ai_feature(name: str, config) -> ReadinessCheck:
+    runtime_mode = str(getattr(config, "runtime_mode", "") or "").strip().lower()
+    provider = str(getattr(config, "provider", "") or "").strip().lower()
+    if allow_demo_or_test_mode(runtime_mode):
+        return _readiness_check(
+            status="skipped",
+            code="demo_mode",
+            detail=f"{name} is running in demo/test mode.",
+            data={"runtimeMode": runtime_mode, "provider": provider},
+        )
+    if provider == "openai":
+        if api_key_configured(settings.OPENAI_API_KEY):
+            return _readiness_check(
+                status="ready",
+                code="provider_ready",
+                detail=f"{name} is ready with the OpenAI provider.",
+                data={"runtimeMode": runtime_mode, "provider": provider},
+            )
+        return _readiness_check(
+            status="not_ready",
+            code="no_provider_configured",
+            detail=f"{name} is missing an OpenAI API key.",
+            data={"runtimeMode": runtime_mode, "provider": provider},
+        )
+    if provider == "anthropic":
+        if api_key_configured(settings.ANTHROPIC_API_KEY):
+            return _readiness_check(
+                status="ready",
+                code="provider_ready",
+                detail=f"{name} is ready with the Anthropic provider.",
+                data={"runtimeMode": runtime_mode, "provider": provider},
+            )
+        return _readiness_check(
+            status="not_ready",
+            code="no_provider_configured",
+            detail=f"{name} is missing an Anthropic API key.",
+            data={"runtimeMode": runtime_mode, "provider": provider},
+        )
+    return _readiness_check(
+        status="not_ready",
+        code="unsupported_provider",
+        detail=f"{name} uses an unsupported AI provider.",
+        data={"runtimeMode": runtime_mode, "provider": provider},
+    )
+
+
+async def check_ai_readiness() -> ReadinessCheck:
+    """Validate the configured AI provider surface."""
+    checks = {
+        feature_name: _check_ai_feature(feature_name, resolver())
+        for feature_name, resolver in _AI_FEATURE_RESOLVERS.items()
+    }
+    status = _aggregate_status(list(checks.values()))
+    return _readiness_check(
+        status=status,
+        code="ai_providers_ready"
+        if status != "not_ready"
+        else "ai_providers_unhealthy",
+        detail="AI provider readiness validated.",
+        data={"checks": {name: check.as_dict() for name, check in checks.items()}},
+    )
+
+
+def _check_github_readiness() -> ReadinessCheck:
+    github_cfg = settings.github
+    token = str(github_cfg.GITHUB_TOKEN or "").strip()
+    org = str(github_cfg.GITHUB_ORG or "").strip()
+    template_owner = str(github_cfg.GITHUB_TEMPLATE_OWNER or "").strip()
+    if settings.DEMO_MODE and not token and not org and not template_owner:
+        return _readiness_check(
+            status="skipped",
+            code="demo_mode",
+            detail="GitHub readiness is skipped in demo mode.",
+        )
+    if not token:
+        return _readiness_check(
+            status="not_ready",
+            code="no_provider_configured",
+            detail="GitHub token is missing.",
+        )
+    if not org and not template_owner:
+        return _readiness_check(
+            status="not_ready",
+            code="missing_github_org",
+            detail="GitHub org or template owner is missing.",
+        )
+    return _readiness_check(
+        status="ready",
+        code="provider_ready",
+        detail="GitHub configuration is ready.",
+        data={
+            "apiBase": github_cfg.GITHUB_API_BASE,
+            "orgConfigured": bool(org),
+            "templateOwnerConfigured": bool(template_owner),
+        },
+    )
+
+
+def _check_email_readiness() -> ReadinessCheck:
+    email_cfg = settings.email
+    provider = str(email_cfg.WINOE_EMAIL_PROVIDER or "console").strip().lower()
+    sender = str(email_cfg.WINOE_EMAIL_FROM or "").strip()
+    if provider == "console":
+        return _readiness_check(
+            status="ready",
+            code="provider_ready",
+            detail="Console email provider is ready for local/demo use.",
+            data={"provider": provider, "senderConfigured": bool(sender)},
+        )
+    if provider == "resend":
+        if str(email_cfg.WINOE_RESEND_API_KEY or "").strip():
+            return _readiness_check(
+                status="ready",
+                code="provider_ready",
+                detail="Resend email provider is configured.",
+                data={"provider": provider, "senderConfigured": bool(sender)},
+            )
+        return _readiness_check(
+            status="not_ready",
+            code="no_provider_configured",
+            detail="Resend API key is missing.",
+            data={"provider": provider},
+        )
+    if provider == "sendgrid":
+        if str(email_cfg.SENDGRID_API_KEY or "").strip():
+            return _readiness_check(
+                status="ready",
+                code="provider_ready",
+                detail="SendGrid email provider is configured.",
+                data={"provider": provider, "senderConfigured": bool(sender)},
+            )
+        return _readiness_check(
+            status="not_ready",
+            code="no_provider_configured",
+            detail="SendGrid API key is missing.",
+            data={"provider": provider},
+        )
+    if provider == "smtp":
+        if str(email_cfg.SMTP_HOST or "").strip():
+            return _readiness_check(
+                status="ready",
+                code="provider_ready",
+                detail="SMTP email provider is configured.",
+                data={"provider": provider, "senderConfigured": bool(sender)},
+            )
+        return _readiness_check(
+            status="not_ready",
+            code="no_provider_configured",
+            detail="SMTP host is missing.",
+            data={"provider": provider},
+        )
+    return _readiness_check(
+        status="not_ready",
+        code="unsupported_provider",
+        detail="Email provider is unsupported.",
+        data={"provider": provider},
+    )
+
+
+def _check_media_readiness() -> ReadinessCheck:
+    media_cfg = settings.storage_media
+    provider = str(media_cfg.MEDIA_STORAGE_PROVIDER or "fake").strip().lower()
+    if provider == "fake":
+        return _readiness_check(
+            status="ready",
+            code="provider_ready",
+            detail="Fake media storage provider is ready for local/demo use.",
+            data={"provider": provider},
+        )
+    if provider == "s3":
+        missing = [
+            name
+            for name, value in (
+                ("MEDIA_S3_ENDPOINT", media_cfg.MEDIA_S3_ENDPOINT),
+                ("MEDIA_S3_BUCKET", media_cfg.MEDIA_S3_BUCKET),
+                ("MEDIA_S3_ACCESS_KEY_ID", media_cfg.MEDIA_S3_ACCESS_KEY_ID),
+                ("MEDIA_S3_SECRET_ACCESS_KEY", media_cfg.MEDIA_S3_SECRET_ACCESS_KEY),
+            )
+            if not str(value or "").strip()
+        ]
+        if missing:
+            return _readiness_check(
+                status="not_ready",
+                code="no_provider_configured",
+                detail="S3 media storage is missing required settings.",
+                data={"provider": provider, "missingFields": missing},
+            )
+        return _readiness_check(
+            status="ready",
+            code="provider_ready",
+            detail="S3 media storage provider is configured.",
+            data={"provider": provider},
+        )
+    return _readiness_check(
+        status="not_ready",
+        code="unsupported_provider",
+        detail="Media storage provider is unsupported.",
+        data={"provider": provider},
+    )
+
+
+async def build_readiness_payload(
+    *,
+    session_maker: async_sessionmaker[AsyncSession] = async_session_maker,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Return the readiness payload consumed by the HTTP endpoint."""
+    resolved_now = _utc_now(now)
+    checks: dict[str, Any] = {}
+
+    database_check = await check_database_readiness()
+    checks["database"] = database_check.as_dict()
+
+    worker_check = await check_worker_readiness(
+        session_maker=session_maker, now=resolved_now
+    )
+    checks["worker"] = worker_check.as_dict()
+
+    ai_check = await check_ai_readiness()
+    checks["ai"] = ai_check.as_dict()
+
+    github_check = _check_github_readiness()
+    checks["github"] = github_check.as_dict()
+
+    email_check = _check_email_readiness()
+    checks["email"] = email_check.as_dict()
+
+    media_check = _check_media_readiness()
+    checks["media"] = media_check.as_dict()
+
+    statuses: list[ReadinessCheck] = [
+        database_check,
+        worker_check,
+        ai_check,
+        github_check,
+        email_check,
+        media_check,
+    ]
+    overall_status = (
+        "ready"
+        if all(check.status != "not_ready" for check in statuses)
+        else "not_ready"
+    )
+    return {
+        "status": overall_status,
+        "checkedAt": resolved_now.isoformat().replace("+00:00", "Z"),
+        "checks": checks,
+    }
+
+
+check_github_readiness = _check_github_readiness
+check_email_readiness = _check_email_readiness
+check_media_readiness = _check_media_readiness
+
+
+__all__ = [
+    "ReadinessCheck",
+    "build_readiness_payload",
+    "check_ai_readiness",
+    "check_database_readiness",
+    "check_email_readiness",
+    "check_github_readiness",
+    "check_media_readiness",
+    "check_worker_readiness",
+]

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,30 +1,52 @@
 # API Reference
 
 Generated from FastAPI OpenAPI plus dependency-based auth mapping.
-Generated at: 2026-03-27T14:41:43.988295+00:00
-Total endpoints: 46
+Generated at: deterministic
+Total endpoints: 57
 
 ## Endpoint Index
 
+- `POST /api/admin/candidate_sessions/{candidate_session_id}/day_windows/control`: Control Candidate Session Day Windows
 - `POST /api/admin/candidate_sessions/{candidate_session_id}/reset`: Reset Candidate Session
 - `POST /api/admin/jobs/{job_id}/requeue`: Requeue Job
 - `POST /api/admin/media/purge`: Purge Media Retention
-- `POST /api/admin/trials/{trial_id}/scenario/use_fallback`: Use Trial Fallback
 - `GET /api/admin/templates/health`: Get Template Health
 - `POST /api/admin/templates/health/run`: Run Template Health
+- `POST /api/admin/trials/{trial_id}/scenario/use_fallback`: Use Trial Fallback
 - `POST /api/auth/logout`: Logout
 - `GET /api/auth/me`: Read Me
+- `POST /api/auth/talent-partner-onboarding`: Complete TalentPartner Onboarding
 - `GET /api/candidate/invites`: List Candidate Invites
 - `GET /api/candidate/session/{candidate_session_id}/current_task`: Get Current Task
 - `POST /api/candidate/session/{candidate_session_id}/privacy/consent`: Record Candidate Privacy Consent
 - `GET /api/candidate/session/{token}`: Resolve Candidate Session
 - `POST /api/candidate/session/{token}/claim`: Claim Candidate Session
+- `GET /api/candidate/session/{token}/review`: Review Candidate Session
 - `POST /api/candidate/session/{token}/schedule`: Schedule Candidate Session
 - `GET /api/candidate_sessions/{candidate_session_id}/winoe_report`: Get Winoe Report Route
 - `POST /api/candidate_sessions/{candidate_session_id}/winoe_report/generate`: Generate Winoe Report Route
+- `GET /api/companies/me/ai-config`: Read TalentPartner Company AI Config
+- `PUT /api/companies/me/ai-config`: Update TalentPartner Company AI Config
 - `POST /api/github/webhooks`: Receive Github Webhook
 - `GET /api/jobs/{job_id}`: Get Job Status
+- `GET /api/recordings/storage/fake/download`: Fake Storage Download Route
+- `PUT /api/recordings/storage/fake/upload`: Fake Storage Upload Route
 - `POST /api/recordings/{recording_id}/delete`: Delete Recording Route
+- `GET /api/submissions`: List Submissions Route
+- `GET /api/submissions/{submission_id}`: Get Submission Detail Route
+- `POST /api/tasks/{task_id}/codespace/init`: Init Codespace Route
+- `GET /api/tasks/{task_id}/codespace/status`: Codespace Status Route
+- `GET /api/tasks/{task_id}/draft`: Get Task Draft Route
+- `PUT /api/tasks/{task_id}/draft`: Put Task Draft Route
+- `GET /api/tasks/{task_id}/handoff/status`: Handoff Status Route
+- `POST /api/tasks/{task_id}/handoff/upload/complete`: Complete Handoff Upload Route
+- `POST /api/tasks/{task_id}/handoff/upload/init`: Init Handoff Upload Route
+- `POST /api/tasks/{task_id}/presentation/upload/complete`: Complete Presentation Upload Route
+- `POST /api/tasks/{task_id}/presentation/upload/init`: Init Presentation Upload Route
+- `GET /api/tasks/{task_id}/presentation/upload/status`: Presentation Status Route
+- `POST /api/tasks/{task_id}/run`: Run Task Tests Route
+- `GET /api/tasks/{task_id}/run/{run_id}`: Get Run Result Route
+- `POST /api/tasks/{task_id}/submit`: Submit Task Route
 - `GET /api/trials`: List Trials
 - `POST /api/trials`: Create Trial
 - `GET /api/trials/{trial_id}`: Get Trial Detail
@@ -39,21 +61,59 @@ Total endpoints: 46
 - `PATCH /api/trials/{trial_id}/scenario/{scenario_version_id}`: Patch Scenario Version
 - `POST /api/trials/{trial_id}/scenario/{scenario_version_id}/approve`: Approve Scenario Version
 - `POST /api/trials/{trial_id}/terminate`: Terminate Trial
-- `GET /api/submissions`: List Submissions Route
-- `GET /api/submissions/{submission_id}`: Get Submission Detail Route
-- `POST /api/tasks/{task_id}/codespace/init`: Init Codespace Route
-- `GET /api/tasks/{task_id}/codespace/status`: Codespace Status Route
-- `GET /api/tasks/{task_id}/draft`: Get Task Draft Route
-- `PUT /api/tasks/{task_id}/draft`: Put Task Draft Route
-- `GET /api/tasks/{task_id}/handoff/status`: Handoff Status Route
-- `POST /api/tasks/{task_id}/handoff/upload/complete`: Complete Handoff Upload Route
-- `POST /api/tasks/{task_id}/handoff/upload/init`: Init Handoff Upload Route
-- `POST /api/tasks/{task_id}/run`: Run Task Tests Route
-- `GET /api/tasks/{task_id}/run/{run_id}`: Get Run Result Route
-- `POST /api/tasks/{task_id}/submit`: Submit Task Route
 - `GET /health`: Health Check
+- `GET /ready`: Readiness Check
 
 ## Endpoint Details
+
+### `POST /api/admin/candidate_sessions/{candidate_session_id}/day_windows/control`
+- Summary: Control Candidate Session Day Windows
+- Description: Local/test-only admin-keyed control that retimes a candidate session so a chosen day window is immediately usable for end-to-end validation.
+- Auth: Admin API key via `X-Admin-Key` header
+- Operation ID: `control_candidate_session_day_windows_api_admin_candidate_sessions__candidate_session_id__day_windows_control_post`
+- Dependency auth signals: `app.shared.auth.shared_auth_admin_api_key_utils.require_admin_key`, `app.shared.database.get_session`
+- Path params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `candidate_session_id` | yes | `integer` | `-` | - |
+- Query params: 
+  - None
+- Header params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `X-Admin-Key` | no | `X-Admin-Key` | `-` | - |
+- Request schema: `CandidateSessionDayWindowControlRequest`
+- Request example:
+```json
+{
+  "targetDayIndex": 1,
+  "reason": "example"
+}
+```
+- Success responses:
+  - `200`: Successful Response (schema: `CandidateSessionDayWindowControlResponse`)
+- Error responses:
+  - `404`: Admin access required. (schema: `-`)
+  - `422`: The requested day-window control payload is invalid. (schema: `-`)
+- Success example (`200`):
+```json
+{
+  "candidateSessionId": 1,
+  "candidateStatus": "example",
+  "status": "ok",
+  "targetDayIndex": 1,
+  "candidateTimezone": "example",
+  "scheduledStartAt": "2026-01-01T00:00:00Z",
+  "scheduleLockedAt": "2026-01-01T00:00:00Z",
+  "dayWindows": [
+    {
+      "dayIndex": 1,
+      "windowStartAt": "2026-01-01T00:00:00Z",
+      "windowEndAt": "2026-01-01T00:00:00Z"
+    }
+  ]
+}
+```
 
 ### `POST /api/admin/candidate_sessions/{candidate_session_id}/reset`
 - Summary: Reset Candidate Session
@@ -171,44 +231,6 @@ Total endpoints: 46
 }
 ```
 
-### `POST /api/admin/trials/{trial_id}/scenario/use_fallback`
-- Summary: Use Trial Fallback
-- Description: Apply a fallback scenario version to a trial when generated content must be overridden in demo mode.
-- Auth: Bearer token for demo admin allowlist (requires `WINOE_DEMO_MODE=true`)
-- Operation ID: `use_trial_fallback_api_admin_trials__trial_id__scenario_use_fallback_post`
-- Dependency auth signals: `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_admin_demo_utils.require_demo_mode_admin`, `fastapi.security.http.unknown`
-- Path params: 
-  - | Name | Required | Type | Default | Description |
-  - |---|---:|---|---|---|
-  - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
-  - None
-- Header params: 
-  - None
-- Request schema: `TrialFallbackRequest`
-- Request example:
-```json
-{
-  "scenarioVersionId": 1,
-  "reason": "example"
-}
-```
-- Success responses:
-  - `200`: Successful Response (schema: `TrialFallbackResponse`)
-- Error responses:
-  - `400`: Fallback request is invalid. (schema: `-`)
-  - `403`: Admin access required. (schema: `-`)
-  - `404`: Demo mode disabled or trial not found. (schema: `-`)
-  - `422`: Validation Error (schema: `HTTPValidationError`)
-- Success example (`200`):
-```json
-{
-  "trialId": 1,
-  "activeScenarioVersionId": 1,
-  "applyTo": "example"
-}
-```
-
 ### `GET /api/admin/templates/health`
 - Summary: Get Template Health
 - Description: Check template repos against the Actions artifact contract (admin-only).
@@ -306,6 +328,44 @@ Total endpoints: 46
 }
 ```
 
+### `POST /api/admin/trials/{trial_id}/scenario/use_fallback`
+- Summary: Use Trial Fallback
+- Description: Apply a fallback scenario version to a trial when generated content must be overridden in demo mode.
+- Auth: Bearer token for demo admin allowlist (requires `WINOE_DEMO_MODE=true`)
+- Operation ID: `use_trial_fallback_api_admin_trials__trial_id__scenario_use_fallback_post`
+- Dependency auth signals: `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_admin_demo_utils.require_demo_mode_admin`, `fastapi.security.http.unknown`
+- Path params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `trial_id` | yes | `integer` | `-` | - |
+- Query params: 
+  - None
+- Header params: 
+  - None
+- Request schema: `TrialFallbackRequest`
+- Request example:
+```json
+{
+  "scenarioVersionId": 1,
+  "reason": "example"
+}
+```
+- Success responses:
+  - `200`: Successful Response (schema: `TrialFallbackResponse`)
+- Error responses:
+  - `400`: Fallback request is invalid. (schema: `-`)
+  - `403`: Admin access required. (schema: `-`)
+  - `404`: Demo mode disabled or trial not found. (schema: `-`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "trialId": 1,
+  "activeScenarioVersionId": 1,
+  "applyTo": "example"
+}
+```
+
 ### `POST /api/auth/logout`
 - Summary: Logout
 - Description: Stateless logout acknowledgment endpoint; client clears local auth state.
@@ -326,8 +386,8 @@ Total endpoints: 46
 
 ### `GET /api/auth/me`
 - Summary: Read Me
-- Description: Return the authenticated talent_partner profile for the caller.
-- Auth: Talent Partner bearer token
+- Description: Return the authenticated Talent Partner profile for the caller.
+- Auth: TalentPartner bearer token
 - Operation ID: `read_me_api_auth_me_get`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_authenticated_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
 - Path params: 
@@ -342,6 +402,42 @@ Total endpoints: 46
 - Error responses:
   - `401`: Authentication required. (schema: `-`)
   - `429`: Rate limit exceeded. (schema: `-`)
+- Success example (`200`):
+```json
+{
+  "id": 1,
+  "name": "example",
+  "email": "example",
+  "role": "example"
+}
+```
+
+### `POST /api/auth/talent-partner-onboarding`
+- Summary: Complete TalentPartner Onboarding
+- Description: Create or attach the Talent Partner's company and finalize app onboarding.
+- Auth: Bearer token
+- Operation ID: `complete_talent_partner_onboarding_api_auth_talent_partner_onboarding_post`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params: 
+  - None
+- Query params: 
+  - None
+- Header params: 
+  - None
+- Request schema: `TalentPartnerOnboardingWrite`
+- Request example:
+```json
+{
+  "name": "example",
+  "companyName": "example"
+}
+```
+- Success responses:
+  - `200`: Successful Response (schema: `UserRead`)
+- Error responses:
+  - `401`: Authentication required. (schema: `-`)
+  - `403`: Talent Partner access required. (schema: `-`)
+  - `422`: Invalid onboarding payload. (schema: `-`)
 - Success example (`200`):
 ```json
 {
@@ -553,6 +649,39 @@ Total endpoints: 46
 }
 ```
 
+### `GET /api/candidate/session/{token}/review`
+- Summary: Review Candidate Session
+- Description: Return a read-only review payload for a completed candidate session.
+- Auth: Candidate bearer token with `candidate:access`
+- Operation ID: `review_candidate_session_api_candidate_session__token__review_get`
+- Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `token` | yes | `string` | `-` | - |
+- Query params: 
+  - None
+- Header params: 
+  - None
+- Request schema: None
+- Success responses:
+  - `200`: Successful Response (schema: `CandidateCompletedReviewResponse`)
+- Error responses:
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "candidateSessionId": 1,
+  "status": "not_started",
+  "completedAt": "2026-01-01T00:00:00Z",
+  "trial": {
+    "id": 1,
+    "title": "example",
+    "role": "example"
+  }
+}
+```
+
 ### `POST /api/candidate/session/{token}/schedule`
 - Summary: Schedule Candidate Session
 - Description: Persist candidate-proposed schedule details and send confirmation notifications for the session token.
@@ -602,8 +731,8 @@ Total endpoints: 46
 
 ### `GET /api/candidate_sessions/{candidate_session_id}/winoe_report`
 - Summary: Get Winoe Report Route
-- Description: Return winoe-report generation status and latest report payload for a talent_partner-visible candidate session.
-- Auth: Talent Partner bearer token
+- Description: Return winoe-report generation status and latest report payload for a Talent Partner-visible candidate session.
+- Auth: TalentPartner bearer token
 - Operation ID: `get_winoe_report_route_api_candidate_sessions__candidate_session_id__winoe_report_get`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
 - Path params: 
@@ -630,8 +759,8 @@ Total endpoints: 46
 
 ### `POST /api/candidate_sessions/{candidate_session_id}/winoe_report/generate`
 - Summary: Generate Winoe Report Route
-- Description: Queue or compute winoe-report artifacts for a candidate session visible to the authenticated talent_partner.
-- Auth: Talent Partner bearer token
+- Description: Queue or compute winoe-report artifacts for a candidate session visible to the authenticated Talent Partner.
+- Auth: TalentPartner bearer token
 - Operation ID: `generate_winoe_report_route_api_candidate_sessions__candidate_session_id__winoe_report_generate_post`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
 - Path params: 
@@ -654,6 +783,77 @@ Total endpoints: 46
 {
   "jobId": "example",
   "status": "example"
+}
+```
+
+### `GET /api/companies/me/ai-config`
+- Summary: Read TalentPartner Company AI Config
+- Description: Return Talent Partner company AI override defaults.
+- Auth: Bearer token
+- Operation ID: `read_company_ai_config_api_companies_me_ai_config_get`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params: 
+  - None
+- Query params: 
+  - None
+- Header params: 
+  - None
+- Request schema: None
+- Success responses:
+  - `200`: Successful Response (schema: `CompanyAIConfigRead`)
+- Error responses:
+  - None
+- Success example (`200`):
+```json
+{
+  "companyId": 1,
+  "companyName": "example",
+  "promptPackVersion": "example"
+}
+```
+
+### `PUT /api/companies/me/ai-config`
+- Summary: Update TalentPartner Company AI Config
+- Description: Replace Talent Partner company AI override defaults.
+- Auth: Bearer token
+- Operation ID: `update_company_ai_config_api_companies_me_ai_config_put`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params: 
+  - None
+- Query params: 
+  - None
+- Header params: 
+  - None
+- Request schema: `CompanyAIConfigWrite`
+- Request example:
+```json
+{
+  "promptOverrides": {
+    "prestart": {
+      "instructionsMd": null,
+      "rubricMd": null
+    },
+    "codespace": {
+      "instructionsMd": null,
+      "rubricMd": null
+    },
+    "day1": {
+      "instructionsMd": null,
+      "rubricMd": null
+    }
+  }
+}
+```
+- Success responses:
+  - `200`: Successful Response (schema: `CompanyAIConfigRead`)
+- Error responses:
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "companyId": 1,
+  "companyName": "example",
+  "promptPackVersion": "example"
 }
 ```
 
@@ -716,6 +916,60 @@ Total endpoints: 46
 }
 ```
 
+### `GET /api/recordings/storage/fake/download`
+- Summary: Fake Storage Download Route
+- Description: Serve a signed fake-storage download for local browser and worker use.
+- Auth: None
+- Operation ID: `fake_storage_download_route_api_recordings_storage_fake_download_get`
+- Dependency auth signals: `app.shared.http.dependencies.shared_http_dependencies_storage_media_utils.get_media_storage_provider`
+- Path params: 
+  - None
+- Query params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `key` | yes | `string` | `-` | - |
+  - | `expiresAt` | yes | `integer` | `-` | - |
+  - | `sig` | yes | `string` | `-` | - |
+- Header params: 
+  - None
+- Request schema: None
+- Success responses:
+  - `200`: Object downloaded (schema: `-`)
+- Error responses:
+  - `403`: Signed URL rejected (schema: `-`)
+  - `404`: Object not found (schema: `-`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+"example"
+```
+
+### `PUT /api/recordings/storage/fake/upload`
+- Summary: Fake Storage Upload Route
+- Description: Accept a signed fake-storage upload for local live validation.
+- Auth: None
+- Operation ID: `fake_storage_upload_route_api_recordings_storage_fake_upload_put`
+- Dependency auth signals: `app.shared.http.dependencies.shared_http_dependencies_storage_media_utils.get_media_storage_provider`
+- Path params: 
+  - None
+- Query params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `key` | yes | `string` | `-` | - |
+  - | `contentType` | yes | `string` | `-` | - |
+  - | `sizeBytes` | yes | `integer` | `-` | - |
+  - | `expiresAt` | yes | `integer` | `-` | - |
+  - | `sig` | yes | `string` | `-` | - |
+- Header params: 
+  - None
+- Request schema: None
+- Success responses:
+  - `204`: Object uploaded (schema: `-`)
+- Error responses:
+  - `403`: Signed URL rejected (schema: `-`)
+  - `404`: Fake storage disabled (schema: `-`)
+  - `422`: Upload rejected (schema: `-`)
+
 ### `POST /api/recordings/{recording_id}/delete`
 - Summary: Delete Recording Route
 - Description: Soft-delete a recording asset owned by the authenticated candidate session and revoke access links.
@@ -745,523 +999,10 @@ Total endpoints: 46
 }
 ```
 
-### `GET /api/trials`
-- Summary: List Trials
-- Description: List trials for talent_partner dashboard (scoped to current user).
-- Auth: Talent Partner bearer token
-- Operation ID: `list_trials_api_trials_get`
-- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
-  - None
-- Query params: 
-  - | Name | Required | Type | Default | Description |
-  - |---|---:|---|---|---|
-  - | `includeTerminated` | no | `boolean` | `False` | - |
-- Header params: 
-  - None
-- Request schema: None
-- Success responses:
-  - `200`: Successful Response (schema: `Response List Trials Api Trials Get`)
-- Error responses:
-  - `422`: Validation Error (schema: `HTTPValidationError`)
-- Success example (`200`):
-```json
-[
-  {
-    "id": 1,
-    "title": "example",
-    "role": "example",
-    "techStack": "example",
-    "templateKey": "example",
-    "status": "draft",
-    "createdAt": "2026-01-01T00:00:00Z",
-    "numCandidates": 1
-  }
-]
-```
-
-### `POST /api/trials`
-- Summary: Create Trial
-- Description: Create a trial and seed default tasks.
-- Auth: Talent Partner bearer token
-- Operation ID: `create_trial_api_trials_post`
-- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
-  - None
-- Query params: 
-  - None
-- Header params: 
-  - None
-- Request schema: `TrialCreate`
-- Request example:
-```json
-{
-  "title": "example",
-  "role": "example",
-  "techStack": "example",
-  "seniority": "example",
-  "focus": "example"
-}
-```
-- Success responses:
-  - `201`: Successful Response (schema: `TrialCreateResponse`)
-- Error responses:
-  - `422`: Validation Error (schema: `HTTPValidationError`)
-- Success example (`201`):
-```json
-{
-  "id": 1,
-  "title": "example",
-  "role": "example",
-  "techStack": "example",
-  "seniority": "example",
-  "focus": "example",
-  "templateKey": "example",
-  "status": "draft",
-  "scenarioGenerationJobId": "example",
-  "tasks": [
-    {
-      "id": 1,
-      "day_index": 1,
-      "type": "design",
-      "title": "example"
-    }
-  ]
-}
-```
-
-### `GET /api/trials/{trial_id}`
-- Summary: Get Trial Detail
-- Description: Return a trial detail view for talent_partners.
-- Auth: Talent Partner bearer token
-- Operation ID: `get_trial_detail_api_trials__trial_id__get`
-- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
-  - | Name | Required | Type | Default | Description |
-  - |---|---:|---|---|---|
-  - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
-  - None
-- Header params: 
-  - None
-- Request schema: None
-- Success responses:
-  - `200`: Successful Response (schema: `TrialDetailResponse`)
-- Error responses:
-  - `422`: Validation Error (schema: `HTTPValidationError`)
-- Success example (`200`):
-```json
-{
-  "id": 1,
-  "status": "draft",
-  "tasks": [
-    {
-      "dayIndex": 1
-    }
-  ]
-}
-```
-
-### `PUT /api/trials/{trial_id}`
-- Summary: Update Trial
-- Description: Update mutable trial configuration.
-- Auth: Talent Partner bearer token
-- Operation ID: `update_trial_api_trials__trial_id__put`
-- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
-  - | Name | Required | Type | Default | Description |
-  - |---|---:|---|---|---|
-  - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
-  - None
-- Header params: 
-  - None
-- Request schema: `TrialUpdate`
-- Request example:
-```json
-{
-  "ai": {
-    "noticeVersion": "example",
-    "noticeText": "example",
-    "evalEnabledByDay": {
-      "key": true
-    }
-  }
-}
-```
-- Success responses:
-  - `200`: Successful Response (schema: `TrialDetailResponse`)
-- Error responses:
-  - `422`: Validation Error (schema: `HTTPValidationError`)
-- Success example (`200`):
-```json
-{
-  "id": 1,
-  "status": "draft",
-  "tasks": [
-    {
-      "dayIndex": 1
-    }
-  ]
-}
-```
-
-### `POST /api/trials/{trial_id}/activate`
-- Summary: Activate Trial
-- Description: Transition a trial into the active state once talent_partner confirms readiness.
-- Auth: Talent Partner bearer token
-- Operation ID: `activate_trial_api_trials__trial_id__activate_post`
-- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
-  - | Name | Required | Type | Default | Description |
-  - |---|---:|---|---|---|
-  - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
-  - None
-- Header params: 
-  - None
-- Request schema: `TrialLifecycleRequest`
-- Request example:
-```json
-{
-  "confirm": true
-}
-```
-- Success responses:
-  - `200`: Successful Response (schema: `TrialActivateResponse`)
-- Error responses:
-  - `400`: Activation confirmation missing. (schema: `-`)
-  - `403`: Talent Partner access required. (schema: `-`)
-  - `404`: Trial not found. (schema: `-`)
-  - `422`: Validation Error (schema: `HTTPValidationError`)
-- Success example (`200`):
-```json
-{
-  "trialId": 1,
-  "status": "draft"
-}
-```
-
-### `GET /api/trials/{trial_id}/candidates`
-- Summary: List Trial Candidates
-- Description: List candidate sessions for a trial (talent_partner-only).
-- Auth: Talent Partner bearer token
-- Operation ID: `list_trial_candidates_api_trials__trial_id__candidates_get`
-- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
-  - | Name | Required | Type | Default | Description |
-  - |---|---:|---|---|---|
-  - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
-  - | Name | Required | Type | Default | Description |
-  - |---|---:|---|---|---|
-  - | `includeTerminated` | no | `boolean` | `False` | - |
-- Header params: 
-  - None
-- Request schema: None
-- Success responses:
-  - `200`: Successful Response (schema: `Response List Trial Candidates Api Trials  Trial Id  Candidates Get`)
-- Error responses:
-  - `422`: Validation Error (schema: `HTTPValidationError`)
-- Success example (`200`):
-```json
-[
-  {
-    "candidateSessionId": 1,
-    "inviteEmail": "user@example.com",
-    "candidateName": "example",
-    "status": "not_started",
-    "startedAt": "2026-01-01T00:00:00Z",
-    "completedAt": "2026-01-01T00:00:00Z",
-    "hasWinoeReport": true
-  }
-]
-```
-
-### `GET /api/trials/{trial_id}/candidates/compare`
-- Summary: List Trial Candidates Compare
-- Description: Return side-by-side candidate progress and scoring signals for a talent_partner-owned trial.
-- Auth: Talent Partner bearer token
-- Operation ID: `list_trial_candidates_compare_api_trials__trial_id__candidates_compare_get`
-- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
-  - | Name | Required | Type | Default | Description |
-  - |---|---:|---|---|---|
-  - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
-  - None
-- Header params: 
-  - None
-- Request schema: None
-- Success responses:
-  - `200`: Successful Response (schema: `TrialCandidatesCompareResponse`)
-- Error responses:
-  - `403`: Talent Partner access required. (schema: `-`)
-  - `404`: Trial not found. (schema: `-`)
-  - `422`: Validation Error (schema: `HTTPValidationError`)
-- Success example (`200`):
-```json
-{
-  "trialId": 1
-}
-```
-
-### `POST /api/trials/{trial_id}/candidates/{candidate_session_id}/invite/resend`
-- Summary: Resend Candidate Invite
-- Description: Resend an existing candidate invite email for a talent_partner-owned trial session.
-- Auth: Talent Partner bearer token
-- Operation ID: `resend_candidate_invite_api_trials__trial_id__candidates__candidate_session_id__invite_resend_post`
-- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_notifications_utils.get_email_service`, `fastapi.security.http.unknown`
-- Path params: 
-  - | Name | Required | Type | Default | Description |
-  - |---|---:|---|---|---|
-  - | `trial_id` | yes | `integer` | `-` | - |
-  - | `candidate_session_id` | yes | `integer` | `-` | - |
-- Query params: 
-  - None
-- Header params: 
-  - None
-- Request schema: None
-- Success responses:
-  - `200`: Successful Response (schema: `-`)
-- Error responses:
-  - `403`: Talent Partner access required. (schema: `-`)
-  - `404`: Trial or candidate session not found. (schema: `-`)
-  - `422`: Validation Error (schema: `HTTPValidationError`)
-- Success example (`200`):
-```json
-"example"
-```
-
-### `POST /api/trials/{trial_id}/invite`
-- Summary: Create Candidate Invite
-- Description: Create a candidate_session invite token for a trial (talent_partner-only).
-- Auth: Talent Partner bearer token
-- Operation ID: `create_candidate_invite_api_trials__trial_id__invite_post`
-- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_github_native_utils.get_github_client`, `app.shared.http.dependencies.shared_http_dependencies_notifications_utils.get_email_service`, `fastapi.security.http.unknown`
-- Path params: 
-  - | Name | Required | Type | Default | Description |
-  - |---|---:|---|---|---|
-  - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
-  - None
-- Header params: 
-  - None
-- Request schema: `CandidateInviteRequest`
-- Request example:
-```json
-{
-  "candidateName": "example",
-  "inviteEmail": "user@example.com"
-}
-```
-- Success responses:
-  - `200`: Successful Response (schema: `CandidateInviteResponse`)
-- Error responses:
-  - `409`: Conflict (schema: `CandidateInviteErrorResponse`)
-  - `422`: Validation Error (schema: `HTTPValidationError`)
-- Success example (`200`):
-```json
-{
-  "candidateSessionId": 1,
-  "token": "example",
-  "inviteUrl": "example",
-  "outcome": "created"
-}
-```
-
-### `PATCH /api/trials/{trial_id}/scenario/active`
-- Summary: Update Active Scenario Version
-- Description: Update active scenario metadata and assignment fields for the trial.
-- Auth: Talent Partner bearer token
-- Operation ID: `update_active_scenario_version_api_trials__trial_id__scenario_active_patch`
-- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
-  - | Name | Required | Type | Default | Description |
-  - |---|---:|---|---|---|
-  - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
-  - None
-- Header params: 
-  - None
-- Request schema: `ScenarioActiveUpdateRequest`
-- Request example:
-```json
-{
-  "storylineMd": "example",
-  "taskPromptsJson": {},
-  "rubricJson": {}
-}
-```
-- Success responses:
-  - `200`: Successful Response (schema: `ScenarioActiveUpdateResponse`)
-- Error responses:
-  - `403`: Talent Partner access required. (schema: `-`)
-  - `404`: Trial not found. (schema: `-`)
-  - `422`: Validation Error (schema: `HTTPValidationError`)
-- Success example (`200`):
-```json
-{
-  "trialId": 1,
-  "scenario": {
-    "id": 1,
-    "versionIndex": 1,
-    "status": "example"
-  }
-}
-```
-
-### `POST /api/trials/{trial_id}/scenario/regenerate`
-- Summary: Regenerate Scenario Version
-- Description: Request a regenerated scenario version for a trial and return the created job reference.
-- Auth: Talent Partner bearer token
-- Operation ID: `regenerate_scenario_version_api_trials__trial_id__scenario_regenerate_post`
-- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
-  - | Name | Required | Type | Default | Description |
-  - |---|---:|---|---|---|
-  - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
-  - None
-- Header params: 
-  - None
-- Request schema: None
-- Success responses:
-  - `200`: Successful Response (schema: `ScenarioRegenerateResponse`)
-- Error responses:
-  - `403`: Talent Partner access required. (schema: `-`)
-  - `404`: Trial not found. (schema: `-`)
-  - `422`: Validation Error (schema: `HTTPValidationError`)
-  - `429`: Scenario regeneration rate limit exceeded. (schema: `-`)
-- Success example (`200`):
-```json
-{
-  "scenarioVersionId": 1,
-  "jobId": "example",
-  "status": "example"
-}
-```
-
-### `PATCH /api/trials/{trial_id}/scenario/{scenario_version_id}`
-- Summary: Patch Scenario Version
-- Description: Patch editable scenario version content and return the updated scenario payload.
-- Auth: Talent Partner bearer token
-- Operation ID: `patch_scenario_version_api_trials__trial_id__scenario__scenario_version_id__patch`
-- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
-  - | Name | Required | Type | Default | Description |
-  - |---|---:|---|---|---|
-  - | `trial_id` | yes | `integer` | `-` | - |
-  - | `scenario_version_id` | yes | `integer` | `-` | - |
-- Query params: 
-  - None
-- Header params: 
-  - None
-- Request schema: `ScenarioVersionPatchRequest`
-- Request example:
-```json
-{
-  "storylineMd": "example",
-  "taskPrompts": [
-    {
-      "dayIndex": 1,
-      "title": "example",
-      "description": "example"
-    }
-  ],
-  "rubric": {}
-}
-```
-- Success responses:
-  - `200`: Successful Response (schema: `ScenarioVersionPatchResponse`)
-- Error responses:
-  - `403`: Talent Partner access required. (schema: `-`)
-  - `404`: Trial or scenario version not found. (schema: `-`)
-  - `422`: Validation Error (schema: `HTTPValidationError`)
-- Success example (`200`):
-```json
-{
-  "scenarioVersionId": 1,
-  "status": "example"
-}
-```
-
-### `POST /api/trials/{trial_id}/scenario/{scenario_version_id}/approve`
-- Summary: Approve Scenario Version
-- Description: Approve a scenario version and promote it for active trial usage.
-- Auth: Talent Partner bearer token
-- Operation ID: `approve_scenario_version_api_trials__trial_id__scenario__scenario_version_id__approve_post`
-- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
-  - | Name | Required | Type | Default | Description |
-  - |---|---:|---|---|---|
-  - | `trial_id` | yes | `integer` | `-` | - |
-  - | `scenario_version_id` | yes | `integer` | `-` | - |
-- Query params: 
-  - None
-- Header params: 
-  - None
-- Request schema: None
-- Success responses:
-  - `200`: Successful Response (schema: `ScenarioApproveResponse`)
-- Error responses:
-  - `403`: Talent Partner access required. (schema: `-`)
-  - `404`: Trial or scenario version not found. (schema: `-`)
-  - `422`: Validation Error (schema: `HTTPValidationError`)
-- Success example (`200`):
-```json
-{
-  "trialId": 1,
-  "status": "draft",
-  "activeScenarioVersionId": 1,
-  "scenario": {
-    "id": 1,
-    "versionIndex": 1,
-    "status": "example"
-  }
-}
-```
-
-### `POST /api/trials/{trial_id}/terminate`
-- Summary: Terminate Trial
-- Description: Terminate an active trial and enqueue workspace cleanup jobs for associated candidate workspaces.
-- Auth: Talent Partner bearer token
-- Operation ID: `terminate_trial_api_trials__trial_id__terminate_post`
-- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
-  - | Name | Required | Type | Default | Description |
-  - |---|---:|---|---|---|
-  - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
-  - None
-- Header params: 
-  - None
-- Request schema: `TrialLifecycleRequest`
-- Request example:
-```json
-{
-  "confirm": true
-}
-```
-- Success responses:
-  - `200`: Successful Response (schema: `TrialTerminateResponse`)
-- Error responses:
-  - `400`: Termination confirmation missing. (schema: `-`)
-  - `403`: Talent Partner access required. (schema: `-`)
-  - `404`: Trial not found. (schema: `-`)
-  - `422`: Validation Error (schema: `HTTPValidationError`)
-- Success example (`200`):
-```json
-{
-  "trialId": 1,
-  "status": "draft"
-}
-```
-
 ### `GET /api/submissions`
 - Summary: List Submissions Route
-- Description: List submissions visible to the talent_partner with optional filters.
-- Auth: Talent Partner bearer token
+- Description: List submissions visible to the Talent Partner with optional filters.
+- Auth: TalentPartner bearer token
 - Operation ID: `list_submissions_route_api_submissions_get`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
 - Path params: 
@@ -1277,7 +1018,7 @@ Total endpoints: 46
   - None
 - Request schema: None
 - Success responses:
-  - `200`: Successful Response (schema: `Talent PartnerSubmissionListOut`)
+  - `200`: Successful Response (schema: `TalentPartnerSubmissionListOut`)
 - Error responses:
   - `422`: Validation Error (schema: `HTTPValidationError`)
 - Success example (`200`):
@@ -1298,8 +1039,8 @@ Total endpoints: 46
 
 ### `GET /api/submissions/{submission_id}`
 - Summary: Get Submission Detail Route
-- Description: Return talent_partner-facing detail for a submission.
-- Auth: Talent Partner bearer token
+- Description: Return Talent Partner-facing detail for a submission.
+- Auth: TalentPartner bearer token
 - Operation ID: `get_submission_detail_route_api_submissions__submission_id__get`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
 - Path params: 
@@ -1312,7 +1053,7 @@ Total endpoints: 46
   - None
 - Request schema: None
 - Success responses:
-  - `200`: Successful Response (schema: `Talent PartnerSubmissionDetailOut`)
+  - `200`: Successful Response (schema: `TalentPartnerSubmissionDetailOut`)
 - Error responses:
   - `422`: Validation Error (schema: `HTTPValidationError`)
 - Success example (`200`):
@@ -1360,7 +1101,6 @@ Total endpoints: 46
 ```json
 {
   "repoFullName": "example",
-  "repoUrl": "example",
   "codespaceUrl": "example",
   "workspaceId": "example"
 }
@@ -1391,7 +1131,6 @@ Total endpoints: 46
 ```json
 {
   "repoFullName": "example",
-  "repoUrl": "example",
   "workspaceId": "example"
 }
 ```
@@ -1577,6 +1316,118 @@ Total endpoints: 46
 }
 ```
 
+### `POST /api/tasks/{task_id}/presentation/upload/complete`
+- Summary: Complete Presentation Upload Route
+- Description: Finalize a previously initialized presentation upload and bind recording metadata to the submission.
+- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-session-id`
+- Operation ID: `complete_handoff_upload_route_api_tasks__task_id__presentation_upload_complete_post`
+- Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_candidate_sessions_utils.candidate_session_from_headers`, `app.shared.http.dependencies.shared_http_dependencies_storage_media_utils.get_media_storage_provider`, `fastapi.security.http.unknown`
+- Path params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `task_id` | yes | `integer` | `-` | - |
+- Query params: 
+  - None
+- Header params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `x-candidate-session-id` | no | `X-Candidate-Session-Id` | `-` | - |
+- Request schema: `HandoffUploadCompleteRequest`
+- Request example:
+```json
+{
+  "recordingId": "example"
+}
+```
+- Success responses:
+  - `200`: Successful Response (schema: `HandoffUploadCompleteResponse`)
+- Error responses:
+  - `403`: Candidate session access denied. (schema: `-`)
+  - `404`: Task or upload record not found. (schema: `-`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "recordingId": "example",
+  "status": "example"
+}
+```
+
+### `POST /api/tasks/{task_id}/presentation/upload/init`
+- Summary: Init Presentation Upload Route
+- Description: Initialize candidate presentation recording upload and return signed upload instructions.
+- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-session-id`
+- Operation ID: `init_handoff_upload_route_api_tasks__task_id__presentation_upload_init_post`
+- Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_candidate_sessions_utils.candidate_session_from_headers`, `app.shared.http.dependencies.shared_http_dependencies_storage_media_utils.get_media_storage_provider`, `fastapi.security.http.unknown`
+- Path params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `task_id` | yes | `integer` | `-` | - |
+- Query params: 
+  - None
+- Header params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `x-candidate-session-id` | no | `X-Candidate-Session-Id` | `-` | - |
+- Request schema: `HandoffUploadInitRequest`
+- Request example:
+```json
+{
+  "contentType": "example",
+  "sizeBytes": 1
+}
+```
+- Success responses:
+  - `200`: Successful Response (schema: `HandoffUploadInitResponse`)
+- Error responses:
+  - `403`: Candidate session access denied. (schema: `-`)
+  - `404`: Task or candidate session not found. (schema: `-`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "recordingId": "example",
+  "uploadUrl": "example",
+  "expiresInSeconds": 1
+}
+```
+
+### `GET /api/tasks/{task_id}/presentation/upload/status`
+- Summary: Presentation Status Route
+- Description: Return the current recording and transcript status for presentation tasks in the candidate session.
+- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-session-id`
+- Operation ID: `handoff_status_route_api_tasks__task_id__presentation_upload_status_get`
+- Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_candidate_sessions_utils.candidate_session_from_headers`, `app.shared.http.dependencies.shared_http_dependencies_storage_media_utils.get_media_storage_provider`, `fastapi.security.http.unknown`
+- Path params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `task_id` | yes | `integer` | `-` | - |
+- Query params: 
+  - None
+- Header params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `x-candidate-session-id` | no | `X-Candidate-Session-Id` | `-` | - |
+- Request schema: None
+- Success responses:
+  - `200`: Successful Response (schema: `HandoffStatusResponse`)
+- Error responses:
+  - `403`: Candidate session access denied. (schema: `-`)
+  - `404`: Task or presentation recording not found. (schema: `-`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "recording": {
+    "recordingId": "example",
+    "status": "example"
+  },
+  "transcript": {
+    "status": "example"
+  }
+}
+```
+
 ### `POST /api/tasks/{task_id}/run`
 - Summary: Run Task Tests Route
 - Description: Dispatch GitHub Actions tests for a candidate task.
@@ -1685,6 +1536,519 @@ Total endpoints: 46
 }
 ```
 
+### `GET /api/trials`
+- Summary: List Trials
+- Description: List trials for Talent Partner dashboard (scoped to current user).
+- Auth: TalentPartner bearer token
+- Operation ID: `list_trials_api_trials_get`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params: 
+  - None
+- Query params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `includeTerminated` | no | `boolean` | `False` | - |
+- Header params: 
+  - None
+- Request schema: None
+- Success responses:
+  - `200`: Successful Response (schema: `Response List Trials Api Trials Get`)
+- Error responses:
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+[
+  {
+    "id": 1,
+    "title": "example",
+    "role": "example",
+    "techStack": "example",
+    "templateKey": "example",
+    "status": "draft",
+    "createdAt": "2026-01-01T00:00:00Z",
+    "numCandidates": 1
+  }
+]
+```
+
+### `POST /api/trials`
+- Summary: Create Trial
+- Description: Create a trial and seed default tasks.
+- Auth: TalentPartner bearer token
+- Operation ID: `create_trial_api_trials_post`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params: 
+  - None
+- Query params: 
+  - None
+- Header params: 
+  - None
+- Request schema: `TrialCreate`
+- Request example:
+```json
+{
+  "title": "example",
+  "role": "example",
+  "techStack": "example",
+  "seniority": "example",
+  "focus": "example"
+}
+```
+- Success responses:
+  - `201`: Successful Response (schema: `TrialCreateResponse`)
+- Error responses:
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`201`):
+```json
+{
+  "id": 1,
+  "title": "example",
+  "role": "example",
+  "techStack": "example",
+  "seniority": "example",
+  "focus": "example",
+  "templateKey": "example",
+  "status": "draft",
+  "scenarioGenerationJobId": "example",
+  "tasks": [
+    {
+      "id": 1,
+      "day_index": 1,
+      "type": "design",
+      "title": "example"
+    }
+  ]
+}
+```
+
+### `GET /api/trials/{trial_id}`
+- Summary: Get Trial Detail
+- Description: Return a trial detail view for talent_partners.
+- Auth: TalentPartner bearer token
+- Operation ID: `get_trial_detail_api_trials__trial_id__get`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `trial_id` | yes | `integer` | `-` | - |
+- Query params: 
+  - None
+- Header params: 
+  - None
+- Request schema: None
+- Success responses:
+  - `200`: Successful Response (schema: `TrialDetailResponse`)
+- Error responses:
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "id": 1,
+  "status": "draft",
+  "tasks": [
+    {
+      "dayIndex": 1
+    }
+  ]
+}
+```
+
+### `PUT /api/trials/{trial_id}`
+- Summary: Update Trial
+- Description: Update mutable trial configuration.
+- Auth: TalentPartner bearer token
+- Operation ID: `update_trial_api_trials__trial_id__put`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `trial_id` | yes | `integer` | `-` | - |
+- Query params: 
+  - None
+- Header params: 
+  - None
+- Request schema: `TrialUpdate`
+- Request example:
+```json
+{
+  "ai": {
+    "noticeVersion": "example",
+    "noticeText": "example",
+    "evalEnabledByDay": {
+      "key": true
+    }
+  }
+}
+```
+- Success responses:
+  - `200`: Successful Response (schema: `TrialDetailResponse`)
+- Error responses:
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "id": 1,
+  "status": "draft",
+  "tasks": [
+    {
+      "dayIndex": 1
+    }
+  ]
+}
+```
+
+### `POST /api/trials/{trial_id}/activate`
+- Summary: Activate Trial
+- Description: Transition a trial into the active state once Talent Partner confirms readiness.
+- Auth: TalentPartner bearer token
+- Operation ID: `activate_trial_api_trials__trial_id__activate_post`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `trial_id` | yes | `integer` | `-` | - |
+- Query params: 
+  - None
+- Header params: 
+  - None
+- Request schema: `TrialLifecycleRequest`
+- Request example:
+```json
+{
+  "confirm": true
+}
+```
+- Success responses:
+  - `200`: Successful Response (schema: `TrialActivateResponse`)
+- Error responses:
+  - `400`: Activation confirmation missing. (schema: `-`)
+  - `403`: Talent Partner access required. (schema: `-`)
+  - `404`: Trial not found. (schema: `-`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "trialId": 1,
+  "status": "draft"
+}
+```
+
+### `GET /api/trials/{trial_id}/candidates`
+- Summary: List Trial Candidates
+- Description: List candidate sessions for a trial (Talent Partner-only).
+- Auth: TalentPartner bearer token
+- Operation ID: `list_trial_candidates_api_trials__trial_id__candidates_get`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `trial_id` | yes | `integer` | `-` | - |
+- Query params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `includeTerminated` | no | `boolean` | `False` | - |
+- Header params: 
+  - None
+- Request schema: None
+- Success responses:
+  - `200`: Successful Response (schema: `Response List Trial Candidates Api Trials  Trial Id  Candidates Get`)
+- Error responses:
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+[
+  {
+    "candidateSessionId": 1,
+    "inviteEmail": "user@example.com",
+    "candidateName": "example",
+    "status": "not_started",
+    "startedAt": "2026-01-01T00:00:00Z",
+    "completedAt": "2026-01-01T00:00:00Z",
+    "hasWinoeReport": true
+  }
+]
+```
+
+### `GET /api/trials/{trial_id}/candidates/compare`
+- Summary: List Trial Candidates Compare
+- Description: Return side-by-side candidate progress and scoring signals for a Talent Partner-owned trial.
+- Auth: TalentPartner bearer token
+- Operation ID: `list_trial_candidates_compare_api_trials__trial_id__candidates_compare_get`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `trial_id` | yes | `integer` | `-` | - |
+- Query params: 
+  - None
+- Header params: 
+  - None
+- Request schema: None
+- Success responses:
+  - `200`: Successful Response (schema: `TrialCandidatesCompareResponse`)
+- Error responses:
+  - `403`: Talent Partner access required. (schema: `-`)
+  - `404`: Trial not found. (schema: `-`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "trialId": 1
+}
+```
+
+### `POST /api/trials/{trial_id}/candidates/{candidate_session_id}/invite/resend`
+- Summary: Resend Candidate Invite
+- Description: Resend an existing candidate invite email for a Talent Partner-owned trial session.
+- Auth: TalentPartner bearer token
+- Operation ID: `resend_candidate_invite_api_trials__trial_id__candidates__candidate_session_id__invite_resend_post`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_notifications_utils.get_email_service`, `fastapi.security.http.unknown`
+- Path params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `trial_id` | yes | `integer` | `-` | - |
+  - | `candidate_session_id` | yes | `integer` | `-` | - |
+- Query params: 
+  - None
+- Header params: 
+  - None
+- Request schema: None
+- Success responses:
+  - `200`: Successful Response (schema: `-`)
+- Error responses:
+  - `403`: Talent Partner access required. (schema: `-`)
+  - `404`: Trial or candidate session not found. (schema: `-`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+"example"
+```
+
+### `POST /api/trials/{trial_id}/invite`
+- Summary: Create Candidate Invite
+- Description: Create a candidate_session invite token for a trial (Talent Partner-only).
+- Auth: TalentPartner bearer token
+- Operation ID: `create_candidate_invite_api_trials__trial_id__invite_post`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_github_native_utils.get_github_client`, `app.shared.http.dependencies.shared_http_dependencies_notifications_utils.get_email_service`, `fastapi.security.http.unknown`
+- Path params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `trial_id` | yes | `integer` | `-` | - |
+- Query params: 
+  - None
+- Header params: 
+  - None
+- Request schema: `CandidateInviteRequest`
+- Request example:
+```json
+{
+  "candidateName": "example",
+  "inviteEmail": "user@example.com"
+}
+```
+- Success responses:
+  - `200`: Successful Response (schema: `CandidateInviteResponse`)
+- Error responses:
+  - `409`: Conflict (schema: `CandidateInviteErrorResponse`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "candidateSessionId": 1,
+  "token": "example",
+  "inviteUrl": "example",
+  "outcome": "created"
+}
+```
+
+### `PATCH /api/trials/{trial_id}/scenario/active`
+- Summary: Update Active Scenario Version
+- Description: Update active scenario metadata and assignment fields for the trial.
+- Auth: TalentPartner bearer token
+- Operation ID: `update_active_scenario_version_api_trials__trial_id__scenario_active_patch`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `trial_id` | yes | `integer` | `-` | - |
+- Query params: 
+  - None
+- Header params: 
+  - None
+- Request schema: `ScenarioActiveUpdateRequest`
+- Request example:
+```json
+{
+  "storylineMd": "example",
+  "taskPromptsJson": {},
+  "rubricJson": {}
+}
+```
+- Success responses:
+  - `200`: Successful Response (schema: `ScenarioActiveUpdateResponse`)
+- Error responses:
+  - `403`: Talent Partner access required. (schema: `-`)
+  - `404`: Trial not found. (schema: `-`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "trialId": 1,
+  "scenario": {
+    "id": 1,
+    "versionIndex": 1,
+    "status": "example"
+  }
+}
+```
+
+### `POST /api/trials/{trial_id}/scenario/regenerate`
+- Summary: Regenerate Scenario Version
+- Description: Request a regenerated scenario version for a trial and return the created job reference.
+- Auth: TalentPartner bearer token
+- Operation ID: `regenerate_scenario_version_api_trials__trial_id__scenario_regenerate_post`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `trial_id` | yes | `integer` | `-` | - |
+- Query params: 
+  - None
+- Header params: 
+  - None
+- Request schema: None
+- Success responses:
+  - `200`: Successful Response (schema: `ScenarioRegenerateResponse`)
+- Error responses:
+  - `403`: Talent Partner access required. (schema: `-`)
+  - `404`: Trial not found. (schema: `-`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+  - `429`: Scenario regeneration rate limit exceeded. (schema: `-`)
+- Success example (`200`):
+```json
+{
+  "scenarioVersionId": 1,
+  "jobId": "example",
+  "status": "example"
+}
+```
+
+### `PATCH /api/trials/{trial_id}/scenario/{scenario_version_id}`
+- Summary: Patch Scenario Version
+- Description: Patch editable scenario version content and return the updated scenario payload.
+- Auth: TalentPartner bearer token
+- Operation ID: `patch_scenario_version_api_trials__trial_id__scenario__scenario_version_id__patch`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `trial_id` | yes | `integer` | `-` | - |
+  - | `scenario_version_id` | yes | `integer` | `-` | - |
+- Query params: 
+  - None
+- Header params: 
+  - None
+- Request schema: `ScenarioVersionPatchRequest`
+- Request example:
+```json
+{
+  "storylineMd": "example",
+  "taskPrompts": [
+    {
+      "dayIndex": 1,
+      "title": "example",
+      "description": "example"
+    }
+  ],
+  "rubric": {}
+}
+```
+- Success responses:
+  - `200`: Successful Response (schema: `ScenarioVersionPatchResponse`)
+- Error responses:
+  - `403`: Talent Partner access required. (schema: `-`)
+  - `404`: Trial or scenario version not found. (schema: `-`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "scenarioVersionId": 1,
+  "status": "example"
+}
+```
+
+### `POST /api/trials/{trial_id}/scenario/{scenario_version_id}/approve`
+- Summary: Approve Scenario Version
+- Description: Approve a scenario version and promote it for active trial usage.
+- Auth: TalentPartner bearer token
+- Operation ID: `approve_scenario_version_api_trials__trial_id__scenario__scenario_version_id__approve_post`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `trial_id` | yes | `integer` | `-` | - |
+  - | `scenario_version_id` | yes | `integer` | `-` | - |
+- Query params: 
+  - None
+- Header params: 
+  - None
+- Request schema: None
+- Success responses:
+  - `200`: Successful Response (schema: `ScenarioApproveResponse`)
+- Error responses:
+  - `403`: Talent Partner access required. (schema: `-`)
+  - `404`: Trial or scenario version not found. (schema: `-`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "trialId": 1,
+  "status": "draft",
+  "activeScenarioVersionId": 1,
+  "scenario": {
+    "id": 1,
+    "versionIndex": 1,
+    "status": "example"
+  }
+}
+```
+
+### `POST /api/trials/{trial_id}/terminate`
+- Summary: Terminate Trial
+- Description: Terminate an active trial and enqueue workspace cleanup jobs for associated candidate workspaces.
+- Auth: TalentPartner bearer token
+- Operation ID: `terminate_trial_api_trials__trial_id__terminate_post`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params: 
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `trial_id` | yes | `integer` | `-` | - |
+- Query params: 
+  - None
+- Header params: 
+  - None
+- Request schema: `TrialLifecycleRequest`
+- Request example:
+```json
+{
+  "confirm": true
+}
+```
+- Success responses:
+  - `200`: Successful Response (schema: `TrialTerminateResponse`)
+- Error responses:
+  - `400`: Termination confirmation missing. (schema: `-`)
+  - `403`: Talent Partner access required. (schema: `-`)
+  - `404`: Trial not found. (schema: `-`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "trialId": 1,
+  "status": "draft"
+}
+```
+
 ### `GET /health`
 - Summary: Health Check
 - Description: Lightweight liveness probe for process and routing health.
@@ -1705,5 +2069,62 @@ Total endpoints: 46
 - Success example (`200`):
 ```json
 "example"
+```
+
+### `GET /ready`
+- Summary: Readiness Check
+- Description: Readiness probe for database, worker, and integration configuration.
+- Auth: None
+- Operation ID: `readiness_check_ready_get`
+- Dependency auth signals: None
+- Path params: 
+  - None
+- Query params: 
+  - None
+- Header params: 
+  - None
+- Request schema: None
+- Success responses:
+  - `200`: System is ready. (schema: `ReadinessPayload`)
+- Error responses:
+  - `503`: System is not ready. (schema: `ReadinessPayload`)
+- Success example (`200`):
+```json
+{
+  "status": "ready",
+  "checkedAt": "example",
+  "checks": {
+    "database": {
+      "status": "ready",
+      "code": "example",
+      "detail": "example"
+    },
+    "worker": {
+      "status": "ready",
+      "code": "example",
+      "detail": "example"
+    },
+    "ai": {
+      "status": "ready",
+      "code": "example",
+      "detail": "example"
+    },
+    "github": {
+      "status": "ready",
+      "code": "example",
+      "detail": "example"
+    },
+    "email": {
+      "status": "ready",
+      "code": "example",
+      "detail": "example"
+    },
+    "media": {
+      "status": "ready",
+      "code": "example",
+      "detail": "example"
+    }
+  }
+}
 ```
 

--- a/pr.md
+++ b/pr.md
@@ -1,62 +1,123 @@
-# Orchestrate Winoe API and worker startup
-Closes #278.
+# Add readiness endpoint and local demo smoke test
+Closes #279.
 
 ## TL;DR
-- `./runBackend.sh` now coordinates the local API and worker together so the standard dev entrypoint matches production process topology.
-- `migrate` runs after environment loading, so database commands use the same Winoe configuration bootstrap as the runtime commands.
-- `Procfile` is split into clear `release`, `web`, and `worker` process types for production deployment.
-- Worker heartbeats now persist to the database, providing the first observability and future readiness-check foundation for `#279`.
-- Dead-letter jobs can be retried from the worker CLI, both for targeted job IDs and for the full queue of eligible dead letters.
-- `bootstrap-local` now gives developers a single, repeatable local demo flow that seeds the expected Winoe state.
+- Added `GET /ready` as the operational readiness gate for Winoe AI backend runtime safety.
+- Kept `GET /health` as a lightweight liveness probe only.
+- `/ready` now checks database connectivity and schema sanity, worker heartbeat freshness, AI provider readiness, GitHub readiness, email readiness, and media readiness.
+- Readiness failures return structured diagnostics and `503`; a ready system returns `200`.
+- Added an OpenAPI contract for readiness via `ReadinessPayload`, and fixed the docs/export nit so both `200` and `503` reference the same schema cleanly.
+- Added a local smoke test that verifies readiness, creates a Trial through the local/demo auth bypass path, and waits for scenario generation to reach a ready state.
 
-## Problem
-Issue `#278` was needed because the backend could not be started and verified as a complete Winoe system. The API and worker were not orchestrated together in the normal launch path, migrations did not consistently run after the environment was loaded, and production startup still lacked a clean split between release, web, and worker responsibilities. That left the local demo path incomplete and made it hard to validate worker health, dead-letter recovery, and bootstrap data in the same run.
+## Why This Matters
+This change closes an operational gap: `/health` could return `ok` even when scenario generation was effectively broken and jobs were dead-lettering. That is not a usable signal for deployment safety or local demo confidence.
 
-## What changed
-### `runBackend.sh`
-- Added a supervised default startup mode that launches both the API and worker, watches both processes, and shuts the pair down cleanly on signal or child failure.
-- Kept `api`, `worker`, `migrate`, `bootstrap-local`, `retry-dead-jobs`, and `test` as explicit subcommands so the script still supports narrow workflows.
-- Moved environment loading and Winoe local defaults into the commands that need them, including `migrate` and `bootstrap-local`.
-- Added direct worker heartbeat and dead-letter retry command wiring through the same backend entrypoint.
+The backend now exposes a real readiness gate that answers a narrower question: can this system actually support Trial creation and the async workflows that follow? That distinction matters for local development, CI-style smoke validation, and runtime monitoring.
 
-### `Procfile`
-- Split production process types into `release`, `web`, and `worker`.
-- Mapped `release` to migrations, `web` to the API, and `worker` to the worker process so deployment startup is explicit.
+## Scope / What Changed
+### Readiness endpoint
+- Added `GET /ready` in `app/shared/http/routes/shared_http_routes_health_routes.py`.
+- `/ready` performs structured readiness checks instead of a single boolean health response.
+- The readiness service lives in `app/shared/http/shared_http_readiness_service.py`.
+- The response schema is defined in `app/shared/http/schemas/shared_http_schemas_readiness_schema.py` and exported from `app/shared/http/schemas/__init__.py`.
 
-### Worker heartbeat runtime
-- Added the worker heartbeat table, repository, and service layer.
-- The worker now records a `running` heartbeat on startup, refreshes it over time, and marks the row `stopped` on shutdown.
-- Added freshness helpers and logging that establish the observability foundation for follow-up readiness checks.
-- Wired the new heartbeat model into the shared database model registry and config settings.
+### Readiness checks
+- Database connectivity and schema sanity.
+- Worker heartbeat freshness and liveness.
+- AI provider readiness.
+- GitHub readiness.
+- Email readiness.
+- Media readiness.
 
-### Dead-letter retry path
-- Added the dead-letter retry service and repository support to requeue eligible jobs.
-- Exposed both targeted retry by job ID and unfiltered retry for all eligible dead-letter jobs through the worker CLI.
+### Operational behavior
+- `200` when the backend is ready.
+- `503` when one or more dependencies are not ready.
+- Structured diagnostics are returned so failures are actionable instead of opaque.
 
-### Local bootstrap flow
-- Updated the local bootstrap command to use the same environment and database setup path as the rest of the backend entrypoints.
-- Kept the local seed flow aligned with the Winoe demo data expectations so developers can bring up a complete local environment with one command.
+### Local smoke test
+- Added `scripts/local_demo_smoke_test.py`.
+- Added `tests/scripts/test_local_demo_smoke_test.py`.
+- The smoke test now verifies:
+  - readiness is green,
+  - Trial creation succeeds through the local/demo auth bypass path,
+  - scenario generation reaches a ready state,
+  - failures exit non-zero with readable diagnostics.
 
-### Tests/docs
-- Added focused coverage for startup scripts, worker heartbeat persistence, dead-letter retry behavior, the heartbeat migration, and the local bootstrap flow.
-- Updated `README.md` so the new startup and bootstrap workflow is documented alongside the backend entrypoint.
+### Docs and contract alignment
+- Updated `docs/api.md` and `README.md` so the docs match the runtime contract.
+- Fixed the `/ready` docs/export nit so both `200` and `503` use the same clean `ReadinessPayload` schema reference.
 
-## QA / verification
-- `./runBackend.sh migrate` passed
-- `./runBackend.sh bootstrap-local` passed
-- `./runBackend.sh` started both API and worker
-- worker heartbeat row observed in running state and updated over time
-- clean shutdown marked worker heartbeat as `stopped`
-- targeted and unfiltered dead-letter retry verified
-- focused regression suite passed: `26 passed in 2.32s`
+### Tests
+- Updated `tests/shared/http/routes/test_shared_http_health_routes.py`.
+- Updated `tests/shared/http/test_shared_http_readiness_service.py`.
+- Updated `tests/trials/services/test_trials_scenario_generation_env_service.py`.
 
-## Files changed
-- Startup/orchestration: `runBackend.sh`, `Procfile`
-- Heartbeat foundation: `alembic/versions/202604140001_add_worker_heartbeats_table.py`, `app/config/config_settings_fields_config.py`, `app/shared/database/shared_database_models_model.py`, `app/shared/jobs/__init__.py`, `app/shared/jobs/shared_jobs_worker_cli_service.py`, `app/shared/jobs/shared_jobs_worker_service.py`, `app/shared/jobs/shared_jobs_worker_heartbeat_service.py`, `app/shared/jobs/repositories/shared_jobs_repositories_worker_heartbeats_repository.py`, `app/shared/jobs/repositories/shared_jobs_repositories_worker_heartbeats_repository_model.py`
-- Dead-letter retry: `app/shared/jobs/shared_jobs_dead_letter_retry_service.py`, `app/shared/jobs/repositories/shared_jobs_repositories_repository.py`, `app/shared/jobs/repositories/shared_jobs_repositories_repository_dead_letter_repository.py`
-- Docs: `README.md`
-- Tests: `tests/core/db/migrations/test_core_db_migrations_worker_heartbeats.py`, `tests/scripts/test_run_backend_bootstrap_local_shell.py`, `tests/scripts/test_run_backend_migrate_shell.py`, `tests/shared/jobs/repositories/test_shared_jobs_repository_dead_letter_retry_repository.py`, `tests/shared/jobs/repositories/test_shared_jobs_repository_worker_heartbeats_repository.py`, `tests/shared/jobs/test_shared_jobs_dead_letter_retry_service.py`, `tests/shared/jobs/test_shared_jobs_worker_cli_service.py`, `tests/shared/jobs/test_shared_jobs_worker_heartbeat_service.py`, `tests/trials/routes/test_trials_local_bootstrap_seed_and_create_trial_routes.py`
+## Readiness Contract Summary
+- `GET /health`: liveness only.
+- `GET /ready`: structured operational readiness.
+- Response body: `ReadinessPayload`.
+- Success: `200`.
+- Not ready: `503`.
+- Failure output includes specific diagnostics per subsystem so operators can see what is blocking Trial readiness.
 
-## Notes / follow-ups
-- `#279` will consume this heartbeat foundation for readiness checks.
-- This PR does not add the readiness endpoint itself; it only lays the worker-heartbeat groundwork needed for that follow-up.
+## Smoke Test Summary
+The local/demo smoke test now exercises the full path that matters for demos and runtime confidence:
+
+1. Confirm `/ready` is green.
+2. Create a Trial through the local/demo auth bypass path.
+3. Wait for scenario generation to produce a ready scenario version.
+4. Fail fast with clear diagnostics if any step is blocked.
+
+This is intentionally stronger than a process-startup check. It proves the system can move from API availability to Trial readiness and async scenario generation.
+
+## Files Changed
+- `README.md`
+- `app/shared/http/routes/shared_http_routes_health_routes.py`
+- `app/shared/http/shared_http_readiness_service.py`
+- `app/shared/http/schemas/__init__.py`
+- `app/shared/http/schemas/shared_http_schemas_readiness_schema.py`
+- `scripts/local_demo_smoke_test.py`
+- `tests/scripts/test_local_demo_smoke_test.py`
+- `tests/shared/http/routes/test_shared_http_health_routes.py`
+- `tests/shared/http/test_shared_http_readiness_service.py`
+- `tests/trials/services/test_trials_scenario_generation_env_service.py`
+- `docs/api.md`
+
+## Test Plan
+- `./runBackend.sh migrate`
+- `./runBackend.sh bootstrap-local`
+- `./runBackend.sh`
+- Verify both API and worker are running.
+- `curl -sS http://localhost:8000/health`
+- `curl -sS http://localhost:8000/ready`
+- `poetry run python scripts/local_demo_smoke_test.py --base-url http://localhost:8000`
+- Clean shutdown via `Ctrl-C`
+- Verify persisted worker heartbeat transitions to `stopped` after shutdown.
+- `poetry run python code-quality/documentation/scripts/docs_api_export.py --strict --verify-doc README.md docs/api.md`
+- `poetry run pytest`
+
+## Manual QA Evidence
+- `./runBackend.sh migrate` - pass
+- `./runBackend.sh bootstrap-local` - pass
+- `./runBackend.sh` - pass
+- Verified both API and worker were running - pass
+- `curl -sS http://localhost:8000/health` - pass
+- `curl -sS http://localhost:8000/ready` - pass
+- `poetry run python scripts/local_demo_smoke_test.py --base-url http://localhost:8000` - pass
+- Clean shutdown via `Ctrl-C` - pass
+- Persisted worker heartbeat transitioned to `stopped` after shutdown - pass
+- `poetry run python code-quality/documentation/scripts/docs_api_export.py --strict --verify-doc README.md docs/api.md` - pass
+- `poetry run pytest` - pass
+- Full suite result: `1733 passed`
+- Coverage gate result: `96.01%`
+
+## Risks / Follow-ups
+- Readiness now reports the operational state accurately, but it still depends on the underlying provider integrations being configured correctly in each environment.
+- The smoke test is only as reliable as the local/demo bootstrap state; if the demo data or bypass path changes, the test will need to be updated with it.
+- If deployment policy changes, `/ready` should be wired into the platform's readiness gate rather than `/health`.
+
+## Reviewer Notes
+- The key behavior change is intentional: `/health` is not the operational gate anymore.
+- The smoke test proves Trial creation through scenario readiness, not just process startup.
+- The structured diagnostics are the main operator-facing improvement; they make failures debuggable instead of binary.
+- Docs and OpenAPI are aligned with the runtime contract, including the `200` and `503` responses for `ReadinessPayload`.

--- a/scripts/local_demo_smoke_test.py
+++ b/scripts/local_demo_smoke_test.py
@@ -1,0 +1,206 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import httpx
+
+
+@dataclass(frozen=True, slots=True)
+class SmokeTestConfig:
+    base_url: str
+    email: str
+    timeout_seconds: int
+    poll_interval_seconds: float
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Winoe local demo smoke test for Trial generation"
+    )
+    parser.add_argument(
+        "--base-url",
+        default="http://localhost:8000",
+        help="Base URL for the local API server.",
+    )
+    parser.add_argument(
+        "--email",
+        default="talent_partner1@local.test",
+        help="Local Talent Partner email to use with DEV auth bypass.",
+    )
+    parser.add_argument(
+        "--timeout-seconds",
+        type=int,
+        default=180,
+        help="Maximum time to wait for the scenario to become ready.",
+    )
+    parser.add_argument(
+        "--poll-interval-seconds",
+        type=float,
+        default=2.0,
+        help="Delay between readiness and trial polling requests.",
+    )
+    return parser
+
+
+def _headers(email: str) -> dict[str, str]:
+    return {"x-dev-user-email": email}
+
+
+def _fail(message: str) -> None:
+    raise RuntimeError(message)
+
+
+def _pretty_payload(payload: dict[str, object]) -> str:
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def _payload_or_raw(response: httpx.Response) -> dict[str, object]:
+    try:
+        payload = response.json()
+    except ValueError:
+        return {"raw": response.text}
+    if isinstance(payload, dict):
+        return payload
+    return {"raw": payload}
+
+
+def _request_or_fail(
+    request: Callable[[], httpx.Response],
+    *,
+    failure_message: str,
+) -> dict[str, object]:
+    try:
+        response = request()
+    except httpx.HTTPError as exc:
+        _fail(failure_message + f"\nHTTP error: {exc}")
+    payload = _payload_or_raw(response)
+    return {"response": response, "payload": payload}
+
+
+def _check_ready(client: httpx.Client) -> dict[str, object]:
+    result = _request_or_fail(
+        lambda: client.get("/ready"),
+        failure_message="Readiness request failed before smoke test:",
+    )
+    response = result["response"]
+    payload = result["payload"]
+    if response.status_code != 200:
+        _fail("Readiness failed before smoke test:\n" + _pretty_payload(payload))
+    print(f"Readiness ok: {payload.get('status', 'unknown')}")
+    return payload
+
+
+def _create_trial(client: httpx.Client, *, email: str) -> dict[str, object]:
+    result = _request_or_fail(
+        lambda: client.post(
+            "/api/trials",
+            headers=_headers(email),
+            json={
+                "title": "Local Demo Smoke Test",
+                "role": "Backend Engineer",
+                "techStack": "Python, FastAPI, PostgreSQL",
+                "seniority": "Mid",
+                "focus": "Prove Trial generation reaches a ready scenario state",
+            },
+        ),
+        failure_message="Trial creation request failed:",
+    )
+    response = result["response"]
+    payload = result["payload"]
+    if response.status_code != 201:
+        _fail("Trial creation failed:\n" + _pretty_payload(payload))
+    print(
+        "Trial created: id={trial_id} scenarioJobId={job_id}".format(
+            trial_id=payload.get("id"), job_id=payload.get("scenarioGenerationJobId")
+        )
+    )
+    return payload
+
+
+def _wait_for_scenario_ready(
+    client: httpx.Client,
+    *,
+    trial_id: int,
+    email: str,
+    timeout_seconds: int,
+    poll_interval_seconds: float,
+) -> dict[str, object]:
+    deadline = time.monotonic() + timeout_seconds
+    headers = _headers(email)
+    last_payload: dict[str, object] | None = None
+    while time.monotonic() < deadline:
+        result = _request_or_fail(
+            lambda: client.get(f"/api/trials/{trial_id}", headers=headers),
+            failure_message=f"Trial detail request failed for trial {trial_id}:",
+        )
+        response = result["response"]
+        payload = result["payload"]
+        if response.status_code != 200:
+            _fail(
+                f"Trial detail lookup failed for trial {trial_id}:\n"
+                + _pretty_payload(payload)
+            )
+        last_payload = payload
+        scenario = payload.get("scenario") if isinstance(payload, dict) else None
+        if (
+            isinstance(scenario, dict)
+            and payload.get("status") == "ready_for_review"
+            and scenario.get("status") == "ready"
+            and scenario.get("versionIndex") == 1
+        ):
+            print(
+                "Scenario ready: trialId={trial_id} scenarioId={scenario_id} "
+                "version={version}".format(
+                    trial_id=trial_id,
+                    scenario_id=scenario.get("id"),
+                    version=scenario.get("versionIndex"),
+                )
+            )
+            return payload
+        time.sleep(max(0.1, poll_interval_seconds))
+    _fail(
+        "Timed out waiting for a ready scenario.\n"
+        + _pretty_payload(last_payload or {"trialId": trial_id})
+    )
+
+
+def run_smoke_test(config: SmokeTestConfig) -> None:
+    with httpx.Client(base_url=config.base_url, timeout=30.0) as client:
+        _check_ready(client)
+        created = _create_trial(client, email=config.email)
+        _wait_for_scenario_ready(
+            client,
+            trial_id=int(created["id"]),
+            email=config.email,
+            timeout_seconds=config.timeout_seconds,
+            poll_interval_seconds=config.poll_interval_seconds,
+        )
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+    config = SmokeTestConfig(
+        base_url=args.base_url.rstrip("/"),
+        email=args.email.strip(),
+        timeout_seconds=max(1, int(args.timeout_seconds)),
+        poll_interval_seconds=max(0.1, float(args.poll_interval_seconds)),
+    )
+
+    run_smoke_test(config)
+    print("Smoke test completed successfully.")
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script entrypoint
+    try:
+        raise SystemExit(main())
+    except Exception as exc:  # pragma: no cover - direct script execution
+        print(f"Smoke test failed: {exc}", file=sys.stderr)
+        raise SystemExit(1) from exc

--- a/tests/scripts/test_local_demo_smoke_test.py
+++ b/tests/scripts/test_local_demo_smoke_test.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from scripts import local_demo_smoke_test as smoke_test
+
+
+class _FakeResponse:
+    def __init__(
+        self,
+        status_code: int,
+        payload: dict[str, object] | list[object] | str,
+        text: str | None = None,
+    ):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text or (payload if isinstance(payload, str) else "")
+
+    def json(self):
+        if isinstance(self._payload, str):
+            raise ValueError("not json")
+        return self._payload
+
+
+class _FakeClient:
+    def __init__(self, responses: list[object]):
+        self._responses = responses
+        self.calls: list[tuple[str, dict[str, str] | None]] = []
+
+    def get(self, path: str, headers: dict[str, str] | None = None):
+        self.calls.append((path, headers))
+        response = self._responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+    def post(self, path: str, headers: dict[str, str] | None = None, json=None):
+        self.calls.append((path, headers))
+        response = self._responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+class _FakeClientContext:
+    def __init__(self, client: _FakeClient):
+        self._client = client
+
+    def __enter__(self):
+        return self._client
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_payload_or_raw_uses_text_for_invalid_json():
+    response = _FakeResponse(503, "plain error", text="plain error")
+
+    assert smoke_test._payload_or_raw(response) == {"raw": "plain error"}
+
+
+def test_check_ready_returns_payload_and_raises_on_failure(monkeypatch):
+    ready = _FakeResponse(200, {"status": "ready"})
+    client = _FakeClient([ready])
+    assert smoke_test._check_ready(client) == {"status": "ready"}
+
+    failing_client = _FakeClient([_FakeResponse(503, {"status": "not_ready"})])
+    with pytest.raises(RuntimeError, match="Readiness failed before smoke test"):
+        smoke_test._check_ready(failing_client)
+
+
+def test_create_trial_returns_payload_and_raises_on_failure(monkeypatch):
+    created = _FakeResponse(201, {"id": 9, "scenarioGenerationJobId": "job-1"})
+    client = _FakeClient([created])
+    assert smoke_test._create_trial(client, email="talent_partner1@local.test") == {
+        "id": 9,
+        "scenarioGenerationJobId": "job-1",
+    }
+    assert client.calls[0][0] == "/api/trials"
+
+    failing_client = _FakeClient([_FakeResponse(400, {"detail": "bad request"})])
+    with pytest.raises(RuntimeError, match="Trial creation failed"):
+        smoke_test._create_trial(failing_client, email="talent_partner1@local.test")
+
+
+def test_wait_for_scenario_ready_returns_after_polling(monkeypatch):
+    pending = _FakeResponse(
+        200,
+        {
+            "status": "in_progress",
+            "scenario": {"status": "generating", "versionIndex": 1, "id": 7},
+        },
+    )
+    ready = _FakeResponse(
+        200,
+        {
+            "status": "ready_for_review",
+            "scenario": {"status": "ready", "versionIndex": 1, "id": 7},
+        },
+    )
+    client = _FakeClient([pending, ready])
+    monotonic_values = iter([0.0, 0.05, 0.2])
+    monkeypatch.setattr(smoke_test.time, "sleep", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(smoke_test.time, "monotonic", lambda: next(monotonic_values))
+
+    result = smoke_test._wait_for_scenario_ready(
+        client,
+        trial_id=11,
+        email="talent_partner1@local.test",
+        timeout_seconds=1,
+        poll_interval_seconds=0.1,
+    )
+
+    assert result["scenario"]["status"] == "ready"
+    assert [call[0] for call in client.calls] == ["/api/trials/11", "/api/trials/11"]
+
+
+def test_wait_for_scenario_ready_reports_timeout(monkeypatch):
+    pending = _FakeResponse(
+        200,
+        {
+            "status": "in_progress",
+            "scenario": {"status": "generating", "versionIndex": 1, "id": 7},
+        },
+    )
+    client = _FakeClient([pending, pending, pending])
+    monotonic_values = iter([0.0, 0.2, 0.4, 0.6])
+    monkeypatch.setattr(smoke_test.time, "sleep", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(smoke_test.time, "monotonic", lambda: next(monotonic_values))
+
+    with pytest.raises(RuntimeError, match="Timed out waiting for a ready scenario"):
+        smoke_test._wait_for_scenario_ready(
+            client,
+            trial_id=11,
+            email="talent_partner1@local.test",
+            timeout_seconds=0.5,
+            poll_interval_seconds=0.1,
+        )
+
+
+def test_wait_for_scenario_ready_wraps_http_errors(monkeypatch):
+    client = _FakeClient(
+        [
+            httpx.ReadTimeout(
+                "timeout", request=httpx.Request("GET", "http://test/api/trials/11")
+            )
+        ]
+    )
+    monkeypatch.setattr(smoke_test.time, "sleep", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(smoke_test.time, "monotonic", lambda: 0.0)
+
+    with pytest.raises(RuntimeError, match="HTTP error"):
+        smoke_test._wait_for_scenario_ready(
+            client,
+            trial_id=11,
+            email="talent_partner1@local.test",
+            timeout_seconds=1,
+            poll_interval_seconds=0.1,
+        )
+
+
+def test_run_smoke_test_and_main_success(monkeypatch):
+    ready = _FakeResponse(200, {"status": "ready"})
+    created = _FakeResponse(201, {"id": 9, "scenarioGenerationJobId": "job-1"})
+    polled = _FakeResponse(
+        200,
+        {
+            "status": "ready_for_review",
+            "scenario": {"status": "ready", "versionIndex": 1, "id": 7},
+        },
+    )
+    client = _FakeClient([ready, created, polled])
+    monkeypatch.setattr(
+        smoke_test.httpx, "Client", lambda **_kwargs: _FakeClientContext(client)
+    )
+    monotonic_values = iter([0.0, 0.05, 0.2])
+    monkeypatch.setattr(smoke_test.time, "sleep", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(smoke_test.time, "monotonic", lambda: next(monotonic_values))
+
+    smoke_test.run_smoke_test(
+        smoke_test.SmokeTestConfig(
+            base_url="http://localhost:8000",
+            email="talent_partner1@local.test",
+            timeout_seconds=1,
+            poll_interval_seconds=0.1,
+        )
+    )
+
+    assert [call[0] for call in client.calls] == [
+        "/ready",
+        "/api/trials",
+        "/api/trials/9",
+    ]
+
+
+def test_main_returns_zero_on_success(monkeypatch):
+    monkeypatch.setattr(smoke_test, "run_smoke_test", lambda _config: None)
+    assert (
+        smoke_test.main(
+            [
+                "--base-url",
+                "http://localhost:8000",
+                "--email",
+                "talent_partner1@local.test",
+                "--timeout-seconds",
+                "1",
+                "--poll-interval-seconds",
+                "0.1",
+            ]
+        )
+        == 0
+    )
+
+
+def test_headers_use_dev_bypass_email():
+    assert smoke_test._headers("talent_partner1@local.test") == {
+        "x-dev-user-email": "talent_partner1@local.test"
+    }

--- a/tests/shared/http/routes/test_shared_http_health_routes.py
+++ b/tests/shared/http/routes/test_shared_http_health_routes.py
@@ -2,6 +2,7 @@ import pytest
 from httpx import AsyncClient
 
 from app.main import app
+from app.shared.http import shared_http_readiness_service as readiness_service
 
 
 @pytest.mark.asyncio
@@ -10,3 +11,105 @@ async def test_health():
         res = await ac.get("/health")
         assert res.status_code == 200
         assert res.json() == {"status": "ok"}
+
+
+@pytest.mark.asyncio
+async def test_ready_returns_200_when_all_checks_pass(monkeypatch):
+    payload = {
+        "status": "ready",
+        "checkedAt": "2026-01-01T00:00:00Z",
+        "checks": {
+            "database": {
+                "status": "ready",
+                "code": "schema_ok",
+                "detail": "ok",
+                "data": None,
+            },
+            "worker": {
+                "status": "ready",
+                "code": "heartbeat_fresh",
+                "detail": "ok",
+                "data": None,
+            },
+            "ai": {
+                "status": "ready",
+                "code": "ai_providers_ready",
+                "detail": "ok",
+                "data": None,
+            },
+            "github": {
+                "status": "skipped",
+                "code": "demo_mode",
+                "detail": "ok",
+                "data": None,
+            },
+            "email": {
+                "status": "ready",
+                "code": "provider_ready",
+                "detail": "ok",
+                "data": None,
+            },
+            "media": {
+                "status": "ready",
+                "code": "provider_ready",
+                "detail": "ok",
+                "data": None,
+            },
+        },
+    }
+
+    async def fake_build_readiness_payload(**_kwargs):
+        return payload
+
+    monkeypatch.setattr(
+        readiness_service,
+        "build_readiness_payload",
+        fake_build_readiness_payload,
+    )
+
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        res = await ac.get("/ready")
+        assert res.status_code == 200
+        assert res.json() == payload
+
+
+@pytest.mark.asyncio
+async def test_ready_returns_503_when_any_check_fails(monkeypatch):
+    payload = {
+        "status": "not_ready",
+        "checkedAt": "2026-01-01T00:00:00Z",
+        "checks": {
+            "database": {
+                "status": "not_ready",
+                "code": "schema_mismatch",
+                "detail": "missing tables",
+                "data": {"missingTables": ["trials"]},
+            }
+        },
+    }
+
+    async def fake_build_readiness_payload(**_kwargs):
+        return payload
+
+    monkeypatch.setattr(
+        readiness_service,
+        "build_readiness_payload",
+        fake_build_readiness_payload,
+    )
+
+    async with AsyncClient(app=app, base_url="http://test") as ac:
+        res = await ac.get("/ready")
+        assert res.status_code == 503
+        assert res.json() == payload
+
+
+def test_ready_openapi_uses_explicit_response_schema():
+    schema = app.openapi()["paths"]["/ready"]["get"]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"]
+    failure_schema = app.openapi()["paths"]["/ready"]["get"]["responses"]["503"][
+        "content"
+    ]["application/json"]["schema"]
+
+    assert "ReadinessPayload" in schema["$ref"]
+    assert failure_schema["$ref"] == "#/components/schemas/ReadinessPayload"

--- a/tests/shared/http/test_shared_http_readiness_service.py
+++ b/tests/shared/http/test_shared_http_readiness_service.py
@@ -1,0 +1,501 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from app.shared.http import shared_http_readiness_service as readiness_service
+
+
+class _FakeSchemaInspector:
+    def __init__(self, tables: list[str], foreign_keys: dict[str, list[dict]]):
+        self._tables = tables
+        self._foreign_keys = foreign_keys
+
+    def get_table_names(self):
+        return self._tables
+
+    def get_foreign_keys(self, table_name: str):
+        return self._foreign_keys.get(table_name, [])
+
+
+class _FakeHeartbeatSessionContext:
+    def __init__(self, db: object):
+        self._db = db
+
+    async def __aenter__(self):
+        return self._db
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+class _FakeHeartbeatSessionMaker:
+    def __init__(self, db: object | None = None):
+        self._db = db or SimpleNamespace()
+
+    def __call__(self):
+        return _FakeHeartbeatSessionContext(self._db)
+
+
+def test_inspect_schema_reports_ready_when_tables_and_fks_exist(monkeypatch):
+    inspector = _FakeSchemaInspector(
+        [
+            "candidate_sessions",
+            "jobs",
+            "scenario_versions",
+            "tasks",
+            "trials",
+            "worker_heartbeats",
+        ],
+        {
+            "candidate_sessions": [
+                {
+                    "constrained_columns": ["trial_id"],
+                    "referred_table": "trials",
+                    "referred_columns": ["id"],
+                },
+                {
+                    "constrained_columns": ["scenario_version_id"],
+                    "referred_table": "scenario_versions",
+                    "referred_columns": ["id"],
+                },
+            ],
+            "scenario_versions": [
+                {
+                    "constrained_columns": ["trial_id"],
+                    "referred_table": "trials",
+                    "referred_columns": ["id"],
+                }
+            ],
+            "tasks": [
+                {
+                    "constrained_columns": ["trial_id"],
+                    "referred_table": "trials",
+                    "referred_columns": ["id"],
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(readiness_service, "inspect", lambda _conn: inspector)
+
+    result = readiness_service._inspect_schema(object())
+
+    assert result.status == "ready"
+    assert result.code == "schema_ok"
+    assert result.detail == "Required database tables and foreign keys are present."
+
+
+def test_inspect_schema_reports_missing_table_and_fk(monkeypatch):
+    inspector = _FakeSchemaInspector(
+        ["trials", "tasks"],
+        {
+            "tasks": [
+                {
+                    "constrained_columns": ["trial_id"],
+                    "referred_table": "trials",
+                    "referred_columns": ["id"],
+                }
+            ]
+        },
+    )
+    monkeypatch.setattr(readiness_service, "inspect", lambda _conn: inspector)
+
+    result = readiness_service._inspect_schema(object())
+
+    assert result.status == "not_ready"
+    assert result.code == "schema_mismatch"
+    assert "scenario_versions" in result.data["missingTables"]
+    assert "candidate_sessions" in result.data["missingTables"]
+
+
+@pytest.mark.asyncio
+async def test_check_database_readiness_returns_specific_schema_failure(monkeypatch):
+    class _BrokenConnection:
+        async def run_sync(self, _func):
+            raise RuntimeError("schema boom")
+
+    class _BrokenContext:
+        async def __aenter__(self):
+            return _BrokenConnection()
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(
+        readiness_service,
+        "engine",
+        SimpleNamespace(connect=lambda: _BrokenContext()),
+    )
+
+    result = await readiness_service.check_database_readiness()
+
+    assert result.status == "not_ready"
+    assert result.code == "database_unavailable"
+
+
+def test_check_ai_feature_skips_demo_mode_and_handles_provider_modes(monkeypatch):
+    demo_config = SimpleNamespace(runtime_mode="demo", provider="openai")
+    test_config = SimpleNamespace(runtime_mode="test", provider="anthropic")
+    real_openai = SimpleNamespace(runtime_mode="real", provider="openai")
+    real_anthropic = SimpleNamespace(runtime_mode="real", provider="anthropic")
+    unsupported = SimpleNamespace(runtime_mode="real", provider="local")
+    monkeypatch.setattr(readiness_service.settings, "OPENAI_API_KEY", "test-openai")
+    monkeypatch.setattr(
+        readiness_service.settings, "ANTHROPIC_API_KEY", "test-anthropic"
+    )
+
+    skipped = readiness_service._check_ai_feature("scenarioGeneration", demo_config)
+    skipped_test = readiness_service._check_ai_feature("transcription", test_config)
+    openai_ready = readiness_service._check_ai_feature(
+        "codespaceSpecializer", real_openai
+    )
+    anthropic_ready = readiness_service._check_ai_feature(
+        "winoeReportAggregator", real_anthropic
+    )
+    unsupported_result = readiness_service._check_ai_feature(
+        "scenarioGeneration", unsupported
+    )
+
+    assert skipped.status == "skipped"
+    assert skipped.code == "demo_mode"
+    assert skipped_test.status == "skipped"
+    assert openai_ready.status == "ready"
+    assert anthropic_ready.status == "ready"
+    assert unsupported_result.status == "not_ready"
+    assert unsupported_result.code == "unsupported_provider"
+
+
+def test_check_ai_feature_reports_missing_provider_keys(monkeypatch):
+    monkeypatch.setattr(readiness_service.settings, "OPENAI_API_KEY", "")
+    monkeypatch.setattr(readiness_service.settings, "ANTHROPIC_API_KEY", "")
+
+    openai_missing = readiness_service._check_ai_feature(
+        "scenarioGeneration", SimpleNamespace(runtime_mode="real", provider="openai")
+    )
+    anthropic_missing = readiness_service._check_ai_feature(
+        "transcription", SimpleNamespace(runtime_mode="real", provider="anthropic")
+    )
+
+    assert openai_missing.status == "not_ready"
+    assert openai_missing.code == "no_provider_configured"
+    assert anthropic_missing.status == "not_ready"
+    assert anthropic_missing.code == "no_provider_configured"
+
+
+def test_check_github_readiness_covers_demo_and_configured_modes(monkeypatch):
+    github_cfg = SimpleNamespace(
+        GITHUB_TOKEN="",
+        GITHUB_ORG="",
+        GITHUB_TEMPLATE_OWNER="",
+        GITHUB_API_BASE="https://api.github.com",
+    )
+    monkeypatch.setattr(readiness_service.settings, "DEMO_MODE", True)
+    monkeypatch.setattr(readiness_service.settings, "github", github_cfg)
+
+    skipped = readiness_service._check_github_readiness()
+    assert skipped.status == "skipped"
+    assert skipped.code == "demo_mode"
+
+    monkeypatch.setattr(readiness_service.settings, "DEMO_MODE", False)
+    missing_token = readiness_service._check_github_readiness()
+    assert missing_token.status == "not_ready"
+    assert missing_token.code == "no_provider_configured"
+
+    monkeypatch.setattr(github_cfg, "GITHUB_TOKEN", "token")
+    missing_org = readiness_service._check_github_readiness()
+    assert missing_org.status == "not_ready"
+    assert missing_org.code == "missing_github_org"
+
+    monkeypatch.setattr(github_cfg, "GITHUB_ORG", "winoe-ai")
+    ready = readiness_service._check_github_readiness()
+    assert ready.status == "ready"
+    assert ready.code == "provider_ready"
+
+
+def test_check_email_readiness_covers_all_provider_modes(monkeypatch):
+    email_cfg = SimpleNamespace(
+        WINOE_EMAIL_PROVIDER="console",
+        WINOE_EMAIL_FROM="Winoe <notifications@winoe.com>",
+        WINOE_RESEND_API_KEY="",
+        SENDGRID_API_KEY="",
+        SMTP_HOST="",
+    )
+    monkeypatch.setattr(readiness_service.settings, "email", email_cfg)
+
+    console_ready = readiness_service._check_email_readiness()
+    assert console_ready.status == "ready"
+    assert console_ready.code == "provider_ready"
+
+    monkeypatch.setattr(email_cfg, "WINOE_EMAIL_PROVIDER", "resend")
+    resend_missing = readiness_service._check_email_readiness()
+    assert resend_missing.status == "not_ready"
+    assert resend_missing.code == "no_provider_configured"
+
+    monkeypatch.setattr(email_cfg, "WINOE_RESEND_API_KEY", "resend-key")
+    resend_ready = readiness_service._check_email_readiness()
+    assert resend_ready.status == "ready"
+
+    monkeypatch.setattr(email_cfg, "WINOE_EMAIL_PROVIDER", "sendgrid")
+    monkeypatch.setattr(email_cfg, "SENDGRID_API_KEY", "")
+    sendgrid_missing = readiness_service._check_email_readiness()
+    assert sendgrid_missing.status == "not_ready"
+    assert sendgrid_missing.code == "no_provider_configured"
+
+    monkeypatch.setattr(email_cfg, "SENDGRID_API_KEY", "sendgrid-key")
+    sendgrid_ready = readiness_service._check_email_readiness()
+    assert sendgrid_ready.status == "ready"
+
+    monkeypatch.setattr(email_cfg, "WINOE_EMAIL_PROVIDER", "smtp")
+    monkeypatch.setattr(email_cfg, "SMTP_HOST", "")
+    smtp_missing = readiness_service._check_email_readiness()
+    assert smtp_missing.status == "not_ready"
+    assert smtp_missing.code == "no_provider_configured"
+
+    monkeypatch.setattr(email_cfg, "SMTP_HOST", "smtp.local")
+    smtp_ready = readiness_service._check_email_readiness()
+    assert smtp_ready.status == "ready"
+
+    monkeypatch.setattr(email_cfg, "WINOE_EMAIL_PROVIDER", "other")
+    unsupported = readiness_service._check_email_readiness()
+    assert unsupported.status == "not_ready"
+    assert unsupported.code == "unsupported_provider"
+
+
+def test_check_media_readiness_covers_all_provider_modes(monkeypatch):
+    media_cfg = SimpleNamespace(
+        MEDIA_STORAGE_PROVIDER="fake",
+        MEDIA_S3_ENDPOINT="",
+        MEDIA_S3_BUCKET="",
+        MEDIA_S3_ACCESS_KEY_ID="",
+        MEDIA_S3_SECRET_ACCESS_KEY="",
+    )
+    monkeypatch.setattr(readiness_service.settings, "storage_media", media_cfg)
+
+    fake_ready = readiness_service._check_media_readiness()
+    assert fake_ready.status == "ready"
+    assert fake_ready.code == "provider_ready"
+
+    monkeypatch.setattr(media_cfg, "MEDIA_STORAGE_PROVIDER", "s3")
+    missing = readiness_service._check_media_readiness()
+    assert missing.status == "not_ready"
+    assert missing.code == "no_provider_configured"
+    assert "MEDIA_S3_ENDPOINT" in missing.data["missingFields"]
+
+    monkeypatch.setattr(media_cfg, "MEDIA_S3_ENDPOINT", "http://minio.local")
+    monkeypatch.setattr(media_cfg, "MEDIA_S3_BUCKET", "winoe-media")
+    monkeypatch.setattr(media_cfg, "MEDIA_S3_ACCESS_KEY_ID", "access")
+    monkeypatch.setattr(media_cfg, "MEDIA_S3_SECRET_ACCESS_KEY", "secret")
+    s3_ready = readiness_service._check_media_readiness()
+    assert s3_ready.status == "ready"
+    assert s3_ready.code == "provider_ready"
+
+    monkeypatch.setattr(media_cfg, "MEDIA_STORAGE_PROVIDER", "other")
+    unsupported = readiness_service._check_media_readiness()
+    assert unsupported.status == "not_ready"
+    assert unsupported.code == "unsupported_provider"
+
+
+@pytest.mark.asyncio
+async def test_worker_readiness_reports_missing_stopped_stale_and_fresh_heartbeat(
+    monkeypatch,
+):
+    class _SessionMaker(_FakeHeartbeatSessionMaker):
+        pass
+
+    async def fake_missing(db, *, service_name):
+        assert (
+            service_name
+            == readiness_service.heartbeat_service.DEFAULT_WORKER_SERVICE_NAME
+        )
+        return None
+
+    monkeypatch.setattr(
+        readiness_service.jobs_repo,
+        "get_latest_worker_heartbeat",
+        fake_missing,
+    )
+
+    missing = await readiness_service.check_worker_readiness(
+        session_maker=_SessionMaker()
+    )
+    assert missing.status == "not_ready"
+    assert missing.code == "heartbeat_missing"
+
+    stopped_heartbeat = SimpleNamespace(
+        service_name="winoe-worker",
+        instance_id="worker-1",
+        status=readiness_service.heartbeat_service.WORKER_HEARTBEAT_STATUS_STOPPED,
+        last_heartbeat_at=datetime.now(UTC),
+    )
+
+    async def fake_stopped(db, *, service_name):
+        return stopped_heartbeat
+
+    monkeypatch.setattr(
+        readiness_service.jobs_repo,
+        "get_latest_worker_heartbeat",
+        fake_stopped,
+    )
+
+    stopped = await readiness_service.check_worker_readiness(
+        session_maker=_SessionMaker()
+    )
+    assert stopped.status == "not_ready"
+    assert stopped.code == "heartbeat_stopped"
+
+    stale_heartbeat = SimpleNamespace(
+        service_name="winoe-worker",
+        instance_id="worker-2",
+        status="running",
+        last_heartbeat_at=datetime.now(UTC) - timedelta(seconds=300),
+    )
+
+    async def fake_stale(db, *, service_name):
+        return stale_heartbeat
+
+    monkeypatch.setattr(
+        readiness_service.jobs_repo,
+        "get_latest_worker_heartbeat",
+        fake_stale,
+    )
+    monkeypatch.setattr(
+        readiness_service.settings, "WORKER_HEARTBEAT_STALE_SECONDS", 60
+    )
+
+    stale = await readiness_service.check_worker_readiness(
+        session_maker=_SessionMaker(),
+        now=datetime.now(UTC),
+    )
+    assert stale.status == "not_ready"
+    assert stale.code == "heartbeat_stale"
+    assert stale.data["ageSeconds"] >= 300
+    assert stale.data["staleAfterSeconds"] == 60
+
+    fresh_heartbeat = SimpleNamespace(
+        service_name="winoe-worker",
+        instance_id="worker-3",
+        status="running",
+        last_heartbeat_at=datetime.now(UTC),
+    )
+
+    async def fake_fresh(db, *, service_name):
+        return fresh_heartbeat
+
+    monkeypatch.setattr(
+        readiness_service.jobs_repo,
+        "get_latest_worker_heartbeat",
+        fake_fresh,
+    )
+
+    fresh = await readiness_service.check_worker_readiness(
+        session_maker=_SessionMaker(),
+        now=datetime.now(UTC),
+    )
+    assert fresh.status == "ready"
+    assert fresh.code == "heartbeat_fresh"
+    assert fresh.data["ageSeconds"] in {0, 1}
+
+
+@pytest.mark.asyncio
+async def test_build_readiness_payload_aggregates_status_and_checked_at(monkeypatch):
+    async def ready_db():
+        return readiness_service._readiness_check(
+            status="ready", code="schema_ok", detail="ok"
+        )
+
+    async def not_ready_worker(**_kwargs):
+        return readiness_service._readiness_check(
+            status="not_ready",
+            code="heartbeat_stale",
+            detail="stale",
+            data={"ageSeconds": 200},
+        )
+
+    async def ready_ai():
+        return readiness_service._readiness_check(
+            status="ready", code="ai_providers_ready", detail="ok"
+        )
+
+    monkeypatch.setattr(readiness_service, "check_database_readiness", ready_db)
+    monkeypatch.setattr(readiness_service, "check_worker_readiness", not_ready_worker)
+    monkeypatch.setattr(readiness_service, "check_ai_readiness", ready_ai)
+    monkeypatch.setattr(
+        readiness_service,
+        "_check_github_readiness",
+        lambda: readiness_service._readiness_check(
+            status="skipped", code="demo_mode", detail="ok"
+        ),
+    )
+    monkeypatch.setattr(
+        readiness_service,
+        "_check_email_readiness",
+        lambda: readiness_service._readiness_check(
+            status="ready", code="provider_ready", detail="ok"
+        ),
+    )
+    monkeypatch.setattr(
+        readiness_service,
+        "_check_media_readiness",
+        lambda: readiness_service._readiness_check(
+            status="ready", code="provider_ready", detail="ok"
+        ),
+    )
+
+    payload = await readiness_service.build_readiness_payload(
+        now=datetime(2026, 1, 1, tzinfo=UTC)
+    )
+
+    assert payload["status"] == "not_ready"
+    assert payload["checkedAt"] == "2026-01-01T00:00:00Z"
+    assert payload["checks"]["worker"]["status"] == "not_ready"
+    assert payload["checks"]["worker"]["data"] == {"ageSeconds": 200}
+    assert payload["checks"]["github"]["status"] == "skipped"
+
+
+@pytest.mark.asyncio
+async def test_build_readiness_payload_returns_ready_when_all_checks_ready(monkeypatch):
+    async def ready_check(**_kwargs):
+        return readiness_service._readiness_check(
+            status="ready", code="provider_ready", detail="ok"
+        )
+
+    monkeypatch.setattr(readiness_service, "check_database_readiness", ready_check)
+    monkeypatch.setattr(readiness_service, "check_worker_readiness", ready_check)
+    monkeypatch.setattr(readiness_service, "check_ai_readiness", ready_check)
+    monkeypatch.setattr(
+        readiness_service,
+        "_check_github_readiness",
+        lambda: readiness_service._readiness_check(
+            status="ready", code="provider_ready", detail="ok"
+        ),
+    )
+    monkeypatch.setattr(
+        readiness_service,
+        "_check_email_readiness",
+        lambda: readiness_service._readiness_check(
+            status="ready", code="provider_ready", detail="ok"
+        ),
+    )
+    monkeypatch.setattr(
+        readiness_service,
+        "_check_media_readiness",
+        lambda: readiness_service._readiness_check(
+            status="ready", code="provider_ready", detail="ok"
+        ),
+    )
+
+    payload = await readiness_service.build_readiness_payload(
+        now=datetime(2026, 1, 1, tzinfo=UTC)
+    )
+
+    assert payload["status"] == "ready"
+    assert set(payload["checks"]) == {
+        "database",
+        "worker",
+        "ai",
+        "github",
+        "email",
+        "media",
+    }

--- a/tests/trials/services/test_trials_scenario_generation_env_service.py
+++ b/tests/trials/services/test_trials_scenario_generation_env_service.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.trials.services import (
+    trials_services_trials_scenario_generation_env_service as scenario_env_service,
+)
+
+
+def test_is_demo_mode_enabled_delegates_to_runtime_mode(monkeypatch):
+    monkeypatch.setattr(
+        scenario_env_service,
+        "resolve_scenario_generation_config",
+        lambda: SimpleNamespace(runtime_mode="demo", provider="openai"),
+    )
+
+    assert scenario_env_service.is_demo_mode_enabled() is True
+
+
+def test_llm_credentials_available_covers_provider_branches(monkeypatch):
+    monkeypatch.setattr(
+        scenario_env_service,
+        "resolve_scenario_generation_config",
+        lambda: SimpleNamespace(runtime_mode="real", provider="openai"),
+    )
+    monkeypatch.setattr(scenario_env_service.settings, "OPENAI_API_KEY", "openai-key")
+    monkeypatch.setattr(
+        scenario_env_service.settings, "ANTHROPIC_API_KEY", "anthropic-key"
+    )
+
+    assert scenario_env_service.llm_credentials_available() is True
+
+    monkeypatch.setattr(
+        scenario_env_service,
+        "resolve_scenario_generation_config",
+        lambda: SimpleNamespace(runtime_mode="real", provider="anthropic"),
+    )
+    assert scenario_env_service.llm_credentials_available() is True
+
+    monkeypatch.setattr(
+        scenario_env_service,
+        "resolve_scenario_generation_config",
+        lambda: SimpleNamespace(runtime_mode="real", provider="other"),
+    )
+    assert scenario_env_service.llm_credentials_available() is False
+
+
+def test_choose_generation_source_handles_demo_and_errors():
+    assert (
+        scenario_env_service.choose_generation_source(demo_mode_enabled=True)
+        == scenario_env_service.SCENARIO_SOURCE_TEMPLATE_FALLBACK
+    )
+    assert (
+        scenario_env_service.choose_generation_source(
+            demo_mode_enabled=False, llm_available=True
+        )
+        == scenario_env_service.SCENARIO_SOURCE_LLM
+    )
+    with pytest.raises(RuntimeError, match="scenario_generation_provider_unavailable"):
+        scenario_env_service.choose_generation_source(
+            demo_mode_enabled=False, llm_available=False
+        )


### PR DESCRIPTION
## TL;DR
- Added `GET /ready` as the operational readiness gate for Winoe AI backend runtime safety.
- Kept `GET /health` as a lightweight liveness probe only.
- `/ready` now checks database connectivity and schema sanity, worker heartbeat freshness, AI provider readiness, GitHub readiness, email readiness, and media readiness.
- Readiness failures return structured diagnostics and `503`; a ready system returns `200`.
- Added an OpenAPI contract for readiness via `ReadinessPayload`, and fixed the docs/export nit so both `200` and `503` reference the same schema cleanly.
- Added a local smoke test that verifies readiness, creates a Trial through the local/demo auth bypass path, and waits for scenario generation to reach a ready state.

## Why This Matters
This change closes an operational gap: `/health` could return `ok` even when scenario generation was effectively broken and jobs were dead-lettering. That is not a usable signal for deployment safety or local demo confidence.

The backend now exposes a real readiness gate that answers a narrower question: can this system actually support Trial creation and the async workflows that follow? That distinction matters for local development, CI-style smoke validation, and runtime monitoring.

## Scope / What Changed
### Readiness endpoint
- Added `GET /ready` in `app/shared/http/routes/shared_http_routes_health_routes.py`.
- `/ready` performs structured readiness checks instead of a single boolean health response.
- The readiness service lives in `app/shared/http/shared_http_readiness_service.py`.
- The response schema is defined in `app/shared/http/schemas/shared_http_schemas_readiness_schema.py` and exported from `app/shared/http/schemas/__init__.py`.

### Readiness checks
- Database connectivity and schema sanity.
- Worker heartbeat freshness and liveness.
- AI provider readiness.
- GitHub readiness.
- Email readiness.
- Media readiness.

### Operational behavior
- `200` when the backend is ready.
- `503` when one or more dependencies are not ready.
- Structured diagnostics are returned so failures are actionable instead of opaque.

### Local smoke test
- Added `scripts/local_demo_smoke_test.py`.
- Added `tests/scripts/test_local_demo_smoke_test.py`.
- The smoke test now verifies:
  - readiness is green,
  - Trial creation succeeds through the local/demo auth bypass path,
  - scenario generation reaches a ready state,
  - failures exit non-zero with readable diagnostics.

### Docs and contract alignment
- Updated `docs/api.md` and `README.md` so the docs match the runtime contract.
- Fixed the `/ready` docs/export nit so both `200` and `503` use the same clean `ReadinessPayload` schema reference.

### Tests
- Updated `tests/shared/http/routes/test_shared_http_health_routes.py`.
- Updated `tests/shared/http/test_shared_http_readiness_service.py`.
- Updated `tests/trials/services/test_trials_scenario_generation_env_service.py`.

## Readiness Contract Summary
- `GET /health`: liveness only.
- `GET /ready`: structured operational readiness.
- Response body: `ReadinessPayload`.
- Success: `200`.
- Not ready: `503`.
- Failure output includes specific diagnostics per subsystem so operators can see what is blocking Trial readiness.

## Smoke Test Summary
The local/demo smoke test now exercises the full path that matters for demos and runtime confidence:

1. Confirm `/ready` is green.
2. Create a Trial through the local/demo auth bypass path.
3. Wait for scenario generation to produce a ready scenario version.
4. Fail fast with clear diagnostics if any step is blocked.

This is intentionally stronger than a process-startup check. It proves the system can move from API availability to Trial readiness and async scenario generation.

## Files Changed
- `README.md`
- `app/shared/http/routes/shared_http_routes_health_routes.py`
- `app/shared/http/shared_http_readiness_service.py`
- `app/shared/http/schemas/__init__.py`
- `app/shared/http/schemas/shared_http_schemas_readiness_schema.py`
- `scripts/local_demo_smoke_test.py`
- `tests/scripts/test_local_demo_smoke_test.py`
- `tests/shared/http/routes/test_shared_http_health_routes.py`
- `tests/shared/http/test_shared_http_readiness_service.py`
- `tests/trials/services/test_trials_scenario_generation_env_service.py`
- `docs/api.md`

## Test Plan
- `./runBackend.sh migrate`
- `./runBackend.sh bootstrap-local`
- `./runBackend.sh`
- Verify both API and worker are running.
- `curl -sS http://localhost:8000/health`
- `curl -sS http://localhost:8000/ready`
- `poetry run python scripts/local_demo_smoke_test.py --base-url http://localhost:8000`
- Clean shutdown via `Ctrl-C`
- Verify persisted worker heartbeat transitions to `stopped` after shutdown.
- `poetry run python code-quality/documentation/scripts/docs_api_export.py --strict --verify-doc README.md docs/api.md`
- `poetry run pytest`

## Manual QA Evidence
- `./runBackend.sh migrate` - pass
- `./runBackend.sh bootstrap-local` - pass
- `./runBackend.sh` - pass
- Verified both API and worker were running - pass
- `curl -sS http://localhost:8000/health` - pass
- `curl -sS http://localhost:8000/ready` - pass
- `poetry run python scripts/local_demo_smoke_test.py --base-url http://localhost:8000` - pass
- Clean shutdown via `Ctrl-C` - pass
- Persisted worker heartbeat transitioned to `stopped` after shutdown - pass
- `poetry run python code-quality/documentation/scripts/docs_api_export.py --strict --verify-doc README.md docs/api.md` - pass
- `poetry run pytest` - pass
- Full suite result: `1733 passed`
- Coverage gate result: `96.01%`

## Risks / Follow-ups
- Readiness now reports the operational state accurately, but it still depends on the underlying provider integrations being configured correctly in each environment.
- The smoke test is only as reliable as the local/demo bootstrap state; if the demo data or bypass path changes, the test will need to be updated with it.
- If deployment policy changes, `/ready` should be wired into the platform's readiness gate rather than `/health`.

## Reviewer Notes
- The key behavior change is intentional: `/health` is not the operational gate anymore.
- The smoke test proves Trial creation through scenario readiness, not just process startup.
- The structured diagnostics are the main operator-facing improvement; they make failures debuggable instead of binary.
- Docs and OpenAPI are aligned with the runtime contract, including the `200` and `503` responses for `ReadinessPayload`.

Closes #279 