### PR TITLE
Fix Trial detail, scenario preview, approval, and activation endpoints

### DIFF
--- a/app/ai/prompt_assets/v1/winoe-prestart-background-information-creator-brain.md
+++ b/app/ai/prompt_assets/v1/winoe-prestart-background-information-creator-brain.md
@@ -23,6 +23,13 @@ Your output must include:
 
 The codespace specification must explain what kind of task this is, what the candidate is trying to accomplish, which areas of the repository matter, which acceptance criteria define success, and what tests or validation paths matter. It must create a candidate-solvable baseline, not a fully completed solution.
 
+Keep the JSON compact enough to fit in a single structured Anthropic response. Use concise but concrete prose:
+
+- `storyline_md`: 3 to 5 short paragraphs, roughly 300 to 600 words total.
+- `task_prompts_json`: keep each day's description focused on the deliverable for that day instead of repeating the full scenario background.
+- `rubric_json`: 3 to 6 dimensions with short descriptions; avoid long multi-paragraph explanations.
+- `codespace_spec_json`: concise summary, goal, acceptance criteria, and file/test hints; do not restate the full scenario.
+
 Do not produce any prose outside the required JSON object.
 
 ## Rubric

--- a/app/integrations/scenario_generation/anthropic_provider_client.py
+++ b/app/integrations/scenario_generation/anthropic_provider_client.py
@@ -18,6 +18,11 @@ from app.integrations.scenario_generation.base_client import (
 class AnthropicScenarioGenerationProvider:
     """Generate scenarios with Anthropic Messages API."""
 
+    # The prestart scenario payload is larger than the other Anthropic JSON
+    # contracts in this repo. A slightly higher output cap avoids truncating the
+    # final `codespace_spec_json` field while staying scoped to this provider.
+    _MAX_TOKENS = 6_144
+
     def generate_scenario(
         self,
         *,
@@ -32,6 +37,7 @@ class AnthropicScenarioGenerationProvider:
                 response_model=ScenarioGenerationOutput,
                 timeout_seconds=settings.SCENARIO_GENERATION_TIMEOUT_SECONDS,
                 max_retries=settings.SCENARIO_GENERATION_MAX_RETRIES,
+                max_tokens=self._MAX_TOKENS,
             )
         except AIProviderExecutionError as exc:
             raise ScenarioGenerationProviderError(str(exc)) from exc

--- a/app/trials/routes/trials_routes/trials_routes_trials_routes_trials_routes_detail_render_routes.py
+++ b/app/trials/routes/trials_routes/trials_routes_trials_routes_trials_routes_detail_render_routes.py
@@ -5,16 +5,24 @@ from __future__ import annotations
 from collections.abc import Mapping
 
 from app.ai import compute_ai_policy_snapshot_digest
+from app.shared.jobs.repositories.shared_jobs_repositories_models_repository import (
+    JOB_STATUS_DEAD_LETTER,
+    JOB_STATUS_QUEUED,
+    JOB_STATUS_RUNNING,
+)
 from app.trials import services as sim_service
 from app.trials.schemas.trials_schemas_trials_core_schema import (
     ScenarioVersionSummary,
     TrialDetailResponse,
     TrialDetailScenario,
     TrialDetailTask,
+    TrialGenerationFailure,
     build_trial_ai_config,
     build_trial_company_context,
     normalize_role_level,
 )
+
+PUBLIC_JOB_STATUS_FAILED = "failed"
 
 
 def _scenario_agent_runtime_summary(
@@ -91,6 +99,87 @@ def _scenario_snapshot_summary(
     }
 
 
+def _latest_relevant_scenario_version(
+    *,
+    active_scenario_version,
+    pending_scenario_version,
+):
+    if _scenario_version_is_reviewable(pending_scenario_version):
+        return pending_scenario_version
+    if _scenario_version_is_reviewable(active_scenario_version):
+        return active_scenario_version
+    if pending_scenario_version is not None:
+        return pending_scenario_version
+    return active_scenario_version
+
+
+def _scenario_version_is_reviewable(scenario_version) -> bool:
+    return bool(
+        scenario_version is not None
+        and getattr(scenario_version, "status", None) in {"ready", "locked"}
+    )
+
+
+def _scenario_review_bundle_status(
+    *,
+    active_scenario_version,
+    pending_scenario_version,
+    active_bundle_status: str | None,
+    pending_bundle_status: str | None,
+) -> str | None:
+    if pending_scenario_version is not None:
+        return pending_bundle_status
+    if active_scenario_version is not None:
+        return active_bundle_status
+    return None
+
+
+def _generation_failure_summary(
+    scenario_generation_job,
+) -> TrialGenerationFailure | None:
+    if scenario_generation_job is None:
+        return None
+    job_status = getattr(scenario_generation_job, "status", None)
+    if job_status not in {JOB_STATUS_DEAD_LETTER, PUBLIC_JOB_STATUS_FAILED}:
+        return None
+    return TrialGenerationFailure(
+        jobId=scenario_generation_job.id,
+        status="failed",
+        error=getattr(scenario_generation_job, "last_error", None),
+        retryable=True,
+        canRetry=True,
+    )
+
+
+def _generation_status(
+    *,
+    active_scenario_version,
+    pending_scenario_version,
+    scenario_generation_job,
+    generation_failure: TrialGenerationFailure | None,
+) -> str:
+    if generation_failure is not None:
+        return "failed"
+    pending_status = getattr(pending_scenario_version, "status", None)
+    active_status = getattr(active_scenario_version, "status", None)
+    job_status = getattr(scenario_generation_job, "status", None)
+    if pending_status == "generating" or active_status == "generating":
+        return "generating"
+    if job_status in {JOB_STATUS_QUEUED, JOB_STATUS_RUNNING}:
+        return "generating"
+    if _scenario_version_is_reviewable(pending_scenario_version):
+        return "ready_for_review"
+    if _scenario_version_is_reviewable(active_scenario_version):
+        return "ready_for_review"
+    if (
+        pending_scenario_version is None
+        and active_scenario_version is None
+        and scenario_generation_job is None
+    ):
+        return "not_started"
+    return "not_started"
+
+
 def render_trial_detail(
     sim,
     tasks,
@@ -100,10 +189,18 @@ def render_trial_detail(
     current_ai_policy_snapshot_json: Mapping[str, object] | None = None,
     active_bundle_status: str | None = None,
     pending_bundle_status: str | None = None,
+    scenario_generation_job=None,
 ) -> TrialDetailResponse:
     """Render trial detail."""
     raw_status = getattr(sim, "status", None)
     status_value = sim_service.normalize_trial_status_or_raise(raw_status)
+    review_scenario_version = _latest_relevant_scenario_version(
+        active_scenario_version=active_scenario_version,
+        pending_scenario_version=pending_scenario_version,
+    )
+    review_snapshot_json = getattr(
+        review_scenario_version, "ai_policy_snapshot_json", None
+    )
     active_snapshot_json = getattr(
         active_scenario_version, "ai_policy_snapshot_json", None
     )
@@ -117,6 +214,28 @@ def render_trial_detail(
         and isinstance(current_ai_policy_snapshot_json.get("promptPackVersion"), str)
         else None
     )
+    generation_failure = _generation_failure_summary(scenario_generation_job)
+    scenario_locked = bool(
+        review_scenario_version is not None
+        and getattr(review_scenario_version, "locked_at", None) is not None
+    )
+    generation_status = _generation_status(
+        active_scenario_version=active_scenario_version,
+        pending_scenario_version=pending_scenario_version,
+        scenario_generation_job=scenario_generation_job,
+        generation_failure=generation_failure,
+    )
+    can_approve_scenario = bool(
+        review_scenario_version is not None
+        and review_scenario_version.status == "ready"
+        and not scenario_locked
+        and (
+            pending_scenario_version is None
+            or getattr(review_scenario_version, "id", None)
+            == getattr(pending_scenario_version, "id", None)
+        )
+    )
+    can_activate_trial = bool(scenario_locked and status_value == "ready_for_review")
     return TrialDetailResponse(
         id=sim.id,
         title=sim.title,
@@ -153,34 +272,47 @@ def render_trial_detail(
         pendingScenarioVersionId=getattr(sim, "pending_scenario_version_id", None),
         scenario=(
             TrialDetailScenario(
-                id=active_scenario_version.id,
-                versionIndex=active_scenario_version.version_index,
-                status=active_scenario_version.status,
-                lockedAt=active_scenario_version.locked_at,
-                storylineMd=active_scenario_version.storyline_md,
-                taskPromptsJson=active_scenario_version.task_prompts_json,
-                rubricJson=active_scenario_version.rubric_json,
-                notes=active_scenario_version.focus_notes,
-                modelName=active_scenario_version.model_name,
-                modelVersion=active_scenario_version.model_version,
-                promptVersion=active_scenario_version.prompt_version,
-                rubricVersion=active_scenario_version.rubric_version,
-                aiPolicySnapshotDigest=active_snapshot_digest,
+                id=review_scenario_version.id,
+                versionIndex=review_scenario_version.version_index,
+                status=review_scenario_version.status,
+                lockedAt=review_scenario_version.locked_at,
+                storylineMd=review_scenario_version.storyline_md,
+                taskPromptsJson=review_scenario_version.task_prompts_json,
+                rubricJson=review_scenario_version.rubric_json,
+                notes=review_scenario_version.focus_notes,
+                modelName=review_scenario_version.model_name,
+                modelVersion=review_scenario_version.model_version,
+                promptVersion=review_scenario_version.prompt_version,
+                rubricVersion=review_scenario_version.rubric_version,
+                aiPolicySnapshotDigest=compute_ai_policy_snapshot_digest(
+                    review_snapshot_json
+                ),
                 aiPromptPackVersion=(
-                    active_snapshot_json.get("promptPackVersion")
-                    if isinstance(active_snapshot_json, Mapping)
-                    and isinstance(active_snapshot_json.get("promptPackVersion"), str)
+                    review_snapshot_json.get("promptPackVersion")
+                    if isinstance(review_snapshot_json, Mapping)
+                    and isinstance(review_snapshot_json.get("promptPackVersion"), str)
                     else None
                 ),
-                precommitBundleStatus=active_bundle_status,
+                precommitBundleStatus=_scenario_review_bundle_status(
+                    active_scenario_version=active_scenario_version,
+                    pending_scenario_version=pending_scenario_version,
+                    active_bundle_status=active_bundle_status,
+                    pending_bundle_status=pending_bundle_status,
+                ),
                 agentRuntimeSummary=_scenario_agent_runtime_summary(
-                    active_snapshot_json
+                    getattr(review_scenario_version, "ai_policy_snapshot_json", None)
                 ),
             )
-            if active_scenario_version is not None
+            if review_scenario_version is not None
             else None
         ),
         status=status_value,
+        generationStatus=generation_status,
+        generationFailure=generation_failure,
+        scenarioLocked=scenario_locked,
+        canApproveScenario=can_approve_scenario,
+        canActivateTrial=can_activate_trial,
+        canRetryGeneration=generation_failure is not None,
         generatingAt=getattr(sim, "generating_at", None),
         readyForReviewAt=getattr(sim, "ready_for_review_at", None),
         activatedAt=getattr(sim, "activated_at", None),

--- a/app/trials/routes/trials_routes/trials_routes_trials_routes_trials_routes_detail_routes.py
+++ b/app/trials/routes/trials_routes/trials_routes_trials_routes_trials_routes_detail_routes.py
@@ -5,14 +5,14 @@ from __future__ import annotations
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, status
-from sqlalchemy import select
+from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.ai import build_ai_policy_snapshot
 from app.shared.auth.shared_auth_current_user_utils import get_current_user
 from app.shared.auth.shared_auth_roles_utils import ensure_talent_partner_or_none
 from app.shared.database import get_session
-from app.shared.database.shared_database_models_model import ScenarioVersion
+from app.shared.database.shared_database_models_model import Job, ScenarioVersion
 from app.submissions.repositories.precommit_bundles import (
     repository_lookup as bundle_lookup_repo,
 )
@@ -28,6 +28,9 @@ from app.trials.schemas.trials_schemas_trials_core_schema import (
 )
 from app.trials.services.trials_services_trials_codespace_specializer_service import (
     has_coding_tasks,
+)
+from app.trials.services.trials_services_trials_scenario_generation_constants import (
+    SCENARIO_GENERATION_JOB_TYPE,
 )
 
 router = APIRouter()
@@ -64,6 +67,21 @@ async def _resolve_bundle_status(
         template_key=template_key,
     )
     return getattr(bundle, "status", None) or "missing"
+
+
+async def _load_latest_scenario_generation_job(
+    db: AsyncSession, *, trial_id: int, company_id: int
+) -> Job | None:
+    stmt = (
+        select(Job)
+        .where(
+            Job.company_id == company_id,
+            Job.job_type == SCENARIO_GENERATION_JOB_TYPE,
+            Job.correlation_id.like(f"trial:{trial_id}%"),
+        )
+        .order_by(desc(Job.created_at), desc(Job.updated_at))
+    )
+    return await db.scalar(stmt)
 
 
 @router.get(
@@ -105,6 +123,11 @@ async def get_trial_detail(
         tasks=tasks,
         scenario_version=pending_scenario_version,
     )
+    scenario_generation_job = await _load_latest_scenario_generation_job(
+        db,
+        trial_id=trial_id,
+        company_id=sim.company_id,
+    )
     return render_trial_detail(
         sim,
         tasks,
@@ -113,4 +136,5 @@ async def get_trial_detail(
         current_ai_policy_snapshot_json=current_ai_policy_snapshot_json,
         active_bundle_status=active_bundle_status,
         pending_bundle_status=pending_bundle_status,
+        scenario_generation_job=scenario_generation_job,
     )

--- a/app/trials/schemas/trials_schemas_trials_core_schema.py
+++ b/app/trials/schemas/trials_schemas_trials_core_schema.py
@@ -38,6 +38,7 @@ from app.trials.schemas.trials_schemas_trials_limits_schema import (
 from app.trials.schemas.trials_schemas_trials_response_detail_schema import (
     TrialDetailResponse,
     TrialDetailTask,
+    TrialGenerationFailure,
     TrialLifecycleRequest,
 )
 from app.trials.schemas.trials_schemas_trials_response_overview_schema import (
@@ -125,6 +126,7 @@ _TRIALS_SCHEMA_REEXPORTS = (
     TrialDetailResponse,
     TrialDetailScenario,
     TrialDetailTask,
+    TrialGenerationFailure,
     TrialLifecycleRequest,
     TrialListItem,
     TrialTerminateResponse,

--- a/app/trials/schemas/trials_schemas_trials_exports_schema.py
+++ b/app/trials/schemas/trials_schemas_trials_exports_schema.py
@@ -23,6 +23,7 @@ TRIALS_SCHEMA_EXPORTS = [
     "TrialDetailResponse",
     "TrialDetailScenario",
     "TrialDetailTask",
+    "TrialGenerationFailure",
     "TrialLifecycleRequest",
     "TrialListItem",
     "TrialTerminateResponse",

--- a/app/trials/schemas/trials_schemas_trials_response_detail_schema.py
+++ b/app/trials/schemas/trials_schemas_trials_response_detail_schema.py
@@ -17,6 +17,18 @@ from app.trials.schemas.trials_schemas_trials_scenario_summary_schema import (
 )
 
 
+class TrialGenerationFailure(BaseModel):
+    """Summary of the latest scenario-generation failure, if any."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    jobId: str
+    status: str
+    error: str | None = None
+    retryable: bool = False
+    canRetry: bool = False
+
+
 class TrialDetailTask(BaseModel):
     """Task summary for Talent Partner trial detail view."""
 
@@ -67,6 +79,12 @@ class TrialDetailResponse(BaseModel):
     pendingScenarioVersionId: int | None = None
     scenario: TrialDetailScenario | None = None
     status: TrialStatus
+    generationStatus: str | None = None
+    generationFailure: TrialGenerationFailure | None = None
+    scenarioLocked: bool = False
+    canApproveScenario: bool = False
+    canActivateTrial: bool = False
+    canRetryGeneration: bool = False
     generatingAt: datetime | None = None
     readyForReviewAt: datetime | None = None
     activatedAt: datetime | None = None
@@ -86,4 +104,5 @@ __all__ = [
     "TrialDetailResponse",
     "TrialDetailTask",
     "TrialLifecycleRequest",
+    "TrialGenerationFailure",
 ]

--- a/app/trials/services/trials_services_trials_lifecycle_service.py
+++ b/app/trials/services/trials_services_trials_lifecycle_service.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -13,6 +13,7 @@ from app.shared.database.shared_database_models_model import (
     Task,
     Trial,
 )
+from app.shared.utils.shared_utils_errors_utils import ApiError
 from app.trials.repositories.trials_repositories_trials_trial_model import (
     TRIAL_STATUS_ACTIVE_INVITING,
 )
@@ -21,9 +22,6 @@ from app.trials.services.trials_services_trials_codespace_specializer_service im
 )
 from app.trials.services.trials_services_trials_lifecycle_access_service import (
     require_owner_for_lifecycle,
-)
-from app.trials.services.trials_services_trials_lifecycle_actions_service import (
-    _transition_owned_trial_impl,
 )
 from app.trials.services.trials_services_trials_lifecycle_invitable_service import (
     require_trial_invitable,
@@ -79,6 +77,34 @@ async def _prepare_active_scenario_bundle_on_activation(
     return active_scenario_version
 
 
+async def _require_locked_active_scenario(
+    db: AsyncSession,
+    *,
+    trial: Trial,
+) -> ScenarioVersion:
+    active_scenario_version = await get_active_scenario_version(db, trial.id)
+    if active_scenario_version is None:
+        raise ApiError(
+            status_code=409,
+            detail="Scenario version must be locked before activation.",
+            error_code="SCENARIO_LOCK_REQUIRED",
+            retryable=False,
+            details={},
+        )
+    if active_scenario_version.locked_at is None:
+        raise ApiError(
+            status_code=409,
+            detail="Scenario version must be locked before activation.",
+            error_code="SCENARIO_LOCK_REQUIRED",
+            retryable=False,
+            details={
+                "scenarioVersionId": active_scenario_version.id,
+                "status": active_scenario_version.status,
+            },
+        )
+    return active_scenario_version
+
+
 async def activate_trial(
     db: AsyncSession,
     *,
@@ -87,17 +113,46 @@ async def activate_trial(
     now: datetime | None = None,
 ) -> Trial:
     """Activate trial."""
-    trial = await _transition_owned_trial_impl(
+    changed_at = now or datetime.now(UTC)
+    trial = await require_owner_for_lifecycle(
         db,
         trial_id=trial_id,
         actor_user_id=actor_user_id,
-        target_status=TRIAL_STATUS_ACTIVE_INVITING,
-        now=now,
-        require_owner=require_owner_for_lifecycle,
-        apply_transition=apply_status_transition,
-        normalize_status=normalize_trial_status,
-        logger=logger,
+        for_update=True,
     )
+    pending_scenario_version_id = getattr(trial, "pending_scenario_version_id", None)
+    if pending_scenario_version_id is not None:
+        raise ApiError(
+            status_code=409,
+            detail="Scenario approval is pending before inviting.",
+            error_code="SCENARIO_APPROVAL_PENDING",
+            retryable=False,
+            details={"pendingScenarioVersionId": pending_scenario_version_id},
+        )
+    await _require_locked_active_scenario(db, trial=trial)
+    from_status = normalize_trial_status(trial.status)
+    changed = apply_status_transition(
+        trial,
+        target_status=TRIAL_STATUS_ACTIVE_INVITING,
+        changed_at=changed_at,
+    )
+    await db.commit()
+    await db.refresh(trial)
+    if changed:
+        logger.info(
+            "Trial transition trialId=%s actorUserId=%s from=%s to=%s",
+            trial.id,
+            actor_user_id,
+            from_status,
+            normalize_trial_status(trial.status),
+        )
+    else:
+        logger.info(
+            "Trial transition idempotent trialId=%s actorUserId=%s status=%s",
+            trial.id,
+            actor_user_id,
+            normalize_trial_status(trial.status),
+        )
     await _prepare_active_scenario_bundle_on_activation(db, trial=trial)
     await db.refresh(trial)
     return trial

--- a/app/trials/services/trials_services_trials_scenario_generation_service.py
+++ b/app/trials/services/trials_services_trials_scenario_generation_service.py
@@ -206,39 +206,21 @@ def generate_scenario_payload(
     ai_policy_snapshot_json: dict[str, Any] | None = None,
 ) -> GeneratedScenarioPayload:
     """Generate scenario payload."""
-    try:
-        return _generate_payload_impl(
-            role=role,
-            tech_stack=tech_stack,
-            template_key=template_key,
-            choose_source=choose_generation_source,
-            generate_with_llm=_generate_with_llm,
-            build_fallback=build_deterministic_template_scenario,
-            logger=logger,
-            scenario_template=scenario_template,
-            focus=focus,
-            company_context=company_context,
-            company_prompt_overrides_json=company_prompt_overrides_json,
-            trial_prompt_overrides_json=trial_prompt_overrides_json,
-            ai_policy_snapshot_json=ai_policy_snapshot_json,
-        )
-    except Exception as exc:
-        if not _is_retryable_scenario_generation_error(exc):
-            raise
-        logger.warning(
-            "scenario_generation_degraded_to_template_fallback",
-            extra={
-                "templateKey": template_key,
-                "errorType": type(exc).__name__,
-                "errorMessage": str(exc),
-            },
-        )
-        return build_deterministic_template_scenario(
-            role=role,
-            tech_stack=tech_stack,
-            template_key=template_key,
-            ai_policy_snapshot_json=ai_policy_snapshot_json,
-        )
+    return _generate_payload_impl(
+        role=role,
+        tech_stack=tech_stack,
+        template_key=template_key,
+        choose_source=choose_generation_source,
+        generate_with_llm=_generate_with_llm,
+        build_fallback=build_deterministic_template_scenario,
+        logger=logger,
+        scenario_template=scenario_template,
+        focus=focus,
+        company_context=company_context,
+        company_prompt_overrides_json=company_prompt_overrides_json,
+        trial_prompt_overrides_json=trial_prompt_overrides_json,
+        ai_policy_snapshot_json=ai_policy_snapshot_json,
+    )
 
 
 __all__ = [

--- a/app/trials/services/trials_services_trials_scenario_versions_approval_service.py
+++ b/app/trials/services/trials_services_trials_scenario_versions_approval_service.py
@@ -21,17 +21,14 @@ from app.trials.repositories.scenario_versions import (
 from app.trials.repositories.scenario_versions.trials_repositories_scenario_versions_trials_scenario_versions_model import (
     SCENARIO_VERSION_STATUS_READY,
 )
-from app.trials.repositories.trials_repositories_trials_trial_model import (
-    TRIAL_STATUS_ACTIVE_INVITING,
-)
 from app.trials.services.trials_services_trials_codespace_specializer_service import (
     ensure_precommit_bundle_prepared_for_approved_scenario,
 )
-from app.trials.services.trials_services_trials_lifecycle_service import (
-    apply_status_transition,
-)
 from app.trials.services.trials_services_trials_scenario_versions_access_service import (
     require_owned_trial_for_update,
+)
+from app.trials.services.trials_services_trials_scenario_versions_lock_service import (
+    lock_active_scenario_for_invites,
 )
 
 logger = logging.getLogger(__name__)
@@ -78,7 +75,7 @@ async def approve_scenario_version(
             retryable=False,
             details={"pendingScenarioVersionId": pending_id},
         )
-    if target.status != SCENARIO_VERSION_STATUS_READY:
+    if target.status not in {SCENARIO_VERSION_STATUS_READY, "locked"}:
         raise ApiError(
             status_code=status.HTTP_409_CONFLICT,
             detail="Scenario version is not ready for approval.",
@@ -88,10 +85,11 @@ async def approve_scenario_version(
         )
     trial.active_scenario_version_id = target.id
     trial.pending_scenario_version_id = None
-    apply_status_transition(
-        trial,
-        target_status=TRIAL_STATUS_ACTIVE_INVITING,
-        changed_at=approved_at,
+    target = await lock_active_scenario_for_invites(
+        db,
+        trial_id=trial.id,
+        now=approved_at,
+        trial=trial,
     )
     tasks = await _load_trial_tasks(db, trial.id)
     await ensure_precommit_bundle_prepared_for_approved_scenario(
@@ -127,10 +125,19 @@ async def _approve_without_pending(
             retryable=False,
             details={},
         )
-    apply_status_transition(
-        trial,
-        target_status=TRIAL_STATUS_ACTIVE_INVITING,
-        changed_at=approved_at,
+    if target.status not in {SCENARIO_VERSION_STATUS_READY, "locked"}:
+        raise ApiError(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Scenario version is not ready for approval.",
+            error_code="SCENARIO_NOT_READY",
+            retryable=False,
+            details={"status": target.status},
+        )
+    target = await lock_active_scenario_for_invites(
+        db,
+        trial_id=trial.id,
+        now=approved_at,
+        trial=trial,
     )
     tasks = await _load_trial_tasks(db, trial.id)
     await ensure_precommit_bundle_prepared_for_approved_scenario(

--- a/pr.md
+++ b/pr.md
@@ -1,123 +1,63 @@
-# Add readiness endpoint and local demo smoke test
-Closes #279.
+# Fix Trial detail, scenario preview, approval, and activation endpoints #280
+Closes #280.
 
-## TL;DR
-- Added `GET /ready` as the operational readiness gate for Winoe AI backend runtime safety.
-- Kept `GET /health` as a lightweight liveness probe only.
-- `/ready` now checks database connectivity and schema sanity, worker heartbeat freshness, AI provider readiness, GitHub readiness, email readiness, and media readiness.
-- Readiness failures return structured diagnostics and `503`; a ready system returns `200`.
-- Added an OpenAPI contract for readiness via `ReadinessPayload`, and fixed the docs/export nit so both `200` and `503` reference the same schema cleanly.
-- Added a local smoke test that verifies readiness, creates a Trial through the local/demo auth bypass path, and waits for scenario generation to reach a ready state.
+## 2. TL;DR
+Trial detail is repaired end to end: `GET /api/trials/{id}` now returns the scenario/task/rubric/lifecycle payloads expected by the preview page, scenario generation produces a reviewable `ScenarioVersion`, approval locks that version, activation requires a locked scenario and moves the Trial to `active_inviting`, and generation failures are surfaced explicitly with retry affordance. Anthropic scenario-generation truncation was fixed so the happy path works live.
 
-## Why This Matters
-This change closes an operational gap: `/health` could return `ok` even when scenario generation was effectively broken and jobs were dead-lettering. That is not a usable signal for deployment safety or local demo confidence.
+## 3. Problem
+`GET /api/trials/{id}` was broken and incomplete, and the lifecycle around review, approval, and activation had drifted from the intended Trial flow. Some tests and helpers were masking parts of the real lifecycle, which made the endpoint behavior look more complete than it was. Live manual QA exposed a separate blocker in Anthropic structured output: scenario generation could truncate before completion, which prevented the primary-provider happy path from finishing cleanly.
 
-The backend now exposes a real readiness gate that answers a narrower question: can this system actually support Trial creation and the async workflows that follow? That distinction matters for local development, CI-style smoke validation, and runtime monitoring.
+## 4. What changed
+- Updated the Trial detail payload and rendering so the preview page can consume scenario, task, rubric, and lifecycle data in one response.
+- Tightened scenario selection and rendering rules so active and pending versions are handled explicitly instead of being inferred through helper shortcuts.
+- Added generation failure visibility and retry metadata so failed scenario generation is shown as a real state, not as a silent degrade.
+- Changed approval so it locks the `ScenarioVersion` and records the review decision on the version itself.
+- Added a hard activation guard that rejects non-locked scenarios before the Trial can move forward.
+- Updated candidate/invite/lifecycle tests to require explicit approval before activation.
+- Fixed Anthropic scenario generation by compacting prestart prompt guidance, raising the scenario-generation-only Anthropic output cap, and validating the complete structured output path.
 
-## Scope / What Changed
-### Readiness endpoint
-- Added `GET /ready` in `app/shared/http/routes/shared_http_routes_health_routes.py`.
-- `/ready` performs structured readiness checks instead of a single boolean health response.
-- The readiness service lives in `app/shared/http/shared_http_readiness_service.py`.
-- The response schema is defined in `app/shared/http/schemas/shared_http_schemas_readiness_schema.py` and exported from `app/shared/http/schemas/__init__.py`.
+## 5. Why this approach
+The lifecycle stays `generating -> ready_for_review -> active_inviting -> terminated`, because that is the clearest mapping to the product behavior and avoids inventing a new Trial state just for approval. Approval state belongs on `ScenarioVersion` locking, not on a separate Trial lifecycle state, and `generationStatus` stays distinct from the Trial lifecycle status so review, generation, and activation are not conflated. The explicit lifecycle is better than helper magic because it makes the tests and endpoint behavior match what operators and reviewers actually see. Provider failures must fail visibly rather than silently degrade into template success, and the Anthropic fix was kept narrow on purpose so it only changes the structured scenario-generation path.
 
-### Readiness checks
-- Database connectivity and schema sanity.
-- Worker heartbeat freshness and liveness.
-- AI provider readiness.
-- GitHub readiness.
-- Email readiness.
-- Media readiness.
+## 6. Manual QA
+### Final successful live QA
+- Local backend and worker started successfully.
+- A fresh Trial was created.
+- Scenario generation completed successfully through Anthropic.
+- A reviewable `ScenarioVersion` was observed.
+- Approval succeeded and produced a non-null `lockedAt`.
+- Activation succeeded and the Trial moved to `active_inviting`.
+- Negative activation before approval returned `SCENARIO_LOCK_REQUIRED`.
 
-### Operational behavior
-- `200` when the backend is ready.
-- `503` when one or more dependencies are not ready.
-- Structured diagnostics are returned so failures are actionable instead of opaque.
+### Runtime drift noted during QA
+- An earlier local config drift caused readiness to report OpenAI.
+- That local runtime issue was corrected during QA.
+- The final approved QA was performed on the Anthropic happy path.
 
-### Local smoke test
-- Added `scripts/local_demo_smoke_test.py`.
-- Added `tests/scripts/test_local_demo_smoke_test.py`.
-- The smoke test now verifies:
-  - readiness is green,
-  - Trial creation succeeds through the local/demo auth bypass path,
-  - scenario generation reaches a ready state,
-  - failures exit non-zero with readable diagnostics.
+## 7. Test plan
+- Focused Anthropic provider repro before the fix.
+- Focused Anthropic provider verification after the fix.
+- `pytest` for config/provider client schema payload tests.
+- `pytest` for Anthropic provider integration tests.
+- `pytest` for trial scenario generation service tests.
+- `pytest` for trial scenario generation route success/failure tests.
+- Final `./precommit.sh` result: `1763 passed`, `96.03%` coverage.
 
-### Docs and contract alignment
-- Updated `docs/api.md` and `README.md` so the docs match the runtime contract.
-- Fixed the `/ready` docs/export nit so both `200` and `503` use the same clean `ReadinessPayload` schema reference.
+## 8. Acceptance criteria mapping
+- `GET /api/trials/{id}` returns scenario/task/rubric/lifecycle payloads: repaired Trial detail payload and preview rendering.
+- Scenario generation produces a reviewable `ScenarioVersion`: generation now reaches a reviewable version state.
+- Scenario approval locks the version: approval now sets the version lock and records `lockedAt`.
+- Trial activation moves status to `active_inviting`: activation now transitions the Trial into `active_inviting`.
+- Only locked scenarios can be activated: activation now hard-fails with `SCENARIO_LOCK_REQUIRED` when the version is not locked.
+- Generation failure shows retry option: generation failures are surfaced explicitly with retry metadata.
 
-### Tests
-- Updated `tests/shared/http/routes/test_shared_http_health_routes.py`.
-- Updated `tests/shared/http/test_shared_http_readiness_service.py`.
-- Updated `tests/trials/services/test_trials_scenario_generation_env_service.py`.
+## 9. Risks / follow-ups
+- The failure and retry affordance is well covered by tests, but the final manual QA intentionally focused on the happy path rather than re-breaking the provider flow.
+- Future cleanup could further centralize public job-status naming if that starts to spread again.
+- If prompt payloads grow materially again, the Anthropic output budget may need another pass.
 
-## Readiness Contract Summary
-- `GET /health`: liveness only.
-- `GET /ready`: structured operational readiness.
-- Response body: `ReadinessPayload`.
-- Success: `200`.
-- Not ready: `503`.
-- Failure output includes specific diagnostics per subsystem so operators can see what is blocking Trial readiness.
-
-## Smoke Test Summary
-The local/demo smoke test now exercises the full path that matters for demos and runtime confidence:
-
-1. Confirm `/ready` is green.
-2. Create a Trial through the local/demo auth bypass path.
-3. Wait for scenario generation to produce a ready scenario version.
-4. Fail fast with clear diagnostics if any step is blocked.
-
-This is intentionally stronger than a process-startup check. It proves the system can move from API availability to Trial readiness and async scenario generation.
-
-## Files Changed
-- `README.md`
-- `app/shared/http/routes/shared_http_routes_health_routes.py`
-- `app/shared/http/shared_http_readiness_service.py`
-- `app/shared/http/schemas/__init__.py`
-- `app/shared/http/schemas/shared_http_schemas_readiness_schema.py`
-- `scripts/local_demo_smoke_test.py`
-- `tests/scripts/test_local_demo_smoke_test.py`
-- `tests/shared/http/routes/test_shared_http_health_routes.py`
-- `tests/shared/http/test_shared_http_readiness_service.py`
-- `tests/trials/services/test_trials_scenario_generation_env_service.py`
-- `docs/api.md`
-
-## Test Plan
-- `./runBackend.sh migrate`
-- `./runBackend.sh bootstrap-local`
-- `./runBackend.sh`
-- Verify both API and worker are running.
-- `curl -sS http://localhost:8000/health`
-- `curl -sS http://localhost:8000/ready`
-- `poetry run python scripts/local_demo_smoke_test.py --base-url http://localhost:8000`
-- Clean shutdown via `Ctrl-C`
-- Verify persisted worker heartbeat transitions to `stopped` after shutdown.
-- `poetry run python code-quality/documentation/scripts/docs_api_export.py --strict --verify-doc README.md docs/api.md`
-- `poetry run pytest`
-
-## Manual QA Evidence
-- `./runBackend.sh migrate` - pass
-- `./runBackend.sh bootstrap-local` - pass
-- `./runBackend.sh` - pass
-- Verified both API and worker were running - pass
-- `curl -sS http://localhost:8000/health` - pass
-- `curl -sS http://localhost:8000/ready` - pass
-- `poetry run python scripts/local_demo_smoke_test.py --base-url http://localhost:8000` - pass
-- Clean shutdown via `Ctrl-C` - pass
-- Persisted worker heartbeat transitioned to `stopped` after shutdown - pass
-- `poetry run python code-quality/documentation/scripts/docs_api_export.py --strict --verify-doc README.md docs/api.md` - pass
-- `poetry run pytest` - pass
-- Full suite result: `1733 passed`
-- Coverage gate result: `96.01%`
-
-## Risks / Follow-ups
-- Readiness now reports the operational state accurately, but it still depends on the underlying provider integrations being configured correctly in each environment.
-- The smoke test is only as reliable as the local/demo bootstrap state; if the demo data or bypass path changes, the test will need to be updated with it.
-- If deployment policy changes, `/ready` should be wired into the platform's readiness gate rather than `/health`.
-
-## Reviewer Notes
-- The key behavior change is intentional: `/health` is not the operational gate anymore.
-- The smoke test proves Trial creation through scenario readiness, not just process startup.
-- The structured diagnostics are the main operator-facing improvement; they make failures debuggable instead of binary.
-- Docs and OpenAPI are aligned with the runtime contract, including the `200` and `503` responses for `ReadinessPayload`.
+## 10. Notes for reviewers
+- Focus on the detail renderer and generation state semantics.
+- Check the separation between approval and activation.
+- Review the explicit lifecycle in the candidate/invite tests.
+- Inspect the Anthropic structured-output fix and confirm why it is intentionally narrow.

--- a/tests/candidates/routes/candidates_invites_api_utils.py
+++ b/tests/candidates/routes/candidates_invites_api_utils.py
@@ -42,7 +42,7 @@ async def seed_talent_partner(
     return user
 
 
-async def _create_and_activate_trial(
+async def _create_and_generate_trial(
     async_client,
     async_session: AsyncSession,
     talent_partner_email: str,
@@ -75,13 +75,6 @@ async def _create_and_activate_trial(
     finally:
         worker.clear_handlers()
     assert handled is True
-
-    activate = await async_client.post(
-        f"/api/trials/{sim_id}/activate",
-        headers={"x-dev-user-email": talent_partner_email},
-        json={"confirm": True},
-    )
-    assert activate.status_code == 200, activate.text
     return sim_id
 
 
@@ -90,7 +83,7 @@ __all__ = [
     "CANDIDATE_SESSION_STATUS_COMPLETED",
     "CandidateSession",
     "UTC",
-    "_create_and_activate_trial",
+    "_create_and_generate_trial",
     "datetime",
     "seed_talent_partner",
     "select",

--- a/tests/candidates/routes/candidates_session_resolve_flow_api_utils.py
+++ b/tests/candidates/routes/candidates_session_resolve_flow_api_utils.py
@@ -43,12 +43,6 @@ async def _create_trial(async_client, async_session, talent_partner_email: str) 
     finally:
         worker.clear_handlers()
     assert handled is True
-    activate = await async_client.post(
-        f"/api/trials/{sim_id}/activate",
-        json={"confirm": True},
-        headers={"x-dev-user-email": talent_partner_email},
-    )
-    assert activate.status_code == 200, activate.text
     return sim_id
 
 

--- a/tests/candidates/routes/test_candidates_candidate_flow_integration_routes.py
+++ b/tests/candidates/routes/test_candidates_candidate_flow_integration_routes.py
@@ -13,6 +13,7 @@ from app.shared.database.shared_database_models_model import (
 )
 from app.shared.jobs import worker
 from tests.shared.factories import create_talent_partner
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 def _task_id_by_day(sim_payload: dict, day_index: int) -> int:
@@ -86,6 +87,12 @@ async def test_full_flow_invite_through_first_submission(
     finally:
         worker.clear_handlers()
     assert handled is True
+
+    await _approve_trial(
+        async_client,
+        sim_id=sim_body["id"],
+        headers=auth_header_factory(talent_partner),
+    )
 
     activate_res = await async_client.post(
         f"/api/trials/{sim_body['id']}/activate",

--- a/tests/candidates/routes/test_candidates_invites_invite_completed_rejected_routes.py
+++ b/tests/candidates/routes/test_candidates_invites_invite_completed_rejected_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.candidates.routes.candidates_invites_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -17,9 +18,22 @@ async def test_invite_completed_rejected(
         company_name="TalentPartner A Co",
     )
 
-    sim_id = await _create_and_activate_trial(
+    sim_id = await _create_and_generate_trial(
         async_client, async_session, "talent_partnerA@winoe.com"
     )
+
+    await _approve_trial(
+        async_client,
+        sim_id=sim_id,
+        headers={"x-dev-user-email": "talent_partnerA@winoe.com"},
+    )
+
+    activate = await async_client.post(
+        f"/api/trials/{sim_id}/activate",
+        headers={"x-dev-user-email": "talent_partnerA@winoe.com"},
+        json={"confirm": True},
+    )
+    assert activate.status_code == 200, activate.text
 
     first = await async_client.post(
         f"/api/trials/{sim_id}/invite",

--- a/tests/candidates/routes/test_candidates_invites_invite_creates_candidate_session_routes.py
+++ b/tests/candidates/routes/test_candidates_invites_invite_creates_candidate_session_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.candidates.routes.candidates_invites_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -17,9 +18,22 @@ async def test_invite_creates_candidate_session(
         company_name="TalentPartner A Co",
     )
 
-    sim_id = await _create_and_activate_trial(
+    sim_id = await _create_and_generate_trial(
         async_client, async_session, "talent_partnerA@winoe.com"
     )
+
+    await _approve_trial(
+        async_client,
+        sim_id=sim_id,
+        headers={"x-dev-user-email": "talent_partnerA@winoe.com"},
+    )
+
+    activate = await async_client.post(
+        f"/api/trials/{sim_id}/activate",
+        headers={"x-dev-user-email": "talent_partnerA@winoe.com"},
+        json={"confirm": True},
+    )
+    assert activate.status_code == 200, activate.text
 
     # Invite candidate
     resp = await async_client.post(

--- a/tests/candidates/routes/test_candidates_invites_invite_duplicate_requests_idempotent_routes.py
+++ b/tests/candidates/routes/test_candidates_invites_invite_duplicate_requests_idempotent_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.candidates.routes.candidates_invites_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -17,9 +18,22 @@ async def test_invite_duplicate_requests_idempotent(
         company_name="TalentPartner A Co",
     )
 
-    sim_id = await _create_and_activate_trial(
+    sim_id = await _create_and_generate_trial(
         async_client, async_session, "talent_partnerA@winoe.com"
     )
+
+    await _approve_trial(
+        async_client,
+        sim_id=sim_id,
+        headers={"x-dev-user-email": "talent_partnerA@winoe.com"},
+    )
+
+    activate = await async_client.post(
+        f"/api/trials/{sim_id}/activate",
+        headers={"x-dev-user-email": "talent_partnerA@winoe.com"},
+        json={"confirm": True},
+    )
+    assert activate.status_code == 200, activate.text
 
     async def _invite():
         return await async_client.post(

--- a/tests/candidates/routes/test_candidates_invites_invite_expired_refreshes_token_routes.py
+++ b/tests/candidates/routes/test_candidates_invites_invite_expired_refreshes_token_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.candidates.routes.candidates_invites_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -17,9 +18,22 @@ async def test_invite_expired_refreshes_token(
         company_name="TalentPartner A Co",
     )
 
-    sim_id = await _create_and_activate_trial(
+    sim_id = await _create_and_generate_trial(
         async_client, async_session, "talent_partnerA@winoe.com"
     )
+
+    await _approve_trial(
+        async_client,
+        sim_id=sim_id,
+        headers={"x-dev-user-email": "talent_partnerA@winoe.com"},
+    )
+
+    activate = await async_client.post(
+        f"/api/trials/{sim_id}/activate",
+        headers={"x-dev-user-email": "talent_partnerA@winoe.com"},
+        json={"confirm": True},
+    )
+    assert activate.status_code == 200, activate.text
 
     first = await async_client.post(
         f"/api/trials/{sim_id}/invite",

--- a/tests/candidates/routes/test_candidates_invites_invite_not_owned_trial_returns_404_routes.py
+++ b/tests/candidates/routes/test_candidates_invites_invite_not_owned_trial_returns_404_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.candidates.routes.candidates_invites_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -20,9 +21,22 @@ async def test_invite_not_owned_trial_returns_404(
         company_name="TalentPartner B Co",
     )
 
-    sim_id = await _create_and_activate_trial(
+    sim_id = await _create_and_generate_trial(
         async_client, async_session, "talent_partnerA@winoe.com"
     )
+
+    await _approve_trial(
+        async_client,
+        sim_id=sim_id,
+        headers={"x-dev-user-email": "talent_partnerA@winoe.com"},
+    )
+
+    activate = await async_client.post(
+        f"/api/trials/{sim_id}/activate",
+        headers={"x-dev-user-email": "talent_partnerA@winoe.com"},
+        json={"confirm": True},
+    )
+    assert activate.status_code == 200, activate.text
 
     # TalentPartner B attempts invite -> 404 (do not leak existence)
     resp = await async_client.post(

--- a/tests/candidates/routes/test_candidates_invites_invite_rate_limited_in_prod_routes.py
+++ b/tests/candidates/routes/test_candidates_invites_invite_rate_limited_in_prod_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.candidates.routes.candidates_invites_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -25,9 +26,22 @@ async def test_invite_rate_limited_in_prod(
         company_name="TalentPartner Rate Co",
     )
 
-    sim_id = await _create_and_activate_trial(
+    sim_id = await _create_and_generate_trial(
         async_client, async_session, "talent_partner-rate@winoe.com"
     )
+
+    await _approve_trial(
+        async_client,
+        sim_id=sim_id,
+        headers={"x-dev-user-email": "talent_partner-rate@winoe.com"},
+    )
+
+    activate = await async_client.post(
+        f"/api/trials/{sim_id}/activate",
+        headers={"x-dev-user-email": "talent_partner-rate@winoe.com"},
+        json={"confirm": True},
+    )
+    assert activate.status_code == 200, activate.text
 
     first = await async_client.post(
         f"/api/trials/{sim_id}/invite",

--- a/tests/candidates/routes/test_candidates_invites_invite_resends_existing_active_routes.py
+++ b/tests/candidates/routes/test_candidates_invites_invite_resends_existing_active_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.candidates.routes.candidates_invites_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -17,9 +18,22 @@ async def test_invite_resends_existing_active(
         company_name="TalentPartner A Co",
     )
 
-    sim_id = await _create_and_activate_trial(
+    sim_id = await _create_and_generate_trial(
         async_client, async_session, "talent_partnerA@winoe.com"
     )
+
+    await _approve_trial(
+        async_client,
+        sim_id=sim_id,
+        headers={"x-dev-user-email": "talent_partnerA@winoe.com"},
+    )
+
+    activate = await async_client.post(
+        f"/api/trials/{sim_id}/activate",
+        headers={"x-dev-user-email": "talent_partnerA@winoe.com"},
+        json={"confirm": True},
+    )
+    assert activate.status_code == 200, activate.text
 
     first = await async_client.post(
         f"/api/trials/{sim_id}/invite",

--- a/tests/candidates/routes/test_candidates_session_resolve_bootstrap_wrong_email_forbidden_routes.py
+++ b/tests/candidates/routes/test_candidates_session_resolve_bootstrap_wrong_email_forbidden_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.candidates.routes.candidates_session_resolve_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -10,6 +11,17 @@ async def test_bootstrap_wrong_email_forbidden(async_client, async_session):
     talent_partner_email = "wrongemail@test.com"
     await _seed_talent_partner(async_session, talent_partner_email)
     sim_id = await _create_trial(async_client, async_session, talent_partner_email)
+    await _approve_trial(
+        async_client,
+        sim_id=sim_id,
+        headers={"x-dev-user-email": talent_partner_email},
+    )
+    activate = await async_client.post(
+        f"/api/trials/{sim_id}/activate",
+        json={"confirm": True},
+        headers={"x-dev-user-email": talent_partner_email},
+    )
+    assert activate.status_code == 200, activate.text
     invite = await _invite_candidate(async_client, sim_id, talent_partner_email)
     other_invite = await _invite_candidate(
         async_client,

--- a/tests/candidates/routes/test_candidates_session_resolve_current_task_advances_after_submission_routes.py
+++ b/tests/candidates/routes/test_candidates_session_resolve_current_task_advances_after_submission_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.candidates.routes.candidates_session_resolve_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -14,6 +15,17 @@ async def test_current_task_advances_after_submission(
     await _seed_talent_partner(async_session, talent_partner_email)
 
     sim_id = await _create_trial(async_client, async_session, talent_partner_email)
+    await _approve_trial(
+        async_client,
+        sim_id=sim_id,
+        headers={"x-dev-user-email": talent_partner_email},
+    )
+    activate = await async_client.post(
+        f"/api/trials/{sim_id}/activate",
+        json={"confirm": True},
+        headers={"x-dev-user-email": talent_partner_email},
+    )
+    assert activate.status_code == 200, activate.text
     invite = await _invite_candidate(async_client, sim_id, talent_partner_email)
 
     await _claim(async_client, invite["token"], "jane@example.com")

--- a/tests/candidates/routes/test_candidates_session_resolve_current_task_completed_after_all_tasks_routes.py
+++ b/tests/candidates/routes/test_candidates_session_resolve_current_task_completed_after_all_tasks_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.candidates.routes.candidates_session_resolve_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -14,6 +15,17 @@ async def test_current_task_completed_after_all_tasks(
     await _seed_talent_partner(async_session, talent_partner_email)
 
     sim_id = await _create_trial(async_client, async_session, talent_partner_email)
+    await _approve_trial(
+        async_client,
+        sim_id=sim_id,
+        headers={"x-dev-user-email": talent_partner_email},
+    )
+    activate = await async_client.post(
+        f"/api/trials/{sim_id}/activate",
+        json={"confirm": True},
+        headers={"x-dev-user-email": talent_partner_email},
+    )
+    assert activate.status_code == 200, activate.text
     invite = await _invite_candidate(async_client, sim_id, talent_partner_email)
 
     await _claim(async_client, invite["token"], "jane@example.com")

--- a/tests/candidates/routes/test_candidates_session_resolve_current_task_expired_invite_410_routes.py
+++ b/tests/candidates/routes/test_candidates_session_resolve_current_task_expired_invite_410_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.candidates.routes.candidates_session_resolve_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -11,6 +12,17 @@ async def test_current_task_expired_invite_410(async_client, async_session):
     await _seed_talent_partner(async_session, talent_partner_email)
 
     sim_id = await _create_trial(async_client, async_session, talent_partner_email)
+    await _approve_trial(
+        async_client,
+        sim_id=sim_id,
+        headers={"x-dev-user-email": talent_partner_email},
+    )
+    activate = await async_client.post(
+        f"/api/trials/{sim_id}/activate",
+        json={"confirm": True},
+        headers={"x-dev-user-email": talent_partner_email},
+    )
+    assert activate.status_code == 200, activate.text
     invite = await _invite_candidate(async_client, sim_id, talent_partner_email)
 
     await _claim(async_client, invite["token"], "jane@example.com")

--- a/tests/candidates/routes/test_candidates_session_resolve_current_task_initial_is_day_1_routes.py
+++ b/tests/candidates/routes/test_candidates_session_resolve_current_task_initial_is_day_1_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.candidates.routes.candidates_session_resolve_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -12,6 +13,17 @@ async def test_current_task_initial_is_day_1(async_client, async_session, monkey
     await _seed_talent_partner(async_session, talent_partner_email)
 
     sim_id = await _create_trial(async_client, async_session, talent_partner_email)
+    await _approve_trial(
+        async_client,
+        sim_id=sim_id,
+        headers={"x-dev-user-email": talent_partner_email},
+    )
+    activate = await async_client.post(
+        f"/api/trials/{sim_id}/activate",
+        json={"confirm": True},
+        headers={"x-dev-user-email": talent_partner_email},
+    )
+    assert activate.status_code == 200, activate.text
     invite = await _invite_candidate(async_client, sim_id, talent_partner_email)
 
     await _claim(async_client, invite["token"], "jane@example.com")

--- a/tests/candidates/routes/test_candidates_session_resolve_current_task_pre_start_returns_schedule_not_started_routes.py
+++ b/tests/candidates/routes/test_candidates_session_resolve_current_task_pre_start_returns_schedule_not_started_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.candidates.routes.candidates_session_resolve_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -14,6 +15,17 @@ async def test_current_task_pre_start_returns_schedule_not_started(
     await _seed_talent_partner(async_session, talent_partner_email)
 
     sim_id = await _create_trial(async_client, async_session, talent_partner_email)
+    await _approve_trial(
+        async_client,
+        sim_id=sim_id,
+        headers={"x-dev-user-email": talent_partner_email},
+    )
+    activate = await async_client.post(
+        f"/api/trials/{sim_id}/activate",
+        json={"confirm": True},
+        headers={"x-dev-user-email": talent_partner_email},
+    )
+    assert activate.status_code == 200, activate.text
     invite = await _invite_candidate(async_client, sim_id, talent_partner_email)
     await _claim(async_client, invite["token"], "jane@example.com")
     cs_id = invite["candidateSessionId"]

--- a/tests/candidates/routes/test_candidates_session_resolve_resolve_expired_token_returns_410_routes.py
+++ b/tests/candidates/routes/test_candidates_session_resolve_resolve_expired_token_returns_410_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.candidates.routes.candidates_session_resolve_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -11,6 +12,17 @@ async def test_resolve_expired_token_returns_410(async_client, async_session):
     await _seed_talent_partner(async_session, talent_partner_email)
 
     sim_id = await _create_trial(async_client, async_session, talent_partner_email)
+    await _approve_trial(
+        async_client,
+        sim_id=sim_id,
+        headers={"x-dev-user-email": talent_partner_email},
+    )
+    activate = await async_client.post(
+        f"/api/trials/{sim_id}/activate",
+        json={"confirm": True},
+        headers={"x-dev-user-email": talent_partner_email},
+    )
+    assert activate.status_code == 200, activate.text
     invite = await _invite_candidate(async_client, sim_id, talent_partner_email)
 
     token = invite["token"]

--- a/tests/candidates/routes/test_candidates_session_resolve_resolve_invalid_token_returns_404_routes.py
+++ b/tests/candidates/routes/test_candidates_session_resolve_resolve_invalid_token_returns_404_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.candidates.routes.candidates_session_resolve_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -11,6 +12,17 @@ async def test_resolve_invalid_token_returns_404(async_client, async_session):
     talent_partner_email = "invalidtoken@test.com"
     await _seed_talent_partner(async_session, talent_partner_email)
     sim_id = await _create_trial(async_client, async_session, talent_partner_email)
+    await _approve_trial(
+        async_client,
+        sim_id=sim_id,
+        headers={"x-dev-user-email": talent_partner_email},
+    )
+    activate = await async_client.post(
+        f"/api/trials/{sim_id}/activate",
+        json={"confirm": True},
+        headers={"x-dev-user-email": talent_partner_email},
+    )
+    assert activate.status_code == 200, activate.text
     invite = await _invite_candidate(async_client, sim_id, talent_partner_email)
     await _claim(async_client, invite["token"], "jane@example.com")
     access_token = "candidate:jane@example.com"

--- a/tests/candidates/routes/test_candidates_session_resolve_resolve_transitions_to_in_progress_routes.py
+++ b/tests/candidates/routes/test_candidates_session_resolve_resolve_transitions_to_in_progress_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.candidates.routes.candidates_session_resolve_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -11,6 +12,17 @@ async def test_resolve_transitions_to_in_progress(async_client, async_session):
     await _seed_talent_partner(async_session, talent_partner_email)
 
     sim_id = await _create_trial(async_client, async_session, talent_partner_email)
+    await _approve_trial(
+        async_client,
+        sim_id=sim_id,
+        headers={"x-dev-user-email": talent_partner_email},
+    )
+    activate = await async_client.post(
+        f"/api/trials/{sim_id}/activate",
+        json={"confirm": True},
+        headers={"x-dev-user-email": talent_partner_email},
+    )
+    assert activate.status_code == 200, activate.text
     invite = await _invite_candidate(async_client, sim_id, talent_partner_email)
 
     token = invite["token"]

--- a/tests/candidates/routes/test_candidates_sessions_misc_coverage_routes.py
+++ b/tests/candidates/routes/test_candidates_sessions_misc_coverage_routes.py
@@ -156,3 +156,76 @@ async def test_build_current_task_view_marks_complete_without_overwriting_comple
     assert result.completed_at == existing_completed_at
     assert db.commit_calls == 1
     assert db.refresh_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_build_current_task_view_fetches_recorded_submission_when_available(
+    monkeypatch,
+):
+    request = SimpleNamespace(
+        headers={"x-candidate-session-id": "7"},
+        client=SimpleNamespace(host="127.0.0.1"),
+    )
+    current_task = SimpleNamespace(
+        id=11, day_index=3, title="Task", type="code", description="desc"
+    )
+    candidate_session = SimpleNamespace(id=7, status="in_progress", completed_at=None)
+    captured: dict[str, object] = {}
+
+    class _FakeDB:
+        async def commit(self):
+            return None
+
+        async def refresh(self, _obj):
+            return None
+
+        async def execute(self, *_args, **_kwargs):
+            return SimpleNamespace()
+
+    async def _fetch_owned_session(_db, _session_id, _principal, now):
+        return candidate_session
+
+    async def _progress_snapshot(_db, _candidate_session, **_kwargs):
+        return ([], set(), current_task, 0, 1, False)
+
+    async def _get_day_audit(_db, *, candidate_session_id, day_index):
+        captured["day_audit_called"] = (candidate_session_id, day_index)
+        return SimpleNamespace(cutoff_commit_sha="sha", cutoff_at=None)
+
+    async def _get_by_candidate_session_task(_db, *, candidate_session_id, task_id):
+        captured["recorded_submission_called"] = (candidate_session_id, task_id)
+        return SimpleNamespace(id=99)
+
+    monkeypatch.setattr(
+        current_task_logic.cs_service, "fetch_owned_session", _fetch_owned_session
+    )
+    monkeypatch.setattr(
+        current_task_logic.cs_service,
+        "ensure_schedule_started_for_content",
+        lambda *_a, **_k: None,
+    )
+    monkeypatch.setattr(
+        current_task_logic.cs_service, "progress_snapshot", _progress_snapshot
+    )
+    monkeypatch.setattr(current_task_logic.cs_repo, "get_day_audit", _get_day_audit)
+    monkeypatch.setattr(
+        current_task_logic.submission_service.submissions_repo,
+        "get_by_candidate_session_task",
+        _get_by_candidate_session_task,
+    )
+    monkeypatch.setattr(
+        current_task_logic,
+        "build_current_task_response",
+        lambda *_a, **kwargs: kwargs["recorded_submission"],
+    )
+    monkeypatch.setattr(
+        current_task_logic.rate_limit, "rate_limit_enabled", lambda: False
+    )
+
+    result = await current_task_logic.build_current_task_view(
+        7, request, SimpleNamespace(sub="auth0|candidate"), _FakeDB()
+    )
+
+    assert captured["day_audit_called"] == (7, 3)
+    assert captured["recorded_submission_called"] == (7, 11)
+    assert result.id == 99

--- a/tests/candidates/services/test_candidates_session_service_ensure_candidate_ownership_variants_service.py
+++ b/tests/candidates/services/test_candidates_session_service_ensure_candidate_ownership_variants_service.py
@@ -41,3 +41,25 @@ def test_ensure_candidate_ownership_variants():
         getattr(excinfo.value, "error_code", None)
         == "CANDIDATE_SESSION_ALREADY_CLAIMED"
     )
+
+
+def test_ensure_candidate_ownership_allows_local_env_without_verification_check(
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ENV", "local")
+    principal = _principal("owner@example.com", email_verified=False)
+    cs = type(
+        "CS",
+        (),
+        {
+            "invite_email": "owner@example.com",
+            "candidate_auth0_sub": None,
+            "candidate_email": None,
+            "candidate_auth0_email": None,
+            "status": "in_progress",
+        },
+    )()
+    changed = cs_service._ensure_candidate_ownership(
+        cs, principal, now=datetime.now(UTC)
+    )
+    assert changed is True

--- a/tests/config/test_ai_provider_clients_schema_payload_service.py
+++ b/tests/config/test_ai_provider_clients_schema_payload_service.py
@@ -3,10 +3,12 @@ from __future__ import annotations
 import sys
 import types
 
+import pytest
 from pydantic import BaseModel
 
 from app.ai import ScenarioGenerationOutput
 from app.ai.ai_provider_clients_service import (
+    AIProviderExecutionError,
     _openai_schema_validation_error,
     _schema_payload,
     call_anthropic_json,
@@ -32,6 +34,53 @@ class _RootPayload(BaseModel):
 
 class _TinyResponse(BaseModel):
     message: str
+
+
+def _scenario_generation_payload(
+    *, include_required_fields: bool = True
+) -> dict[str, object]:
+    payload: dict[str, object] = {
+        "storyline_md": "A concise but realistic Winoe scenario.",
+        "task_prompts_json": [
+            {
+                "dayIndex": day_index,
+                "title": f"Day {day_index}",
+                "description": f"Deliverable for day {day_index}.",
+            }
+            for day_index in range(1, 6)
+        ],
+    }
+    if include_required_fields:
+        payload["rubric_json"] = {
+            "summary": "Concise rubric summary.",
+            "dayWeights": {"1": 10, "2": 20, "3": 30, "4": 20, "5": 20},
+            "dimensions": [
+                {
+                    "name": "Planning",
+                    "weight": 40,
+                    "description": "Plans the work well.",
+                },
+                {
+                    "name": "Execution",
+                    "weight": 60,
+                    "description": "Delivers the work cleanly.",
+                },
+            ],
+        }
+        payload["codespace_spec_json"] = {
+            "task_kind": "feature",
+            "summary": "Build the Winoe feature.",
+            "candidate_goal": "Implement the required backend changes.",
+            "acceptance_criteria": [
+                "The endpoint works.",
+                "The data is persisted correctly.",
+            ],
+            "target_files": ["app/example.py"],
+            "repo_adjustments": ["Add route and service logic"],
+            "test_focus": ["happy path", "failure path"],
+            "test_command": "poetry run pytest tests/example",
+        }
+    return payload
 
 
 def test_schema_payload_sets_additional_properties_false_recursively() -> None:
@@ -184,3 +233,91 @@ def test_call_anthropic_json_prefers_tool_schema_output(monkeypatch) -> None:
     request = client.messages.calls[0]
     assert request["tool_choice"] == {"type": "tool", "name": "_TinyResponse"}
     assert request["tools"][0]["name"] == "_TinyResponse"
+
+
+def test_call_anthropic_json_validates_complete_tool_payload(monkeypatch) -> None:
+    class _FakeBlock:
+        def __init__(self, *, block_type: str, input_payload=None) -> None:
+            self.type = block_type
+            self.input = input_payload
+
+    class _FakeMessages:
+        def create(self, **kwargs):
+            return types.SimpleNamespace(
+                content=[
+                    _FakeBlock(
+                        block_type="tool_use",
+                        input_payload=_scenario_generation_payload(),
+                    )
+                ]
+            )
+
+    class _FakeAnthropic:
+        def __init__(self, *, api_key, timeout, max_retries) -> None:
+            self.api_key = api_key
+            self.timeout = timeout
+            self.max_retries = max_retries
+            self.messages = _FakeMessages()
+
+    monkeypatch.setitem(
+        sys.modules, "anthropic", types.SimpleNamespace(Anthropic=_FakeAnthropic)
+    )
+
+    result = call_anthropic_json(
+        api_key="test-key",
+        model="claude-opus-4-6",
+        system_prompt="system",
+        user_prompt="user",
+        response_model=ScenarioGenerationOutput,
+        timeout_seconds=30,
+        max_retries=1,
+        max_tokens=512,
+    )
+
+    assert result.storyline_md == "A concise but realistic Winoe scenario."
+    assert len(result.task_prompts_json) == 5
+    assert result.rubric_json.summary == "Concise rubric summary."
+    assert result.codespace_spec_json.summary == "Build the Winoe feature."
+
+
+def test_call_anthropic_json_rejects_partial_tool_payload(monkeypatch) -> None:
+    class _FakeBlock:
+        def __init__(self, *, block_type: str, input_payload=None) -> None:
+            self.type = block_type
+            self.input = input_payload
+
+    class _FakeMessages:
+        def create(self, **kwargs):
+            return types.SimpleNamespace(
+                content=[
+                    _FakeBlock(
+                        block_type="tool_use",
+                        input_payload=_scenario_generation_payload(
+                            include_required_fields=False
+                        ),
+                    )
+                ]
+            )
+
+    class _FakeAnthropic:
+        def __init__(self, *, api_key, timeout, max_retries) -> None:
+            self.api_key = api_key
+            self.timeout = timeout
+            self.max_retries = max_retries
+            self.messages = _FakeMessages()
+
+    monkeypatch.setitem(
+        sys.modules, "anthropic", types.SimpleNamespace(Anthropic=_FakeAnthropic)
+    )
+
+    with pytest.raises(AIProviderExecutionError, match="anthropic_invalid_json_output"):
+        call_anthropic_json(
+            api_key="test-key",
+            model="claude-opus-4-6",
+            system_prompt="system",
+            user_prompt="user",
+            response_model=ScenarioGenerationOutput,
+            timeout_seconds=30,
+            max_retries=1,
+            max_tokens=512,
+        )

--- a/tests/evaluations/services/test_evaluations_winoe_report_jobs_service.py
+++ b/tests/evaluations/services/test_evaluations_winoe_report_jobs_service.py
@@ -34,3 +34,33 @@ async def test_enqueue_evaluation_run_uses_retry_budget(monkeypatch) -> None:
     assert observed["max_attempts"] == winoe_report_jobs.EVALUATION_RUN_JOB_MAX_ATTEMPTS
     assert observed["candidate_session_id"] == 42
     db.flush.assert_awaited_once()
+
+
+async def test_enqueue_evaluation_run_commits_and_refreshes_when_requested(
+    monkeypatch,
+) -> None:
+    observed: dict[str, object] = {}
+
+    async def _create_or_get_idempotent(db, **kwargs):
+        observed.update(kwargs)
+        return SimpleNamespace(id="job-2", payload_json={})
+
+    db = SimpleNamespace(commit=AsyncMock(), refresh=AsyncMock(), flush=AsyncMock())
+    monkeypatch.setattr(
+        winoe_report_jobs.jobs_repo,
+        "create_or_get_idempotent",
+        _create_or_get_idempotent,
+    )
+
+    result = await winoe_report_jobs.enqueue_evaluation_run(
+        db,
+        candidate_session_id=7,
+        company_id=11,
+        requested_by_user_id=13,
+        commit=True,
+    )
+
+    assert result.id == "job-2"
+    assert observed["company_id"] == 11
+    db.commit.assert_awaited_once()
+    db.refresh.assert_awaited_once()

--- a/tests/evaluations/services/test_evaluations_winoe_report_pipeline_gap_service.py
+++ b/tests/evaluations/services/test_evaluations_winoe_report_pipeline_gap_service.py
@@ -18,6 +18,10 @@ from types import SimpleNamespace
 import pytest
 
 from app.evaluations.services import winoe_report_pipeline
+from app.evaluations.services.evaluations_services_evaluations_winoe_report_pipeline_runner_service import (
+    _is_retryable_winoe_report_provider_error,
+)
+from app.integrations.winoe_report_review import WinoeReportReviewProviderError
 
 
 class _ScalarOneResult:
@@ -47,6 +51,16 @@ def test_segment_text_returns_none_for_empty_keys():
             {"text": "   ", "content": None, "excerpt": ""}
         )
         is None
+    )
+
+
+def test_retryable_provider_error_helper_handles_blank_and_retryable_values():
+    assert not _is_retryable_winoe_report_provider_error(ValueError("rate limit"))
+    assert not _is_retryable_winoe_report_provider_error(
+        WinoeReportReviewProviderError("")
+    )
+    assert _is_retryable_winoe_report_provider_error(
+        WinoeReportReviewProviderError("Rate limit exceeded")
     )
 
 

--- a/tests/integrations/scenario_generation/test_integrations_scenario_generation_anthropic_provider_client.py
+++ b/tests/integrations/scenario_generation/test_integrations_scenario_generation_anthropic_provider_client.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from app.ai.ai_output_models import (
+    CodespaceSpec,
+    ScenarioGenerationOutput,
+    ScenarioRubric,
+    ScenarioRubricDayWeights,
+    ScenarioRubricDimension,
+    ScenarioTaskPrompt,
+)
+from app.integrations.scenario_generation.anthropic_provider_client import (
+    AnthropicScenarioGenerationProvider,
+)
+from app.integrations.scenario_generation.base_client import (
+    ScenarioGenerationProviderRequest,
+)
+
+
+def _scenario_generation_output() -> ScenarioGenerationOutput:
+    return ScenarioGenerationOutput(
+        storyline_md="Short scenario",
+        task_prompts_json=[
+            ScenarioTaskPrompt(
+                dayIndex=day_index,
+                title=f"Day {day_index}",
+                description=f"Do the work for day {day_index}.",
+            )
+            for day_index in range(1, 6)
+        ],
+        rubric_json=ScenarioRubric(
+            summary="Short rubric",
+            dayWeights=ScenarioRubricDayWeights(
+                day1=10, day2=20, day3=30, day4=20, day5=20
+            ),
+            dimensions=[
+                ScenarioRubricDimension(
+                    name="Planning",
+                    weight=50,
+                    description="Plans well.",
+                ),
+                ScenarioRubricDimension(
+                    name="Execution",
+                    weight=50,
+                    description="Delivers well.",
+                ),
+            ],
+        ),
+        codespace_spec_json=CodespaceSpec(
+            summary="Build the feature.",
+            candidate_goal="Ship the requested backend changes.",
+            acceptance_criteria=["It works.", "It is tested."],
+            target_files=["app/example.py"],
+            repo_adjustments=["Add endpoint"],
+            test_focus=["happy path"],
+            test_command="poetry run pytest tests/example",
+        ),
+    )
+
+
+def test_anthropic_scenario_generation_provider_uses_larger_output_budget(
+    monkeypatch,
+) -> None:
+    calls: list[dict[str, object]] = []
+
+    def _fake_call_anthropic_json(**kwargs):
+        calls.append(kwargs)
+        return _scenario_generation_output()
+
+    monkeypatch.setattr(
+        "app.integrations.scenario_generation.anthropic_provider_client.call_anthropic_json",
+        _fake_call_anthropic_json,
+    )
+    monkeypatch.setattr(
+        "app.integrations.scenario_generation.anthropic_provider_client.settings.ANTHROPIC_API_KEY",
+        "anthropic-test-key",
+    )
+
+    provider = AnthropicScenarioGenerationProvider()
+    response = provider.generate_scenario(
+        request=ScenarioGenerationProviderRequest(
+            system_prompt="system",
+            user_prompt="user",
+            model="claude-opus-4-6",
+        )
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["max_tokens"] == 6_144
+    assert response.model_name == "claude-opus-4-6"
+    assert response.model_version == "claude-opus-4-6"
+    assert response.result.storyline_md == "Short scenario"

--- a/tests/shared/jobs/handlers/test_shared_jobs_handlers_transcribe_recording_success_handler.py
+++ b/tests/shared/jobs/handlers/test_shared_jobs_handlers_transcribe_recording_success_handler.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from types import SimpleNamespace
+
 import pytest
 
 from tests.shared.jobs.handlers.shared_jobs_handlers_transcribe_recording_utils import *
@@ -51,3 +53,19 @@ async def test_transcribe_recording_handler_success(async_session):
     assert refreshed_transcript.segments_json
     assert refreshed_transcript.model_name == "fake-stt-v1"
     assert refreshed_transcript.last_error is None
+
+
+def test_transcription_job_has_retry_headroom_handles_missing_and_boundaries():
+    assert handler._transcription_job_has_retry_headroom(None) is False
+    assert (
+        handler._transcription_job_has_retry_headroom(
+            SimpleNamespace(attempt=1, max_attempts=2)
+        )
+        is True
+    )
+    assert (
+        handler._transcription_job_has_retry_headroom(
+            SimpleNamespace(attempt=2, max_attempts=2)
+        )
+        is False
+    )

--- a/tests/shared/jobs/repositories/test_shared_jobs_repository_dead_letter_retry_repository.py
+++ b/tests/shared/jobs/repositories/test_shared_jobs_repository_dead_letter_retry_repository.py
@@ -121,3 +121,15 @@ async def test_requeue_dead_letter_jobs_deduplicates_requested_ids(async_session
     )
 
     assert count == 1
+
+
+@pytest.mark.asyncio
+async def test_requeue_dead_letter_jobs_returns_zero_when_no_dead_letters(
+    async_session,
+):
+    count = await jobs_repo.requeue_dead_letter_jobs(
+        async_session,
+        now=datetime(2026, 4, 14, 14, 15, tzinfo=UTC),
+    )
+
+    assert count == 0

--- a/tests/shared/jobs/repositories/test_shared_jobs_repository_worker_heartbeats_repository.py
+++ b/tests/shared/jobs/repositories/test_shared_jobs_repository_worker_heartbeats_repository.py
@@ -105,3 +105,23 @@ async def test_worker_heartbeat_rejects_blank_fields_and_can_mark_stopped(
 
     assert stopped.status == heartbeat_service.WORKER_HEARTBEAT_STATUS_STOPPED
     assert _to_utc(stopped.last_heartbeat_at) == stopped_at
+
+
+@pytest.mark.asyncio
+async def test_get_latest_worker_heartbeat_returns_none_when_missing(async_session):
+    latest = await jobs_repo.get_latest_worker_heartbeat(
+        async_session, service_name="missing-worker"
+    )
+
+    assert latest is None
+
+
+@pytest.mark.asyncio
+async def test_worker_heartbeat_rejects_overlong_service_name(async_session):
+    with pytest.raises(ValueError):
+        await jobs_repo.upsert_worker_heartbeat(
+            async_session,
+            service_name="x" * 101,
+            instance_id="worker-overlong",
+            now=datetime(2026, 4, 14, 12, 12, tzinfo=UTC),
+        )

--- a/tests/shared/jobs/worker_runtime/test_shared_jobs_worker_runtime_failure_paths_service.py
+++ b/tests/shared/jobs/worker_runtime/test_shared_jobs_worker_runtime_failure_paths_service.py
@@ -56,3 +56,42 @@ async def test_retry_or_dead_letter_uses_provider_backoff_for_rate_limit_errors(
 
     assert observed["job_id"] == "job-1"
     assert observed["next_run_at"] == claim_time + timedelta(seconds=15)
+
+
+def test_is_provider_backoff_error_returns_false_for_blank_string():
+    assert failure_paths._is_provider_backoff_error("   ") is False
+
+
+@pytest.mark.asyncio
+async def test_retry_or_dead_letter_dead_letters_when_attempt_budget_exhausted(
+    monkeypatch,
+) -> None:
+    observed: dict[str, object] = {}
+    claim_time = datetime(2026, 4, 3, tzinfo=UTC)
+
+    async def _mark_dead_letter(_session_maker, *, job_id, error_str, claim_time):
+        observed["job_id"] = job_id
+        observed["error_str"] = error_str
+        observed["claim_time"] = claim_time
+
+    monkeypatch.setattr(failure_paths, "mark_dead_letter", _mark_dead_letter)
+
+    logger = SimpleNamespace(
+        info=lambda *_args, **_kwargs: None,
+        warning=lambda *_args, **_kwargs: None,
+    )
+    job = SimpleNamespace(id="job-2", attempt=7, max_attempts=7)
+
+    await failure_paths.retry_or_dead_letter(
+        object(),
+        job=job,
+        error_str="RuntimeError: terminal failure",
+        claim_time=claim_time,
+        log_extra={},
+        base_backoff_seconds=1,
+        max_backoff_seconds=60,
+        logger=logger,
+        warn_event="job_rescheduled",
+    )
+
+    assert observed["job_id"] == "job-2"

--- a/tests/shared/utils/test_shared_ai_runtime_config_service_branch_gaps_utils.py
+++ b/tests/shared/utils/test_shared_ai_runtime_config_service_branch_gaps_utils.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from app.ai import ai_runtime_config_service as runtime_config_service
+
+
+def test_require_real_mode_covers_real_and_non_real_branches():
+    assert (
+        runtime_config_service.require_real_mode(
+            runtime_config_service.AI_RUNTIME_MODE_REAL
+        )
+        is True
+    )
+    assert (
+        runtime_config_service.require_real_mode(
+            runtime_config_service.AI_RUNTIME_MODE_DEMO
+        )
+        is False
+    )

--- a/tests/submissions/services/test_submissions_submission_actions_service_derives_completed_status_service.py
+++ b/tests/submissions/services/test_submissions_submission_actions_service_derives_completed_status_service.py
@@ -32,3 +32,43 @@ def test_derive_actions_metadata_persists_workflow_completion_fields():
     assert metadata["workflow_run_completed_at"] == now
     assert metadata["last_run_at"] == now
     assert metadata["commit_sha"] == "abc123"
+
+
+def test_derive_actions_metadata_returns_defaults_when_missing():
+    now = datetime(2026, 4, 2, 15, 30, tzinfo=UTC)
+
+    metadata = derive_actions_metadata(None, now)
+
+    assert metadata == {
+        "tests_passed": None,
+        "tests_failed": None,
+        "test_output": None,
+        "commit_sha": None,
+        "workflow_run_id": None,
+        "workflow_run_status": None,
+        "workflow_run_conclusion": None,
+        "workflow_run_completed_at": None,
+        "last_run_at": None,
+    }
+
+
+def test_derive_actions_metadata_marks_running_workflow_in_progress():
+    now = datetime(2026, 4, 2, 15, 30, tzinfo=UTC)
+
+    result = ActionsRunResult(
+        status="running",
+        run_id=12346,
+        conclusion="",
+        passed=0,
+        failed=0,
+        total=0,
+        stdout="",
+        stderr=None,
+        head_sha="def456",
+        html_url="https://github.example/run/12346",
+    )
+
+    metadata = derive_actions_metadata(result, now)
+
+    assert metadata["workflow_run_status"] == "in_progress"
+    assert metadata["workflow_run_completed_at"] is None

--- a/tests/tasks/routes/test_tasks_submit_api_runtime_utils.py
+++ b/tests/tasks/routes/test_tasks_submit_api_runtime_utils.py
@@ -5,6 +5,7 @@ from datetime import UTC, datetime
 from sqlalchemy.ext.asyncio import async_sessionmaker
 
 from app.shared.jobs import worker
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 async def create_trial(async_client, async_session, talent_partner_email: str) -> dict:
@@ -37,6 +38,11 @@ async def create_trial(async_client, async_session, talent_partner_email: str) -
     finally:
         worker.clear_handlers()
     assert handled is True
+    await _approve_trial(
+        async_client,
+        sim_id=trial["id"],
+        headers={"x-dev-user-email": talent_partner_email},
+    )
     activate = await async_client.post(
         f"/api/trials/{trial['id']}/activate",
         headers={"x-dev-user-email": talent_partner_email},

--- a/tests/trials/routes/test_trials_detail_routes.py
+++ b/tests/trials/routes/test_trials_detail_routes.py
@@ -1,5 +1,19 @@
+from types import SimpleNamespace
+
 import pytest
 
+from app.shared.jobs.repositories.shared_jobs_repositories_models_repository import (
+    JOB_STATUS_QUEUED,
+    JOB_STATUS_RUNNING,
+)
+from app.trials.routes.trials_routes.trials_routes_trials_routes_trials_routes_detail_render_routes import (
+    _generation_failure_summary,
+    _generation_status,
+    _latest_relevant_scenario_version,
+    _scenario_agent_runtime_summary,
+    _scenario_review_bundle_status,
+    _scenario_snapshot_summary,
+)
 from tests.shared.factories import create_talent_partner, create_trial
 
 
@@ -21,6 +35,8 @@ async def test_get_trial_detail_happy_path(
 
     body = res.json()
     assert body["id"] == sim.id
+    assert body["status"] == sim.status
+    assert body["generationStatus"] == "ready_for_review"
     assert body["activeScenarioVersionId"] == sim.active_scenario_version_id
     assert body["pendingScenarioVersionId"] is None
     assert body["scenario"]["id"] == sim.active_scenario_version_id
@@ -103,3 +119,196 @@ async def test_trial_context_round_trips_on_create_and_detail(
     assert detail["ai"]["evalEnabledByDay"] == payload["ai"]["evalEnabledByDay"]
     assert detail["ai"]["promptPackVersion"] == "winoe-ai-pack-v1"
     assert detail["ai"]["changesPendingRegeneration"] is False
+
+
+def test_latest_relevant_scenario_version_prefers_reviewable_pending_only():
+    active = SimpleNamespace(id=1, status="ready", locked_at=None)
+    pending_generating = SimpleNamespace(id=2, status="generating", locked_at=None)
+    pending_ready = SimpleNamespace(id=3, status="ready", locked_at=None)
+
+    assert (
+        _latest_relevant_scenario_version(
+            active_scenario_version=active,
+            pending_scenario_version=pending_generating,
+        )
+        is active
+    )
+    assert (
+        _latest_relevant_scenario_version(
+            active_scenario_version=active,
+            pending_scenario_version=pending_ready,
+        )
+        is pending_ready
+    )
+
+
+def test_generation_failure_summary_accepts_terminal_failed_states():
+    for status in ("failed", "dead_letter"):
+        summary = _generation_failure_summary(
+            SimpleNamespace(id="job-1", status=status, last_error="boom")
+        )
+        assert summary is not None
+        assert summary.jobId == "job-1"
+        assert summary.status == "failed"
+        assert summary.error == "boom"
+        assert summary.retryable is True
+        assert summary.canRetry is True
+
+
+def test_generation_failure_summary_returns_none_for_missing_or_non_terminal_jobs():
+    assert _generation_failure_summary(None) is None
+    assert (
+        _generation_failure_summary(
+            SimpleNamespace(id="job-2", status="queued", last_error="boom")
+        )
+        is None
+    )
+
+
+def test_detail_helpers_handle_non_reviewable_and_non_mapping_state():
+    assert _scenario_agent_runtime_summary(None) is None
+    assert _scenario_agent_runtime_summary({"agents": ["bad"]}) is None
+
+    snapshot = {
+        "promptPackVersion": "pack-v2",
+        "agents": {
+            "prestart": {
+                "runtime": {
+                    "runtimeMode": "primary",
+                    "provider": "anthropic",
+                    "model": "claude-opus-4.6",
+                },
+                "promptVersion": "v9",
+                "rubricVersion": "r9",
+            },
+            "ignore-me": "not-a-mapping",
+        },
+    }
+    version = SimpleNamespace(id="sv-1", ai_policy_snapshot_json=snapshot)
+    summary = _scenario_snapshot_summary(version, bundle_status="ready")
+    assert summary is not None
+    assert summary["scenarioVersionId"] == "sv-1"
+    assert summary["promptPackVersion"] == "pack-v2"
+    assert summary["bundleStatus"] == "ready"
+    assert summary["agents"] == [
+        {
+            "key": "prestart",
+            "provider": "anthropic",
+            "model": "claude-opus-4.6",
+            "runtimeMode": "primary",
+            "promptVersion": "v9",
+            "rubricVersion": "r9",
+        }
+    ]
+
+    assert _scenario_snapshot_summary(None, bundle_status=None) is None
+    assert (
+        _scenario_snapshot_summary(
+            SimpleNamespace(id="sv-2", ai_policy_snapshot_json=[]),
+            bundle_status=None,
+        )
+        is None
+    )
+
+
+def test_detail_helpers_cover_bundle_and_generation_status_branches():
+    assert (
+        _scenario_review_bundle_status(
+            active_scenario_version=None,
+            pending_scenario_version=None,
+            active_bundle_status="active",
+            pending_bundle_status="pending",
+        )
+        is None
+    )
+    assert (
+        _scenario_review_bundle_status(
+            active_scenario_version=SimpleNamespace(id="a"),
+            pending_scenario_version=None,
+            active_bundle_status="active",
+            pending_bundle_status="pending",
+        )
+        == "active"
+    )
+    assert (
+        _scenario_review_bundle_status(
+            active_scenario_version=SimpleNamespace(id="a"),
+            pending_scenario_version=SimpleNamespace(id="p"),
+            active_bundle_status="active",
+            pending_bundle_status="pending",
+        )
+        == "pending"
+    )
+
+    assert (
+        _generation_status(
+            active_scenario_version=None,
+            pending_scenario_version=None,
+            scenario_generation_job=SimpleNamespace(status="failed"),
+            generation_failure=SimpleNamespace(),
+        )
+        == "failed"
+    )
+    assert (
+        _generation_status(
+            active_scenario_version=SimpleNamespace(status="generating"),
+            pending_scenario_version=None,
+            scenario_generation_job=None,
+            generation_failure=None,
+        )
+        == "generating"
+    )
+    assert (
+        _generation_status(
+            active_scenario_version=None,
+            pending_scenario_version=SimpleNamespace(status="generating"),
+            scenario_generation_job=None,
+            generation_failure=None,
+        )
+        == "generating"
+    )
+    assert (
+        _generation_status(
+            active_scenario_version=None,
+            pending_scenario_version=None,
+            scenario_generation_job=SimpleNamespace(status=JOB_STATUS_QUEUED),
+            generation_failure=None,
+        )
+        == "generating"
+    )
+    assert (
+        _generation_status(
+            active_scenario_version=None,
+            pending_scenario_version=None,
+            scenario_generation_job=SimpleNamespace(status=JOB_STATUS_RUNNING),
+            generation_failure=None,
+        )
+        == "generating"
+    )
+    assert (
+        _generation_status(
+            active_scenario_version=SimpleNamespace(status="ready"),
+            pending_scenario_version=None,
+            scenario_generation_job=None,
+            generation_failure=None,
+        )
+        == "ready_for_review"
+    )
+    assert (
+        _generation_status(
+            active_scenario_version=None,
+            pending_scenario_version=SimpleNamespace(status="locked"),
+            scenario_generation_job=None,
+            generation_failure=None,
+        )
+        == "ready_for_review"
+    )
+    assert (
+        _generation_status(
+            active_scenario_version=None,
+            pending_scenario_version=None,
+            scenario_generation_job=None,
+            generation_failure=None,
+        )
+        == "not_started"
+    )

--- a/tests/trials/routes/test_trials_lifecycle_activate_is_owner_only_and_idempotent_routes.py
+++ b/tests/trials/routes/test_trials_lifecycle_activate_is_owner_only_and_idempotent_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.trials.routes.trials_lifecycle_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -17,6 +18,9 @@ async def test_activate_is_owner_only_and_idempotent(
         async_client, async_session, auth_header_factory(owner)
     )
     sim_id = created["id"]
+    await _approve_trial(
+        async_client, sim_id=sim_id, headers=auth_header_factory(owner)
+    )
 
     forbidden = await async_client.post(
         f"/api/trials/{sim_id}/activate",

--- a/tests/trials/routes/test_trials_lifecycle_activate_rejects_unlocked_scenario_routes.py
+++ b/tests/trials/routes/test_trials_lifecycle_activate_rejects_unlocked_scenario_routes.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.shared.database.shared_database_models_model import Trial
+from app.shared.jobs import worker
+from app.shared.jobs.handlers import scenario_generation as scenario_handler
+from tests.trials.routes.trials_lifecycle_api_utils import *
+from tests.trials.routes.trials_scenario_generation_flow_api_utils import (
+    session_maker,
+)
+
+
+@pytest.mark.asyncio
+async def test_activate_rejects_unlocked_scenario(
+    async_client, async_session, auth_header_factory, monkeypatch
+):
+    owner = await create_talent_partner(async_session, email="owner-unlocked@test.com")
+    monkeypatched_session_maker = session_maker(async_session)
+    monkeypatch.setattr(
+        scenario_handler, "async_session_maker", monkeypatched_session_maker
+    )
+    response = await async_client.post(
+        "/api/trials",
+        headers=auth_header_factory(owner),
+        json={
+            "title": "Unlocked Guard",
+            "role": "Backend Engineer",
+            "techStack": "Python, FastAPI",
+            "seniority": "Mid",
+            "focus": "Verify activation is blocked before approval",
+        },
+    )
+    assert response.status_code == 201, response.text
+    created = response.json()
+    trial_id = created["id"]
+
+    worker.clear_handlers()
+    try:
+        worker.register_builtin_handlers()
+        handled = await worker.run_once(
+            session_maker=monkeypatched_session_maker,
+            worker_id="activate-unlocked-worker",
+            now=datetime.now(UTC),
+        )
+    finally:
+        worker.clear_handlers()
+    assert handled is True
+    trial = await async_session.get(Trial, trial_id)
+    assert trial is not None
+    assert trial.active_scenario_version_id is not None
+
+    response = await async_client.post(
+        f"/api/trials/{trial_id}/activate",
+        headers=auth_header_factory(owner),
+        json={"confirm": True},
+    )
+    assert response.status_code == 409, response.text
+    body = response.json()
+    assert body["errorCode"] == "SCENARIO_LOCK_REQUIRED"

--- a/tests/trials/routes/test_trials_lifecycle_activate_requires_confirm_true_routes.py
+++ b/tests/trials/routes/test_trials_lifecycle_activate_requires_confirm_true_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.trials.routes.trials_lifecycle_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -16,6 +17,9 @@ async def test_activate_requires_confirm_true(
         async_client, async_session, auth_header_factory(owner)
     )
     sim_id = created["id"]
+    await _approve_trial(
+        async_client, sim_id=sim_id, headers=auth_header_factory(owner)
+    )
 
     res = await async_client.post(
         f"/api/trials/{sim_id}/activate",

--- a/tests/trials/routes/test_trials_lifecycle_candidate_token_resolve_and_claim_hidden_after_termination_routes.py
+++ b/tests/trials/routes/test_trials_lifecycle_candidate_token_resolve_and_claim_hidden_after_termination_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.trials.routes.trials_lifecycle_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -16,6 +17,9 @@ async def test_candidate_token_resolve_and_claim_hidden_after_termination(
         async_client, async_session, auth_header_factory(talent_partner)
     )
     sim_id = created["id"]
+    await _approve_trial(
+        async_client, sim_id=sim_id, headers=auth_header_factory(talent_partner)
+    )
 
     activate = await async_client.post(
         f"/api/trials/{sim_id}/activate",

--- a/tests/trials/routes/test_trials_lifecycle_detail_includes_status_and_lifecycle_timestamps_routes.py
+++ b/tests/trials/routes/test_trials_lifecycle_detail_includes_status_and_lifecycle_timestamps_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.trials.routes.trials_lifecycle_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -24,11 +25,15 @@ async def test_detail_includes_status_and_lifecycle_timestamps(
     assert detail.status_code == 200, detail.text
     body = detail.json()
     assert body["status"] == "ready_for_review"
+    assert body["generationStatus"] == "ready_for_review"
     assert body["generatingAt"] is not None
     assert body["readyForReviewAt"] is not None
     assert body["activatedAt"] is None
     assert body["scenarioVersionSummary"]["templateKey"] == "python-fastapi"
 
+    await _approve_trial(
+        async_client, sim_id=sim_id, headers=auth_header_factory(talent_partner)
+    )
     activate = await async_client.post(
         f"/api/trials/{sim_id}/activate",
         headers=auth_header_factory(talent_partner),
@@ -43,4 +48,5 @@ async def test_detail_includes_status_and_lifecycle_timestamps(
     assert detail_after.status_code == 200, detail_after.text
     body_after = detail_after.json()
     assert body_after["status"] == "active_inviting"
+    assert body_after["generationStatus"] == "ready_for_review"
     assert body_after["activatedAt"] is not None

--- a/tests/trials/routes/test_trials_lifecycle_invite_create_blocked_after_termination_routes.py
+++ b/tests/trials/routes/test_trials_lifecycle_invite_create_blocked_after_termination_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.trials.routes.trials_lifecycle_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -16,6 +17,9 @@ async def test_invite_create_blocked_after_termination(
         async_client, async_session, auth_header_factory(talent_partner)
     )
     sim_id = created["id"]
+    await _approve_trial(
+        async_client, sim_id=sim_id, headers=auth_header_factory(talent_partner)
+    )
 
     activate = await async_client.post(
         f"/api/trials/{sim_id}/activate",

--- a/tests/trials/routes/test_trials_lifecycle_invite_requires_active_inviting_routes.py
+++ b/tests/trials/routes/test_trials_lifecycle_invite_requires_active_inviting_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.trials.routes.trials_lifecycle_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -30,6 +31,9 @@ async def test_invite_requires_active_inviting(
         "details": {"status": "ready_for_review"},
     }
 
+    await _approve_trial(
+        async_client, sim_id=sim_id, headers=auth_header_factory(talent_partner)
+    )
     activate = await async_client.post(
         f"/api/trials/{sim_id}/activate",
         headers=auth_header_factory(talent_partner),

--- a/tests/trials/routes/test_trials_lifecycle_invite_resend_blocked_after_termination_routes.py
+++ b/tests/trials/routes/test_trials_lifecycle_invite_resend_blocked_after_termination_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.trials.routes.trials_lifecycle_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -16,6 +17,9 @@ async def test_invite_resend_blocked_after_termination(
         async_client, async_session, auth_header_factory(talent_partner)
     )
     sim_id = created["id"]
+    await _approve_trial(
+        async_client, sim_id=sim_id, headers=auth_header_factory(talent_partner)
+    )
 
     activate = await async_client.post(
         f"/api/trials/{sim_id}/activate",

--- a/tests/trials/routes/test_trials_lifecycle_terminated_hidden_by_default_in_trial_and_candidate_lists_routes.py
+++ b/tests/trials/routes/test_trials_lifecycle_terminated_hidden_by_default_in_trial_and_candidate_lists_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import pytest
 
 from tests.trials.routes.trials_lifecycle_api_utils import *
+from tests.trials.routes.trials_scenario_versions_api_utils import _approve_trial
 
 
 @pytest.mark.asyncio
@@ -14,6 +15,9 @@ async def test_terminated_hidden_by_default_in_trial_and_candidate_lists(
         async_client, async_session, auth_header_factory(talent_partner)
     )
     sim_id = created["id"]
+    await _approve_trial(
+        async_client, sim_id=sim_id, headers=auth_header_factory(talent_partner)
+    )
 
     activate = await async_client.post(
         f"/api/trials/{sim_id}/activate",

--- a/tests/trials/routes/test_trials_scenario_generation_flow_failure_routes.py
+++ b/tests/trials/routes/test_trials_scenario_generation_flow_failure_routes.py
@@ -75,3 +75,18 @@ async def test_scenario_generation_failure_marks_job_failed_and_keeps_generating
     assert job_status["jobType"] == "scenario_generation"
     assert job_status["status"] == "failed"
     assert "forced scenario generation failure" in (job_status["error"] or "")
+
+    detail_response = await async_client.get(
+        f"/api/trials/{trial_id}",
+        headers=auth_header_factory(talent_partner),
+    )
+    assert detail_response.status_code == 200, detail_response.text
+    detail = detail_response.json()
+    assert detail["generationStatus"] == "failed"
+    assert detail["generationFailure"] is not None
+    assert detail["generationFailure"]["jobId"] == job_id
+    assert detail["generationFailure"]["status"] == "failed"
+    assert detail["generationFailure"]["retryable"] is True
+    assert detail["generationFailure"]["canRetry"] is True
+    assert detail["canRetryGeneration"] is True
+    assert detail["scenario"] is None

--- a/tests/trials/routes/test_trials_scenario_versions_first_invite_locks_active_scenario_and_pins_candidate_session_routes.py
+++ b/tests/trials/routes/test_trials_scenario_versions_first_invite_locks_active_scenario_and_pins_candidate_session_routes.py
@@ -16,6 +16,11 @@ async def test_first_invite_locks_active_scenario_and_pins_candidate_session(
         async_client, async_session, auth_header_factory(talent_partner)
     )
 
+    await _approve_trial(
+        async_client,
+        sim_id=sim_id,
+        headers=auth_header_factory(talent_partner),
+    )
     activate = await async_client.post(
         f"/api/trials/{sim_id}/activate",
         headers=auth_header_factory(talent_partner),
@@ -29,8 +34,8 @@ async def test_first_invite_locks_active_scenario_and_pins_candidate_session(
     assert detail_before.status_code == 200, detail_before.text
     scenario_before = detail_before.json()["scenario"]
     assert scenario_before["versionIndex"] == 1
-    assert scenario_before["status"] == "ready"
-    assert scenario_before["lockedAt"] is None
+    assert scenario_before["status"] == "locked"
+    assert scenario_before["lockedAt"] is not None
 
     invite = await async_client.post(
         f"/api/trials/{sim_id}/invite",

--- a/tests/trials/routes/test_trials_scenario_versions_mutating_locked_scenario_returns_scenario_locked_routes.py
+++ b/tests/trials/routes/test_trials_scenario_versions_mutating_locked_scenario_returns_scenario_locked_routes.py
@@ -16,6 +16,9 @@ async def test_mutating_locked_scenario_returns_scenario_locked(
         async_client, async_session, auth_header_factory(talent_partner)
     )
 
+    await _approve_trial(
+        async_client, sim_id=sim_id, headers=auth_header_factory(talent_partner)
+    )
     activate = await async_client.post(
         f"/api/trials/{sim_id}/activate",
         headers=auth_header_factory(talent_partner),

--- a/tests/trials/routes/test_trials_scenario_versions_patch_scenario_version_locked_returns_scenario_locked_routes.py
+++ b/tests/trials/routes/test_trials_scenario_versions_patch_scenario_version_locked_returns_scenario_locked_routes.py
@@ -15,6 +15,7 @@ async def test_patch_scenario_version_locked_returns_scenario_locked(
     headers = auth_header_factory(talent_partner)
     sim_id = await _create_trial(async_client, async_session, headers)
 
+    await _approve_trial(async_client, sim_id=sim_id, headers=headers)
     activate = await async_client.post(
         f"/api/trials/{sim_id}/activate",
         headers=headers,

--- a/tests/trials/routes/test_trials_scenario_versions_regenerate_approval_promotes_pending_routes.py
+++ b/tests/trials/routes/test_trials_scenario_versions_regenerate_approval_promotes_pending_routes.py
@@ -18,6 +18,7 @@ async def test_regenerate_approval_promotes_pending_scenario(
     )
     headers = auth_header_factory(talent_partner)
 
+    await _approve_trial(async_client, sim_id=sim_id, headers=headers)
     activate = await async_client.post(
         f"/api/trials/{sim_id}/activate",
         headers=headers,
@@ -53,6 +54,10 @@ async def test_regenerate_approval_promotes_pending_scenario(
         active_id=first_scenario.id,
         pending_id=regenerated_scenario_id,
     )
+    assert ready_body["scenario"]["id"] == regenerated_scenario_id
+    assert ready_body["scenario"]["lockedAt"] is None
+    assert ready_body["canApproveScenario"] is True
+    assert ready_body["scenarioLocked"] is False
 
     approve = await async_client.post(
         f"/api/trials/{sim_id}/scenario/{regenerated_scenario_id}/approve",
@@ -61,14 +66,16 @@ async def test_regenerate_approval_promotes_pending_scenario(
     assert approve.status_code == 200, approve.text
     _assert_trial_state(
         approve.json(),
-        status="active_inviting",
+        status="ready_for_review",
         active_id=regenerated_scenario_id,
         pending_id=None,
     )
     approved_detail = await _trial_detail(async_client, sim_id=sim_id, headers=headers)
     _assert_trial_state(
         approved_detail,
-        status="active_inviting",
+        status="ready_for_review",
         active_id=regenerated_scenario_id,
         pending_id=None,
     )
+    assert approved_detail["scenario"]["lockedAt"] is not None
+    assert approved_detail["canActivateTrial"] is True

--- a/tests/trials/routes/test_trials_scenario_versions_regenerate_blocks_until_ready_routes.py
+++ b/tests/trials/routes/test_trials_scenario_versions_regenerate_blocks_until_ready_routes.py
@@ -18,6 +18,7 @@ async def test_regenerate_blocks_activation_and_invites_until_ready(
     )
     headers = auth_header_factory(talent_partner)
 
+    await _approve_trial(async_client, sim_id=sim_id, headers=headers)
     activate = await async_client.post(
         f"/api/trials/{sim_id}/activate",
         headers=headers,
@@ -47,6 +48,9 @@ async def test_regenerate_blocks_activation_and_invites_until_ready(
         active_id=first_scenario.id,
         pending_id=regenerated_scenario_id,
     )
+    assert pending_body["scenario"]["id"] == first_scenario.id
+    assert pending_body["generationStatus"] == "generating"
+    assert pending_body["canApproveScenario"] is False
 
     activate_while_pending = await async_client.post(
         f"/api/trials/{sim_id}/activate",

--- a/tests/trials/routes/test_trials_scenario_versions_regenerate_duplicate_pending_returns_409_routes.py
+++ b/tests/trials/routes/test_trials_scenario_versions_regenerate_duplicate_pending_returns_409_routes.py
@@ -17,6 +17,7 @@ async def test_regenerate_duplicate_pending_returns_409(
     )
     headers = auth_header_factory(talent_partner)
 
+    await _approve_trial(async_client, sim_id=sim_id, headers=headers)
     activate = await async_client.post(
         f"/api/trials/{sim_id}/activate",
         headers=headers,

--- a/tests/trials/routes/test_trials_scenario_versions_regenerate_enqueues_scenario_generation_job_routes.py
+++ b/tests/trials/routes/test_trials_scenario_versions_regenerate_enqueues_scenario_generation_job_routes.py
@@ -16,6 +16,7 @@ async def test_regenerate_enqueues_scenario_generation_job(
         async_client, async_session, auth_header_factory(talent_partner)
     )
     headers = auth_header_factory(talent_partner)
+    await _approve_trial(async_client, sim_id=sim_id, headers=headers)
     activate = await async_client.post(
         f"/api/trials/{sim_id}/activate",
         headers=headers,

--- a/tests/trials/routes/test_trials_scenario_versions_regenerate_preserves_invite_pinning_routes.py
+++ b/tests/trials/routes/test_trials_scenario_versions_regenerate_preserves_invite_pinning_routes.py
@@ -18,6 +18,7 @@ async def test_regenerate_preserves_existing_invite_pinning(
     )
     headers = auth_header_factory(talent_partner)
 
+    await _approve_trial(async_client, sim_id=sim_id, headers=headers)
     activate = await async_client.post(
         f"/api/trials/{sim_id}/activate",
         headers=headers,
@@ -49,6 +50,13 @@ async def test_regenerate_preserves_existing_invite_pinning(
         headers=headers,
     )
     assert approve.status_code == 200, approve.text
+
+    re_activate = await async_client.post(
+        f"/api/trials/{sim_id}/activate",
+        headers=headers,
+        json={"confirm": True},
+    )
+    assert re_activate.status_code == 200, re_activate.text
 
     second_candidate_session_id = await _invite_candidate(
         async_client,

--- a/tests/trials/routes/test_trials_scenario_versions_regenerate_rate_limited_in_prod_routes.py
+++ b/tests/trials/routes/test_trials_scenario_versions_regenerate_rate_limited_in_prod_routes.py
@@ -25,12 +25,15 @@ async def test_regenerate_rate_limited_in_prod(
         first_sim_id = await _create_trial(async_client, async_session, headers)
         second_sim_id = await _create_trial(async_client, async_session, headers)
 
+        await _approve_trial(async_client, sim_id=first_sim_id, headers=headers)
+
         activate_first = await async_client.post(
             f"/api/trials/{first_sim_id}/activate",
             headers=headers,
             json={"confirm": True},
         )
         assert activate_first.status_code == 200, activate_first.text
+        await _approve_trial(async_client, sim_id=second_sim_id, headers=headers)
         activate_second = await async_client.post(
             f"/api/trials/{second_sim_id}/activate",
             headers=headers,

--- a/tests/trials/routes/trials_scenario_versions_api_utils.py
+++ b/tests/trials/routes/trials_scenario_versions_api_utils.py
@@ -92,6 +92,18 @@ async def _trial_detail(async_client, *, sim_id: int, headers) -> dict:
     return response.json()
 
 
+async def _approve_trial(async_client, *, sim_id: int, headers) -> dict:
+    detail = await _trial_detail(async_client, sim_id=sim_id, headers=headers)
+    scenario_version_id = detail["activeScenarioVersionId"]
+    assert scenario_version_id is not None
+    response = await async_client.post(
+        f"/api/trials/{sim_id}/scenario/{scenario_version_id}/approve",
+        headers=headers,
+    )
+    assert response.status_code == 200, response.text
+    return response.json()
+
+
 async def _active_scenario(async_session, *, sim_id: int):
     return (
         await async_session.execute(

--- a/tests/trials/schemas/test_trials_ai_models_schema.py
+++ b/tests/trials/schemas/test_trials_ai_models_schema.py
@@ -27,3 +27,18 @@ def test_trial_ai_config_serializer_omits_none_fields():
     assert TrialAIConfig.model_validate(
         {"evalEnabledByDay": {"1": True}}
     ).model_dump() == {"evalEnabledByDay": {"1": True}}
+
+
+def test_trial_ai_config_serializes_prompt_overrides():
+    config = TrialAIConfig.model_validate(
+        {
+            "promptOverrides": {
+                "prestart": {"instructionsMd": "Use a realistic storyline."}
+            }
+        }
+    )
+    assert config.model_dump() == {
+        "promptOverrides": {
+            "prestart": {"instructionsMd": "Use a realistic storyline."}
+        }
+    }

--- a/tests/trials/services/test_trials_lifecycle_service_activate_and_terminate_service_idempotency_service.py
+++ b/tests/trials/services/test_trials_lifecycle_service_activate_and_terminate_service_idempotency_service.py
@@ -36,6 +36,10 @@ async def test_activate_and_terminate_service_idempotency(async_session):
     async_session.add(trial)
     await async_session.flush()
     await _attach_active_scenario(async_session, trial)
+    active = await async_session.get(ScenarioVersion, trial.active_scenario_version_id)
+    assert active is not None
+    active.status = "locked"
+    active.locked_at = datetime.now(UTC)
     trial.status = sim_service.TRIAL_STATUS_READY_FOR_REVIEW
     trial.ready_for_review_at = datetime.now(UTC)
     await async_session.commit()

--- a/tests/trials/services/test_trials_lifecycle_service_activate_rejected_when_scenario_missing_service.py
+++ b/tests/trials/services/test_trials_lifecycle_service_activate_rejected_when_scenario_missing_service.py
@@ -1,19 +1,22 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
 import pytest
 
 from tests.trials.services.trials_lifecycle_service_utils import *
 
 
 @pytest.mark.asyncio
-async def test_activate_rejected_transition_surfaces_api_error(async_session):
-    company = Company(name="Activate Reject Co")
+async def test_activate_rejected_when_scenario_missing(async_session):
+    company = Company(name="Activate Missing Guard Co")
     async_session.add(company)
     await async_session.flush()
 
     owner = User(
         name="Owner",
-        email="owner-activate-reject@test.com",
+        email="owner-activate-missing@test.com",
         role="talent_partner",
         company_id=company.id,
         password_hash="",
@@ -23,11 +26,11 @@ async def test_activate_rejected_transition_surfaces_api_error(async_session):
 
     trial = Trial(
         company_id=company.id,
-        title="Already Terminated",
+        title="Missing Scenario",
         role="Backend Engineer",
         tech_stack="Python",
         seniority="Mid",
-        focus="Rejected transition",
+        focus="Reject lifecycle activate without a locked scenario",
         scenario_template="default-5day-node-postgres",
         created_by=owner.id,
         status=sim_service.TRIAL_STATUS_GENERATING,
@@ -35,13 +38,6 @@ async def test_activate_rejected_transition_surfaces_api_error(async_session):
     )
     async_session.add(trial)
     await async_session.flush()
-    await _attach_active_scenario(async_session, trial)
-    active = await async_session.get(ScenarioVersion, trial.active_scenario_version_id)
-    assert active is not None
-    active.status = "locked"
-    active.locked_at = datetime.now(UTC)
-    trial.status = sim_service.TRIAL_STATUS_TERMINATED
-    trial.terminated_at = datetime.now(UTC)
     await async_session.commit()
 
     with pytest.raises(ApiError) as excinfo:
@@ -51,4 +47,24 @@ async def test_activate_rejected_transition_surfaces_api_error(async_session):
             actor_user_id=owner.id,
         )
     assert excinfo.value.status_code == 409
-    assert excinfo.value.error_code == "TRIAL_INVALID_STATUS_TRANSITION"
+    assert excinfo.value.error_code == "SCENARIO_LOCK_REQUIRED"
+
+
+@pytest.mark.asyncio
+async def test_prepare_active_scenario_bundle_on_activation_returns_none_when_missing(
+    monkeypatch,
+):
+    async def _missing_active_scenario_version(*_args, **_kwargs):
+        return None
+
+    monkeypatch.setattr(
+        lifecycle_service,
+        "get_active_scenario_version",
+        _missing_active_scenario_version,
+    )
+
+    result = await lifecycle_service._prepare_active_scenario_bundle_on_activation(
+        object(), trial=SimpleNamespace(id=1)
+    )
+
+    assert result is None

--- a/tests/trials/services/test_trials_lifecycle_service_activate_rejected_when_scenario_unlocked_service.py
+++ b/tests/trials/services/test_trials_lifecycle_service_activate_rejected_when_scenario_unlocked_service.py
@@ -1,19 +1,21 @@
 from __future__ import annotations
 
+from datetime import UTC, datetime
+
 import pytest
 
 from tests.trials.services.trials_lifecycle_service_utils import *
 
 
 @pytest.mark.asyncio
-async def test_activate_rejected_transition_surfaces_api_error(async_session):
-    company = Company(name="Activate Reject Co")
+async def test_activate_rejected_when_scenario_unlocked(async_session):
+    company = Company(name="Activate Locked Guard Co")
     async_session.add(company)
     await async_session.flush()
 
     owner = User(
         name="Owner",
-        email="owner-activate-reject@test.com",
+        email="owner-activate-locked@test.com",
         role="talent_partner",
         company_id=company.id,
         password_hash="",
@@ -23,11 +25,11 @@ async def test_activate_rejected_transition_surfaces_api_error(async_session):
 
     trial = Trial(
         company_id=company.id,
-        title="Already Terminated",
+        title="Unlocked Scenario",
         role="Backend Engineer",
         tech_stack="Python",
         seniority="Mid",
-        focus="Rejected transition",
+        focus="Reject lifecycle activate unless scenario is locked",
         scenario_template="default-5day-node-postgres",
         created_by=owner.id,
         status=sim_service.TRIAL_STATUS_GENERATING,
@@ -36,12 +38,6 @@ async def test_activate_rejected_transition_surfaces_api_error(async_session):
     async_session.add(trial)
     await async_session.flush()
     await _attach_active_scenario(async_session, trial)
-    active = await async_session.get(ScenarioVersion, trial.active_scenario_version_id)
-    assert active is not None
-    active.status = "locked"
-    active.locked_at = datetime.now(UTC)
-    trial.status = sim_service.TRIAL_STATUS_TERMINATED
-    trial.terminated_at = datetime.now(UTC)
     await async_session.commit()
 
     with pytest.raises(ApiError) as excinfo:
@@ -51,4 +47,4 @@ async def test_activate_rejected_transition_surfaces_api_error(async_session):
             actor_user_id=owner.id,
         )
     assert excinfo.value.status_code == 409
-    assert excinfo.value.error_code == "TRIAL_INVALID_STATUS_TRANSITION"
+    assert excinfo.value.error_code == "SCENARIO_LOCK_REQUIRED"

--- a/tests/trials/services/test_trials_scenario_generation_env_service.py
+++ b/tests/trials/services/test_trials_scenario_generation_env_service.py
@@ -62,3 +62,12 @@ def test_choose_generation_source_handles_demo_and_errors():
         scenario_env_service.choose_generation_source(
             demo_mode_enabled=False, llm_available=False
         )
+
+
+def test_choose_generation_source_defaults_to_llm_when_available(monkeypatch):
+    monkeypatch.setattr(scenario_env_service, "is_demo_mode_enabled", lambda: False)
+    monkeypatch.setattr(scenario_env_service, "llm_credentials_available", lambda: True)
+    assert (
+        scenario_env_service.choose_generation_source()
+        == scenario_env_service.SCENARIO_SOURCE_LLM
+    )

--- a/tests/trials/services/test_trials_scenario_generation_generation_service.py
+++ b/tests/trials/services/test_trials_scenario_generation_generation_service.py
@@ -5,8 +5,17 @@ from types import SimpleNamespace
 import pytest
 
 from app.ai import AIPolicySnapshotError, build_ai_policy_snapshot
+from app.ai.ai_output_models import (
+    CodespaceSpec,
+    ScenarioGenerationOutput,
+    ScenarioRubric,
+    ScenarioRubricDimension,
+    ScenarioTaskPrompt,
+)
 from app.integrations.scenario_generation.base_client import (
     ScenarioGenerationProviderError,
+    ScenarioGenerationProviderRequest,
+    ScenarioGenerationProviderResponse,
 )
 from app.trials.services import scenario_generation
 
@@ -125,7 +134,7 @@ def test_generate_scenario_payload_fails_closed_when_llm_generation_errors(
         )
 
 
-def test_generate_scenario_payload_degrades_to_fallback_on_retryable_provider_error(
+def test_generate_scenario_payload_raises_on_retryable_provider_error(
     monkeypatch,
 ) -> None:
     monkeypatch.setattr(
@@ -139,16 +148,13 @@ def test_generate_scenario_payload_degrades_to_fallback_on_retryable_provider_er
 
     monkeypatch.setattr(scenario_generation, "_generate_with_llm", _rate_limited)
 
-    payload = scenario_generation.generate_scenario_payload(
-        role="Backend Engineer",
-        tech_stack="Python",
-        template_key="python-fastapi",
-        ai_policy_snapshot_json=_snapshot(),
-    )
-
-    assert (
-        payload.metadata.source == scenario_generation.SCENARIO_SOURCE_TEMPLATE_FALLBACK
-    )
+    with pytest.raises(RuntimeError, match="openai_request_failed:RateLimitError"):
+        scenario_generation.generate_scenario_payload(
+            role="Backend Engineer",
+            tech_stack="Python",
+            template_key="python-fastapi",
+            ai_policy_snapshot_json=_snapshot(),
+        )
 
 
 def test_generate_scenario_payload_fails_closed_when_source_selection_fails(
@@ -221,6 +227,171 @@ def test_generate_with_llm_placeholder_raises(monkeypatch) -> None:
             template_key="python-fastapi",
             ai_policy_snapshot_json=_snapshot(),
         )
+
+
+def test_is_retryable_scenario_generation_error_detects_blank_and_marker() -> None:
+    assert not scenario_generation._is_retryable_scenario_generation_error(
+        Exception("")
+    )
+    assert not scenario_generation._is_retryable_scenario_generation_error(
+        Exception("temporary provider issue")
+    )
+    assert scenario_generation._is_retryable_scenario_generation_error(
+        Exception("Rate limit exceeded")
+    )
+
+
+def test_generate_with_llm_success_includes_override_context(monkeypatch) -> None:
+    captured: dict[str, object] = {}
+
+    def _build_prompt(*, snapshot_json, agent_key, run_context_md):
+        captured["snapshot_json"] = snapshot_json
+        captured["agent_key"] = agent_key
+        captured["run_context_md"] = run_context_md
+        return "system prompt", "rubric guidance"
+
+    def _require_agent_runtime(snapshot_json, agent_key):
+        captured["runtime_snapshot_json"] = snapshot_json
+        captured["runtime_agent_key"] = agent_key
+        return {"provider": "anthropic", "model": "claude-opus-4.6"}
+
+    def _require_agent_policy_snapshot(snapshot_json, agent_key):
+        captured["policy_snapshot_json"] = snapshot_json
+        captured["policy_agent_key"] = agent_key
+        return {"promptVersion": "v9", "rubricVersion": "r9"}
+
+    class _Provider:
+        def generate_scenario(
+            self, *, request: ScenarioGenerationProviderRequest
+        ) -> ScenarioGenerationProviderResponse:
+            captured["request"] = request
+            return ScenarioGenerationProviderResponse(
+                result=ScenarioGenerationOutput(
+                    storyline_md="A custom storyline with a realistic demo path.",
+                    task_prompts_json=[
+                        ScenarioTaskPrompt(
+                            dayIndex=1,
+                            title="Plan the stack",
+                            description="Define the initial implementation plan.",
+                        ),
+                        ScenarioTaskPrompt(
+                            dayIndex=2,
+                            title="Build the core",
+                            description="Implement the core backend workflow.",
+                        ),
+                        ScenarioTaskPrompt(
+                            dayIndex=3,
+                            title="Integrate the UI",
+                            description="Wire the implementation into the UI.",
+                        ),
+                        ScenarioTaskPrompt(
+                            dayIndex=4,
+                            title="Polish for demo",
+                            description="Prepare the demo narrative and edge cases.",
+                        ),
+                        ScenarioTaskPrompt(
+                            dayIndex=5,
+                            title="Reflect and ship",
+                            description="Finalize the submission and document tradeoffs.",
+                        ),
+                    ],
+                    rubric_json=ScenarioRubric(
+                        summary="Generated rubric for the scenario.",
+                        dayWeights={
+                            "1": 10,
+                            "2": 20,
+                            "3": 25,
+                            "4": 20,
+                            "5": 25,
+                        },
+                        dimensions=[
+                            ScenarioRubricDimension(
+                                name="Scope",
+                                weight=40,
+                                description="Evaluates whether the work is well scoped.",
+                            ),
+                            ScenarioRubricDimension(
+                                name="Delivery",
+                                weight=60,
+                                description="Evaluates implementation quality and finish.",
+                            ),
+                        ],
+                    ),
+                    codespace_spec_json=CodespaceSpec(
+                        summary="A custom scenario requiring full-stack work.",
+                        candidate_goal="Ship the end-to-end implementation in the trial.",
+                        acceptance_criteria=[
+                            "Implement the requested flow.",
+                            "Keep the code testable.",
+                        ],
+                        test_focus=["happy path", "regression coverage"],
+                    ),
+                ),
+                model_name="claude-opus-4.6",
+                model_version="2024-11-15",
+            )
+
+    monkeypatch.setattr(
+        scenario_generation,
+        "build_required_snapshot_prompt",
+        _build_prompt,
+    )
+    monkeypatch.setattr(
+        scenario_generation,
+        "require_agent_runtime",
+        _require_agent_runtime,
+    )
+    monkeypatch.setattr(
+        scenario_generation,
+        "require_agent_policy_snapshot",
+        _require_agent_policy_snapshot,
+    )
+    monkeypatch.setattr(
+        scenario_generation,
+        "get_scenario_generation_provider",
+        lambda _provider: _Provider(),
+    )
+
+    payload = scenario_generation._generate_with_llm(
+        role="Backend Engineer",
+        tech_stack="Python",
+        template_key="python-fastapi",
+        scenario_template="custom-5day",
+        focus="Emphasize production realism.",
+        company_context={"domain": "payments", "productArea": "billing"},
+        company_prompt_overrides_json={"tone": "pragmatic"},
+        trial_prompt_overrides_json={"scope": "end-to-end"},
+        ai_policy_snapshot_json=_snapshot(),
+    )
+
+    assert payload.metadata.source == scenario_generation.SCENARIO_SOURCE_LLM
+    assert payload.metadata.model_name == "claude-opus-4.6"
+    assert payload.metadata.model_version == "2024-11-15"
+    assert payload.metadata.prompt_version == "v9"
+    assert payload.metadata.rubric_version == "r9"
+    assert payload.storyline_md.startswith("A custom storyline")
+    assert (
+        payload.codespace_spec_json["summary"]
+        == "A custom scenario requiring full-stack work."
+    )
+
+    assert captured["agent_key"] == "prestart"
+    assert captured["runtime_agent_key"] == "prestart"
+    assert captured["policy_agent_key"] == "prestart"
+    assert (
+        'Company prompt overrides: {"tone": "pragmatic"}' in captured["run_context_md"]
+    )
+    assert (
+        'Trial prompt overrides: {"scope": "end-to-end"}' in captured["run_context_md"]
+    )
+    request = captured["request"]
+    assert isinstance(request, ScenarioGenerationProviderRequest)
+    assert request.model == "claude-opus-4.6"
+    assert '"focus": "Emphasize production realism."' in request.user_prompt
+    assert (
+        '"companyContext": {\n    "domain": "payments",\n    "productArea": "billing"\n  }'
+        in request.user_prompt
+    )
 
 
 def test_generate_scenario_payload_requires_snapshot() -> None:

--- a/tests/trials/services/test_trials_scenario_versions_approve_scenario_version_guards_service.py
+++ b/tests/trials/services/test_trials_scenario_versions_approve_scenario_version_guards_service.py
@@ -55,3 +55,29 @@ async def test_approve_scenario_version_guards(async_session):
         )
     assert mismatch_exc.value.status_code == 409
     assert mismatch_exc.value.error_code == "SCENARIO_VERSION_NOT_PENDING"
+
+
+@pytest.mark.asyncio
+async def test_approve_scenario_version_without_pending_rejects_unready_active(
+    async_session,
+):
+    owner = await create_talent_partner(
+        async_session, email="scenario-approve-no-pending@test.com"
+    )
+    sim, _tasks = await create_trial(async_session, created_by=owner)
+    active_version = await scenario_service.get_active_scenario_version(
+        async_session, sim.id
+    )
+    assert active_version is not None
+    active_version.status = "generating"
+    await async_session.commit()
+
+    with pytest.raises(ApiError) as excinfo:
+        await scenario_service.approve_scenario_version(
+            async_session,
+            trial_id=sim.id,
+            scenario_version_id=active_version.id,
+            actor_user_id=owner.id,
+        )
+    assert excinfo.value.status_code == 409
+    assert excinfo.value.error_code == "SCENARIO_NOT_READY"

--- a/tests/trials/services/test_trials_scenario_versions_approve_scenario_version_promotes_pending_to_active_service.py
+++ b/tests/trials/services/test_trials_scenario_versions_approve_scenario_version_promotes_pending_to_active_service.py
@@ -6,7 +6,7 @@ from tests.trials.services.trials_scenario_versions_service_utils import *
 
 
 @pytest.mark.asyncio
-async def test_approve_scenario_version_promotes_pending_to_active(async_session):
+async def test_approve_scenario_version_locks_pending_version(async_session):
     talent_partner = await create_talent_partner(
         async_session, email="scenario-approve-ok@test.com"
     )
@@ -35,7 +35,8 @@ async def test_approve_scenario_version_promotes_pending_to_active(async_session
     assert approved_sim.pending_scenario_version_id is None
     assert approved_sim.active_scenario_version_id == regenerated.id
     assert approved_sim.active_scenario_version_id != previous_active
-    assert approved_sim.status == "active_inviting"
+    assert approved_sim.status == "ready_for_review"
+    assert approved_version.locked_at is not None
 
     first_session_active = await async_session.get(ScenarioVersion, previous_active)
     assert first_session_active is not None

--- a/tests/trials/services/test_trials_scenario_versions_approve_scenario_version_without_pending_state_branches_service.py
+++ b/tests/trials/services/test_trials_scenario_versions_approve_scenario_version_without_pending_state_branches_service.py
@@ -23,8 +23,9 @@ async def test_approve_scenario_version_without_pending_state_branches(async_ses
         scenario_version_id=active_id,
         actor_user_id=talent_partner.id,
     )
-    assert approved_sim.status == "active_inviting"
+    assert approved_sim.status == "ready_for_review"
     assert approved_version.id == active_id
+    assert approved_version.locked_at is not None
 
     non_active = ScenarioVersion(
         trial_id=sim.id,


### PR DESCRIPTION
## 2. TL;DR
Trial detail is repaired end to end: `GET /api/trials/{id}` now returns the scenario/task/rubric/lifecycle payloads expected by the preview page, scenario generation produces a reviewable `ScenarioVersion`, approval locks that version, activation requires a locked scenario and moves the Trial to `active_inviting`, and generation failures are surfaced explicitly with retry affordance. Anthropic scenario-generation truncation was fixed so the happy path works live.

## 3. Problem
`GET /api/trials/{id}` was broken and incomplete, and the lifecycle around review, approval, and activation had drifted from the intended Trial flow. Some tests and helpers were masking parts of the real lifecycle, which made the endpoint behavior look more complete than it was. Live manual QA exposed a separate blocker in Anthropic structured output: scenario generation could truncate before completion, which prevented the primary-provider happy path from finishing cleanly.

## 4. What changed
- Updated the Trial detail payload and rendering so the preview page can consume scenario, task, rubric, and lifecycle data in one response.
- Tightened scenario selection and rendering rules so active and pending versions are handled explicitly instead of being inferred through helper shortcuts.
- Added generation failure visibility and retry metadata so failed scenario generation is shown as a real state, not as a silent degrade.
- Changed approval so it locks the `ScenarioVersion` and records the review decision on the version itself.
- Added a hard activation guard that rejects non-locked scenarios before the Trial can move forward.
- Updated candidate/invite/lifecycle tests to require explicit approval before activation.
- Fixed Anthropic scenario generation by compacting prestart prompt guidance, raising the scenario-generation-only Anthropic output cap, and validating the complete structured output path.

## 5. Why this approach
The lifecycle stays `generating -> ready_for_review -> active_inviting -> terminated`, because that is the clearest mapping to the product behavior and avoids inventing a new Trial state just for approval. Approval state belongs on `ScenarioVersion` locking, not on a separate Trial lifecycle state, and `generationStatus` stays distinct from the Trial lifecycle status so review, generation, and activation are not conflated. The explicit lifecycle is better than helper magic because it makes the tests and endpoint behavior match what operators and reviewers actually see. Provider failures must fail visibly rather than silently degrade into template success, and the Anthropic fix was kept narrow on purpose so it only changes the structured scenario-generation path.

## 6. Manual QA
### Final successful live QA
- Local backend and worker started successfully.
- A fresh Trial was created.
- Scenario generation completed successfully through Anthropic.
- A reviewable `ScenarioVersion` was observed.
- Approval succeeded and produced a non-null `lockedAt`.
- Activation succeeded and the Trial moved to `active_inviting`.
- Negative activation before approval returned `SCENARIO_LOCK_REQUIRED`.

### Runtime drift noted during QA
- An earlier local config drift caused readiness to report OpenAI.
- That local runtime issue was corrected during QA.
- The final approved QA was performed on the Anthropic happy path.

## 7. Test plan
- Focused Anthropic provider repro before the fix.
- Focused Anthropic provider verification after the fix.
- `pytest` for config/provider client schema payload tests.
- `pytest` for Anthropic provider integration tests.
- `pytest` for trial scenario generation service tests.
- `pytest` for trial scenario generation route success/failure tests.
- Final `./precommit.sh` result: `1763 passed`, `96.03%` coverage.

## 8. Acceptance criteria mapping
- `GET /api/trials/{id}` returns scenario/task/rubric/lifecycle payloads: repaired Trial detail payload and preview rendering.
- Scenario generation produces a reviewable `ScenarioVersion`: generation now reaches a reviewable version state.
- Scenario approval locks the version: approval now sets the version lock and records `lockedAt`.
- Trial activation moves status to `active_inviting`: activation now transitions the Trial into `active_inviting`.
- Only locked scenarios can be activated: activation now hard-fails with `SCENARIO_LOCK_REQUIRED` when the version is not locked.
- Generation failure shows retry option: generation failures are surfaced explicitly with retry metadata.

## 9. Risks / follow-ups
- The failure and retry affordance is well covered by tests, but the final manual QA intentionally focused on the happy path rather than re-breaking the provider flow.
- Future cleanup could further centralize public job-status naming if that starts to spread again.
- If prompt payloads grow materially again, the Anthropic output budget may need another pass.

## 10. Notes for reviewers
- Focus on the detail renderer and generation state semantics.
- Check the separation between approval and activation.
- Review the explicit lifecycle in the candidate/invite tests.
- Inspect the Anthropic structured-output fix and confirm why it is intentionally narrow.

Closes #280 