### PR TITLE
Make Trial termination transactional and clean up workspaces, invites, and jobs

### DIFF
--- a/app/shared/jobs/handlers/shared_jobs_handlers_trial_cleanup_handler.py
+++ b/app/shared/jobs/handlers/shared_jobs_handlers_trial_cleanup_handler.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import logging
+from dataclasses import replace
+from datetime import UTC, datetime
 from typing import Any
 
 from sqlalchemy import select
@@ -11,6 +14,31 @@ from app.shared.database.shared_database_models_model import (
     CandidateSession,
     Trial,
     Workspace,
+    WorkspaceGroup,
+)
+from app.shared.http.dependencies.shared_http_dependencies_github_native_utils import (
+    get_github_client,
+)
+from app.shared.jobs.handlers.shared_jobs_handlers_workspace_cleanup_handler import (
+    _apply_retention_cleanup,
+    _enforce_collaborator_revocation,
+)
+from app.shared.jobs.handlers.shared_jobs_handlers_workspace_cleanup_processing_handler import (
+    _process_cleanup_target,
+)
+from app.shared.jobs.handlers.shared_jobs_handlers_workspace_cleanup_queries_handler import (
+    _load_sessions_with_cutoff,
+)
+from app.shared.jobs.handlers.shared_jobs_handlers_workspace_cleanup_runner_handler import (
+    _resolve_cleanup_config,
+)
+from app.shared.jobs.handlers.shared_jobs_handlers_workspace_cleanup_types_handler import (
+    _WorkspaceCleanupTarget,
+)
+from app.shared.jobs.handlers.shared_jobs_handlers_workspace_cleanup_utils import (
+    _cleanup_target_repo_key,
+    _normalize_datetime,
+    _parse_positive_int,
 )
 from app.trials.repositories.trials_repositories_trials_trial_model import (
     TRIAL_STATUS_TERMINATED,
@@ -18,6 +46,8 @@ from app.trials.repositories.trials_repositories_trials_trial_model import (
 from app.trials.services.trials_services_trials_cleanup_jobs_service import (
     TRIAL_CLEANUP_JOB_TYPE,
 )
+
+logger = logging.getLogger(__name__)
 
 
 def _parse_trial_id(payload_json: dict[str, Any]) -> int | None:
@@ -32,8 +62,94 @@ def _parse_trial_id(payload_json: dict[str, Any]) -> int | None:
     return None
 
 
+async def _list_trial_cleanup_targets(
+    db, *, trial_id: int
+) -> list[_WorkspaceCleanupTarget]:
+    grouped_rows = (
+        await db.execute(
+            select(WorkspaceGroup, CandidateSession, Trial)
+            .join(
+                CandidateSession,
+                CandidateSession.id == WorkspaceGroup.candidate_session_id,
+            )
+            .join(Trial, Trial.id == CandidateSession.trial_id)
+            .where(Trial.id == trial_id)
+            .order_by(WorkspaceGroup.created_at.asc(), WorkspaceGroup.id.asc())
+        )
+    ).all()
+    legacy_rows = (
+        await db.execute(
+            select(Workspace, CandidateSession, Trial)
+            .join(
+                CandidateSession, CandidateSession.id == Workspace.candidate_session_id
+            )
+            .join(Trial, Trial.id == CandidateSession.trial_id)
+            .where(Trial.id == trial_id, Workspace.workspace_group_id.is_(None))
+            .order_by(Workspace.created_at.asc(), Workspace.id.asc())
+        )
+    ).all()
+
+    targets: list[_WorkspaceCleanupTarget] = []
+    seen_repo_keys: set[tuple[int, str]] = set()
+    for record, candidate_session, trial in [*grouped_rows, *legacy_rows]:
+        fallback_prefix = (
+            "workspace_group" if isinstance(record, WorkspaceGroup) else "workspace"
+        )
+        repo_key = _cleanup_target_repo_key(
+            candidate_session_id=candidate_session.id,
+            repo_full_name=record.repo_full_name,
+            fallback_id=f"{fallback_prefix}:{record.id}",
+        )
+        if repo_key in seen_repo_keys:
+            continue
+        seen_repo_keys.add(repo_key)
+        targets.append(
+            _WorkspaceCleanupTarget(
+                record=record,
+                candidate_session=candidate_session,
+                trial=trial,
+            )
+        )
+
+    targets.sort(
+        key=lambda target: (
+            _normalize_datetime(target.record.created_at),
+            str(target.record.id),
+        )
+    )
+    return targets
+
+
+async def _process_terminated_trial_cleanup_target(
+    *,
+    db,
+    target: _WorkspaceCleanupTarget,
+    now: datetime,
+    config,
+    github_client,
+    cutoff_session_ids: set[int],
+    summary: dict[str, int],
+    job_id: str | None,
+    logger,
+) -> None:
+    immediate_config = replace(config, retention_days=0)
+    await _process_cleanup_target(
+        db=db,
+        target=target,
+        now=now,
+        config=immediate_config,
+        github_client=github_client,
+        cutoff_session_ids=cutoff_session_ids,
+        summary=summary,
+        job_id=job_id,
+        logger=logger,
+        enforce_collaborator_revocation=_enforce_collaborator_revocation,
+        apply_retention_cleanup=_apply_retention_cleanup,
+    )
+
+
 async def handle_trial_cleanup(payload_json: dict[str, Any]) -> dict[str, Any]:
-    """Retry-safe no-op cleanup skeleton scoped to trial-owned resources."""
+    """Handle trial cleanup."""
     trial_id = _parse_trial_id(payload_json)
     if trial_id is None:
         return {"status": "skipped_invalid_payload", "trialId": None}
@@ -50,26 +166,49 @@ async def handle_trial_cleanup(payload_json: dict[str, Any]) -> dict[str, Any]:
                 "trialId": trial_id,
             }
 
-        rows = (
-            await db.execute(
-                select(Workspace.repo_full_name, Workspace.template_repo_full_name)
-                .join(
-                    CandidateSession,
-                    CandidateSession.id == Workspace.candidate_session_id,
-                )
-                .where(CandidateSession.trial_id == trial_id)
-            )
-        ).all()
+        targets = await _list_trial_cleanup_targets(db, trial_id=trial_id)
+        config = _resolve_cleanup_config()
+        github_client = get_github_client()
+        candidate_session_ids = sorted(
+            {target.candidate_session.id for target in targets}
+        )
+        cutoff_session_ids = await _load_sessions_with_cutoff(
+            db,
+            candidate_session_ids=candidate_session_ids,
+        )
+        summary: dict[str, int] = {
+            "candidateCount": len(targets),
+            "processed": 0,
+            "revoked": 0,
+            "archived": 0,
+            "deleted": 0,
+            "failed": 0,
+            "pending": 0,
+            "alreadyCleaned": 0,
+            "skippedActive": 0,
+        }
 
-    protected_template_repo_matches = sum(
-        1 for repo_full_name, template_repo in rows if repo_full_name == template_repo
-    )
-    return {
-        "status": "noop",
-        "trialId": trial_id,
-        "workspaceRepoCount": len(rows),
-        "protectedTemplateRepoMatches": protected_template_repo_matches,
-    }
+        job_id = str(_parse_positive_int(payload_json.get("jobId")) or "")
+        job_id = job_id or None
+        now = datetime.now(UTC)
+        for target in targets:
+            await _process_terminated_trial_cleanup_target(
+                db=db,
+                target=target,
+                now=now,
+                config=config,
+                github_client=github_client,
+                cutoff_session_ids=cutoff_session_ids,
+                summary=summary,
+                job_id=job_id,
+                logger=logger,
+            )
+
+        return {
+            "status": "completed",
+            "trialId": trial_id,
+            **summary,
+        }
 
 
 __all__ = [

--- a/app/shared/jobs/handlers/shared_jobs_handlers_workspace_cleanup_revocation_handler.py
+++ b/app/shared/jobs/handlers/shared_jobs_handlers_workspace_cleanup_revocation_handler.py
@@ -10,6 +10,7 @@ from app.shared.jobs.handlers.shared_jobs_handlers_workspace_cleanup_types_handl
     _WorkspaceCleanupRetryableError,
 )
 from app.shared.jobs.handlers.shared_jobs_handlers_workspace_cleanup_utils import (
+    _cleanup_is_complete,
     _is_transient_github_error,
     _normalize_repo_full_name,
     _workspace_error_code,
@@ -36,6 +37,8 @@ async def _enforce_collaborator_revocation(
 
     repo_full_name = _normalize_repo_full_name(record.repo_full_name)
     if repo_full_name is None:
+        if _cleanup_is_complete(record):
+            return "already_cleaned"
         record.access_revocation_error = "missing_repo_full_name"
         return "missing_repo"
 

--- a/app/trials/services/trials_services_trials_lifecycle_termination_service.py
+++ b/app/trials/services/trials_services_trials_lifecycle_termination_service.py
@@ -7,14 +7,25 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import UTC, datetime
 
+from sqlalchemy import or_, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.shared.database.shared_database_models_model import Trial
+from app.shared.database.shared_database_models_model import (
+    CandidateSession,
+    Job,
+    Trial,
+)
+from app.shared.jobs.repositories.shared_jobs_repositories_models_repository import (
+    JOB_STATUS_DEAD_LETTER,
+    JOB_STATUS_QUEUED,
+    JOB_STATUS_RUNNING,
+)
 from app.shared.utils.shared_utils_errors_utils import ApiError
 from app.trials.repositories.trials_repositories_trials_trial_model import (
     TRIAL_STATUS_TERMINATED,
 )
 from app.trials.services.trials_services_trials_cleanup_jobs_service import (
+    TRIAL_CLEANUP_JOB_TYPE,
     enqueue_trial_cleanup_job,
 )
 from app.trials.services.trials_services_trials_lifecycle_access_service import (
@@ -31,6 +42,60 @@ class TerminateTrialResult:
 
     trial: Trial
     cleanup_job_ids: list[str]
+
+
+async def _expire_pending_candidate_sessions(
+    db: AsyncSession, *, trial_id: int, changed_at: datetime
+) -> int:
+    """Expire pending invite rows for the terminated trial."""
+    result = await db.execute(
+        select(CandidateSession).where(
+            CandidateSession.trial_id == trial_id,
+            CandidateSession.status == "not_started",
+            CandidateSession.started_at.is_(None),
+        )
+    )
+    expired = 0
+    for candidate_session in result.scalars():
+        candidate_session.status = "expired"
+        candidate_session.expires_at = changed_at
+        expired += 1
+    return expired
+
+
+async def _cancel_pending_trial_jobs(
+    db: AsyncSession,
+    *,
+    trial: Trial,
+    changed_at: datetime,
+) -> int:
+    """Cancel pending jobs scoped to the terminated trial."""
+    candidate_session_ids = select(CandidateSession.id).where(
+        CandidateSession.trial_id == trial.id
+    )
+    result = await db.execute(
+        select(Job).where(
+            Job.company_id == trial.company_id,
+            Job.job_type != TRIAL_CLEANUP_JOB_TYPE,
+            Job.status.in_((JOB_STATUS_QUEUED, JOB_STATUS_RUNNING)),
+            or_(
+                Job.candidate_session_id.in_(candidate_session_ids),
+                Job.payload_json["trialId"].as_integer() == trial.id,
+                Job.correlation_id.like(f"trial:{trial.id}%"),
+            ),
+        )
+    )
+    cancelled = 0
+    for job in result.scalars():
+        job.status = JOB_STATUS_DEAD_LETTER
+        job.last_error = "trial_terminated"
+        job.result_json = None
+        job.locked_at = None
+        job.locked_by = None
+        job.next_run_at = None
+        job.updated_at = changed_at
+        cancelled += 1
+    return cancelled
 
 
 async def terminate_trial_with_cleanup_impl(
@@ -67,8 +132,14 @@ async def terminate_trial_with_cleanup_impl(
         raise
     if changed:
         trial.terminated_by_talent_partner_id = actor_user_id
-        if normalized_reason is not None:
-            trial.terminated_reason = normalized_reason
+    if normalized_reason is not None and trial.terminated_reason is None:
+        trial.terminated_reason = normalized_reason
+    expired_count = await _expire_pending_candidate_sessions(
+        db, trial_id=trial.id, changed_at=changed_at
+    )
+    cancelled_job_count = await _cancel_pending_trial_jobs(
+        db, trial=trial, changed_at=changed_at
+    )
     cleanup_job = await enqueue_cleanup_job(
         db,
         trial=trial,
@@ -80,11 +151,16 @@ async def terminate_trial_with_cleanup_impl(
     await db.refresh(trial)
     cleanup_job_ids = [str(cleanup_job.id)]
     logger.info(
-        "Trial terminated trialId=%s actorUserId=%s from=%s to=%s cleanupJobIds=%s",
+        (
+            "Trial terminated trialId=%s actorUserId=%s from=%s to=%s "
+            "expiredInvites=%s cancelledJobs=%s cleanupJobIds=%s"
+        ),
         trial.id,
         actor_user_id,
         from_status,
         normalize_status(trial.status),
+        expired_count,
+        cancelled_job_count,
         cleanup_job_ids,
     )
     return TerminateTrialResult(trial=trial, cleanup_job_ids=cleanup_job_ids)

--- a/pr.md
+++ b/pr.md
@@ -1,122 +1,61 @@
-# Enable candidate invite flow from active Trial through email, empty repo, and Codespace provisioning #283
-Closes #283.
+# Make Trial termination transactional and clean up workspaces, invites, and jobs #284
 
-## Summary
-- The Talent Partner invite flow now works end to end from an `active_inviting` Trial through invite creation, unique invite URL generation, invite email send, candidate claim, empty repo bootstrap, and GitHub Codespace provisioning.
-- Candidate repos are now created as empty repos under `winoe-ai-repos/winoe-ws-{session_id}` and bootstrapped with only `.devcontainer/devcontainer.json`, `.github/workflows/evidence-capture.yml`, `.gitignore`, and `README.md`.
-- No template cloning happens and no precommit is applied. Fresh live QA for candidate session `28` proved `template_repo_full_name=null`, `precommit_sha=null`, and `precommit_details_json=null`.
-- Codespace init/status now refreshes the live GitHub Codespace state and persists the normalized lower-case state back to the workspace row, which closed the stale-state gap seen during local QA.
-- The invite response includes the unique `inviteUrl` contract used by the Talent Partner UI copy action, and candidate claim was validated through the supported local dev email-verification bypass path.
+## Title
+Make Trial termination transactional and clean up workspaces, invites, and jobs #284
 
-## Files changed
-- `app/integrations/github/client/integrations_github_client_github_client_repos_client.py`: hardens empty-repo creation identity checks and changes `get_codespace()` to use the user-scoped Codespaces lookup with repo validation.
-- `app/submissions/repositories/github_native/workspaces/submissions_repositories_github_native_workspaces_submissions_github_native_workspaces_mutations_repository.py`: adds persisted workspace `codespace_state` writes.
-- `app/submissions/services/submissions_services_submissions_workspace_bootstrap_service.py`: replaces template/bootstrap assumptions with the empty-repo bootstrap path, writes only the required bootstrap files, creates the Codespace, and stores normalized Codespace metadata.
-- `app/submissions/services/submissions_services_submissions_workspace_repo_state_service.py`: refreshes live Codespace state from GitHub and persists normalized lower-case state into the workspace row.
-- `app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_codespace_init_service.py`: triggers empty-repo workspace provisioning and post-init Codespace refresh during candidate init.
-- `app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_codespace_status_service.py`: refreshes persisted Codespace state during status reads.
-- `app/tasks/routes/tasks/tasks_routes_tasks_tasks_codespace_status_routes.py`: returns the refreshed persisted Codespace state through the candidate status route.
-- `scripts/local_qa_backend.sh`: committed local QA wrapper that pins the supported local bypass flags before delegating to `runBackend.sh`.
-- `README.md`: documents `bash scripts/local_qa_backend.sh` as the local QA backend entrypoint for invite/claim verification.
-- `tests/integrations/github/client/test_integrations_github_client_github_client_misc_methods_client.py`: covers the `/user/codespaces/{name}` lookup path.
-- `tests/scripts/test_local_qa_backend_shell.py`: covers the local QA wrapper env pinning and `.env` reload protection.
+## TL;DR
+Trial termination now runs inside a transaction, marks the Trial as `terminated`, blocks new invites, and creates a single idempotent cleanup job that is reused on reruns. The cleanup path expires pending `not_started` candidate sessions, cancels/dead-letters trial-scoped jobs, archives/deletes candidate workspace repos through the canonical cleanup record, revokes GitHub direct collaborator access, and persists the workspace cleanup fields required for auditability.
 
-## Why
-- The Talent Partner invite flow needed to work end to end from Trial invite through candidate claim.
-- The v4 pivot required from-scratch repo bootstrap instead of template cloning and precommit application.
-- Codespace state persistence had a stale-state gap; live refresh and DB persistence were needed so status reads reflected the actual GitHub Codespace state.
-- Local QA needed a deterministic committed path for claim-bypass validation.
+## Problem
+The previous cleanup handler was a no-op skeleton returning `{"status":"noop"}`, which meant terminating a Trial did not reliably stop new work, did not clean up candidate workspaces, did not revoke GitHub access, and did not cancel queued or running trial-scoped jobs. That left the Trial lifecycle inconsistent and made termination unsafe to rerun.
 
-## Implementation details
-- `get_codespace()` now calls `GET /user/codespaces/{name}` and verifies that the returned `repository.full_name` matches the expected repo before accepting the payload.
-- The Codespace refresh path now normalizes GitHub state to lower case and persists it into the workspace row through `set_codespace_state(...)`.
-- Codespace refresh is triggered during both Codespace init and Codespace status flows, so the DB is repaired from live GitHub state on those paths.
-- The empty-repo bootstrap path creates the candidate repo under `winoe-ai-repos`, writes only `.devcontainer/devcontainer.json`, `.github/workflows/evidence-capture.yml`, `.gitignore`, and `README.md`, then stores the normalized Codespace name/state/url returned by GitHub.
-- Template and precommit fields remain unset on this path, which matches the v4 requirement that the repo stay empty apart from config and the project brief.
-- `scripts/local_qa_backend.sh` now loads env once, forces `DEV_AUTH_BYPASS=1`, forces `WINOE_DEV_AUTH_BYPASS=1`, and redirects `ENV_FILE=/dev/null` before calling `runBackend.sh` so `.env` defaults do not reset the local QA flags.
+## What changed
+- Trial termination is now transactional.
+- Termination sets the Trial state to `terminated`.
+- Terminated Trials block new invites.
+- Pending `not_started` candidate sessions are expired on termination.
+- Pending/running trial-scoped jobs are cancelled or dead-lettered during cleanup.
+- A single idempotent Trial cleanup job is created and reused across reruns.
+- Trial cleanup follows the canonical cleanup path to archive/delete candidate workspace repos.
+- Trial cleanup revokes GitHub direct collaborator access.
+- Workspace cleanup fields are populated on the canonical cleanup record.
+- Termination and cleanup reruns are idempotent.
 
-## QA
-### Automated validation
-- Focused `pytest` slices were run with `--no-cov` against the GitHub client, workspace bootstrap/state persistence, Codespace init/status, and local QA shell wrapper coverage.
-- `poetry run ruff check .`
-- `git diff --check`
-- `bash ./precommit.sh`
-- Final result: `precommit` passed.
+## Why this approach
+The termination path needs to be safe under retries and partial failure. Making termination transactional ensures the Trial state change and cleanup scheduling stay consistent. Reusing one canonical cleanup job avoids duplicate side effects across reruns, and routing all repository cleanup through the canonical cleanup record keeps workspace state, GitHub actions, and audit fields aligned.
 
-### Fresh live QA
-- Trial id: `20`
-- Candidate session id: `28`
-- Candidate email: `qa283live9.1776355353@gmail.com`
-- Invite response payload:
+## Test plan
+- `bash precommit.sh`
+- Final result: `1697 passed, 13 warnings`
+- Coverage: `96.20%`
 
-```json
-{"candidateSessionId":28,"token":"2dyizjDp3uG4_Cpx3zEU-tXQ4kJ0roScw0_veFOhqwU","inviteUrl":"http://localhost:3000/candidate/session/2dyizjDp3uG4_Cpx3zEU-tXQ4kJ0roScw0_veFOhqwU","outcome":"created"}
-```
+## Manual QA evidence
+- Real backend API used.
+- Real GitHub used, not a mock.
+- Trial creation, activation, invite, and terminate flow were exercised end to end.
+- `POST /api/trials/26/terminate` returned terminated with cleanup job id `001a7fb9-0aec-4fb8-93ba-142be4438019`.
+- Repeated terminate returned the same cleanup job id.
+- Candidate session `37` moved to `expired`.
+- Canonical workspace group row for `winoe-ai-repos/winoe-ws-37` showed:
+  - `cleanup_status=archived`
+  - `cleanup_attempted_at` populated
+  - `cleaned_at` populated
+  - `access_revoked_at` populated
+  - `retention_expires_at` populated
+  - `cleanup_error=null`
+- Live GitHub repo `winoe-ai-repos/winoe-ws-37` was archived.
+- `RobelKDev` appeared in `affiliation=direct` before cleanup and disappeared from `affiliation=direct` after cleanup.
+- Post-termination invite attempts were blocked.
+- Trial cleanup job succeeded and was reused idempotently.
+- Collaborator revocation was exercised through a seeded `CandidateDayAudit` cutoff row so the real revocation branch executed.
+- The queued/running job cancellation proof used a synthetic trial-scoped probe job because the scenario generation job had already succeeded during QA.
 
-- Invite URL: `http://localhost:3000/candidate/session/2dyizjDp3uG4_Cpx3zEU-tXQ4kJ0roScw0_veFOhqwU`
-- The invite response returned the unique `inviteUrl` used by the Talent Partner UI copy action.
-- Email DB evidence:
+## Risks / reviewer notes
+- Live GitHub QA showed direct collaborator revocation by confirming the collaborator disappeared from `affiliation=direct`.
+- Any remaining visibility in `affiliation=all` after cleanup was inherited org/team/admin access, not direct collaborator access.
+- Grouped workspace cleanup is canonical. Duplicate legacy workspace rows for the same repo key are intentionally skipped and are not a blocker.
+- Cleanup reruns are designed to be idempotent, so repeated terminate requests should return the same cleanup job id and avoid duplicate side effects.
 
-```text
-invite_email_status=sent
-invite_email_error=null
-invite_email_last_attempt_at=2026-04-16T16:02:33.682493+00:00
-invite_email_sent_at=2026-04-16T16:02:33.682493+00:00
-```
-
-- Repo full name: `winoe-ai-repos/winoe-ws-28`
-- Exact repo contents:
-
-```text
-.devcontainer/devcontainer.json
-.github/workflows/evidence-capture.yml
-.gitignore
-README.md
-```
-
-- Template/precommit DB proof:
-
-```text
-template_repo_full_name=null
-precommit_sha=null
-precommit_details_json=null
-```
-
-- Codespace name: `symmetrical-couscous-4j9qqw4qwjqvf69r`
-- Codespace URL: `https://symmetrical-couscous-4j9qqw4qwjqvf69r.github.dev`
-- GitHub codespace state: `Available`
-- DB workspace row state: `available`
-- Refresh route used: `GET /api/tasks/97/codespace/status` with `Authorization: Bearer candidate:qa283live9.1776355353@gmail.com` and `x-candidate-session-id: 28`
-- Claim request: `POST /api/candidate/session/2dyizjDp3uG4_Cpx3zEU-tXQ4kJ0roScw0_veFOhqwU/claim` with `Authorization: Bearer candidate:qa283live9.1776355353@gmail.com`
-- Claim response proof: candidate session returned `status=in_progress`
-- Candidate session DB row after claim:
-
-```text
-status=in_progress
-claimed_at=2026-04-16T16:03:32.393842+00:00
-started_at=2026-04-16T16:03:32.393842+00:00
-candidate_auth0_sub=candidate:qa283live9.1776355353@gmail.com
-candidate_auth0_email=qa283live9.1776355353@gmail.com
-candidate_email=qa283live9.1776355353@gmail.com
-candidate_timezone=America/New_York
-scheduled_start_at=2026-04-15T15:48:00+00:00
-schedule_locked_at=2026-04-16T16:03:53.462718+00:00
-```
-
-### Acceptance criteria checklist
-- [x] Talent Partner invites by full name and email from `active_inviting` Trial
-- [x] Unique invite URL generated and emailed
-- [x] Copyable invite link in Talent Partner UI
-- [x] Empty candidate repo created under the Winoe repos org
-- [x] Repo initialized with `.devcontainer/devcontainer.json`, `README.md`, `.gitignore`, and evidence-capture workflow
-- [x] No template cloning, no precommit application
-- [x] GitHub Codespace provisioned for the repo
-- [x] Candidate can claim invite via local dev email verification bypass
-
-## QA nuances
-- The persisted Codespace-state refresh proof was validated through the day-2 Codespace status route in local QA.
-- The local claim proof uses the supported local-only bypass path through the committed `scripts/local_qa_backend.sh`.
-- These are QA/runtime notes, not product-facing behavior changes.
-
-## Conclusion
-Issue #283 is addressed. Fresh live QA satisfied the acceptance criteria above, and this PR is ready to raise.
+## Follow-ups / non-blockers
+- Continue monitoring cleanup telemetry for repeated termination attempts and workspace cleanup retries.
+- Keep the canonical workspace cleanup path as the only place that mutates repository archive/revocation state.

--- a/tests/trials/services/test_trials_cleanup_handler_handler.py
+++ b/tests/trials/services/test_trials_cleanup_handler_handler.py
@@ -3,25 +3,19 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 import pytest
-from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
-from app.shared.jobs.handlers import (
-    shared_jobs_handlers_trial_cleanup_handler as cleanup_handler,
-)
-from app.submissions.repositories.github_native.workspaces import (
-    repository as workspace_repo,
-)
-from tests.shared.factories import (
+from app.shared.jobs.handlers import trial_cleanup as cleanup_handler
+from tests.shared.jobs.handlers.shared_jobs_handlers_workspace_cleanup_utils import (
+    WORKSPACE_CLEANUP_STATUS_ARCHIVED,
+    Workspace,
+    WorkspaceGroup,
+    _session_maker,
     create_candidate_session,
     create_talent_partner,
     create_trial,
+    cs_repo,
+    workspace_repo,
 )
-
-
-def _session_maker(async_session: AsyncSession) -> async_sessionmaker[AsyncSession]:
-    return async_sessionmaker(
-        bind=async_session.bind, expire_on_commit=False, autoflush=False
-    )
 
 
 def test_parse_trial_id_helper_variants():
@@ -66,39 +60,169 @@ async def test_handle_trial_cleanup_skips_when_not_terminated(
 
 
 @pytest.mark.asyncio
-async def test_handle_trial_cleanup_noop_counts_trial_owned_workspaces(
+async def test_handle_trial_cleanup_processes_only_trial_owned_workspaces(
     async_session, monkeypatch
 ):
     talent_partner = await create_talent_partner(
-        async_session, email="cleanup-noop@test.com"
+        async_session, email="cleanup-owner@test.com"
     )
     trial, tasks = await create_trial(async_session, created_by=talent_partner)
+    other_trial, _other_tasks = await create_trial(
+        async_session,
+        created_by=talent_partner,
+        title="Other cleanup trial",
+    )
+
     trial.status = "terminated"
     trial.terminated_at = datetime.now(UTC)
+    trial.terminated_by_talent_partner_id = talent_partner.id
+    await async_session.flush()
+
     candidate_session = await create_candidate_session(
         async_session,
         trial=trial,
-        invite_email="cleanup-noop@example.com",
+        invite_email="cleanup-target@example.com",
+        candidate_name="Cleanup Target",
+        with_default_schedule=True,
+    )
+    legacy_candidate_session = await create_candidate_session(
+        async_session,
+        trial=trial,
+        invite_email="cleanup-legacy@example.com",
+        candidate_name="Cleanup Legacy",
+        with_default_schedule=True,
+    )
+    other_candidate_session = await create_candidate_session(
+        async_session,
+        trial=other_trial,
+        invite_email="cleanup-other@example.com",
+        candidate_name="Cleanup Other",
+        with_default_schedule=True,
+    )
+    candidate_session.github_username = "octocat"
+    legacy_candidate_session.github_username = "legacy-user"
+    other_candidate_session.github_username = "other-user"
+
+    created_at = datetime.now(UTC)
+    target_group = await workspace_repo.create_workspace_group(
+        async_session,
+        candidate_session_id=candidate_session.id,
+        workspace_key="coding",
+        template_repo_full_name="org/template-repo",
+        repo_full_name="org/cleanup-target",
+        default_branch="main",
+        base_template_sha="base-sha",
+        created_at=created_at,
+    )
+    legacy_workspace = await workspace_repo.create_workspace(
+        async_session,
+        workspace_group_id=None,
+        candidate_session_id=legacy_candidate_session.id,
+        task_id=tasks[2].id,
+        template_repo_full_name="org/template-repo",
+        repo_full_name="org/cleanup-legacy",
+        repo_id=5678,
+        default_branch="main",
+        base_template_sha="base-sha",
+        created_at=created_at,
+    )
+    other_group = await workspace_repo.create_workspace_group(
+        async_session,
+        candidate_session_id=other_candidate_session.id,
+        workspace_key="coding",
+        template_repo_full_name="org/template-repo",
+        repo_full_name="org/cleanup-other",
+        default_branch="main",
+        base_template_sha="base-sha",
+        created_at=created_at,
+    )
+    await cs_repo.create_day_audit_once(
+        async_session,
+        candidate_session_id=candidate_session.id,
+        day_index=2,
+        cutoff_at=created_at,
+        cutoff_commit_sha="cutoff-sha",
+        eval_basis_ref="refs/heads/main@cutoff",
+        commit=False,
+    )
+    await cs_repo.create_day_audit_once(
+        async_session,
+        candidate_session_id=legacy_candidate_session.id,
+        day_index=3,
+        cutoff_at=created_at,
+        cutoff_commit_sha="cutoff-sha-legacy",
+        eval_basis_ref="refs/heads/main@cutoff-legacy",
+        commit=False,
     )
     await async_session.commit()
 
-    await workspace_repo.create_workspace(
-        async_session,
-        candidate_session_id=candidate_session.id,
-        task_id=tasks[0].id,
-        template_repo_full_name="org/template-repo",
-        repo_full_name="org/template-repo",
-        repo_id=12345,
-        default_branch="main",
-        base_template_sha="abc123",
-        created_at=datetime.now(UTC),
-    )
+    calls = {"remove": 0, "archive": 0, "delete": 0}
+    target_repos = {target_group.repo_full_name, legacy_workspace.repo_full_name}
+
+    class StubGithubClient:
+        async def remove_collaborator(self, repo_full_name, github_username):
+            calls["remove"] += 1
+            assert repo_full_name in target_repos
+            assert github_username in {"octocat", "legacy-user"}
+            return {}
+
+        async def archive_repo(self, repo_full_name):
+            calls["archive"] += 1
+            assert repo_full_name in target_repos
+            return {"archived": True}
+
+        async def delete_repo(self, repo_full_name):
+            calls["delete"] += 1
+            assert repo_full_name in target_repos
+            return {}
 
     monkeypatch.setattr(
         cleanup_handler, "async_session_maker", _session_maker(async_session)
     )
+    monkeypatch.setattr(
+        cleanup_handler, "get_github_client", lambda: StubGithubClient()
+    )
+
     result = await cleanup_handler.handle_trial_cleanup({"trialId": trial.id})
-    assert result["status"] == "noop"
+
+    assert result["status"] == "completed"
     assert result["trialId"] == trial.id
-    assert result["workspaceRepoCount"] == 1
-    assert result["protectedTemplateRepoMatches"] == 1
+    assert result["candidateCount"] == 2
+    assert result["processed"] == 2
+    assert result["revoked"] == 2
+    assert result["archived"] == 2
+    assert result["deleted"] == 0
+    assert result["alreadyCleaned"] == 0
+    assert result["failed"] == 0
+
+    stored_group = await async_session.get(WorkspaceGroup, target_group.id)
+    assert stored_group is not None
+    await async_session.refresh(stored_group)
+    assert stored_group.cleanup_status == WORKSPACE_CLEANUP_STATUS_ARCHIVED
+    assert stored_group.cleanup_attempted_at is not None
+    assert stored_group.retention_expires_at is not None
+    assert stored_group.cleaned_at is not None
+    assert stored_group.access_revoked_at is not None
+    assert stored_group.cleanup_error is None
+
+    stored_legacy_workspace = await async_session.get(Workspace, legacy_workspace.id)
+    assert stored_legacy_workspace is not None
+    await async_session.refresh(stored_legacy_workspace)
+    assert stored_legacy_workspace.cleanup_status == WORKSPACE_CLEANUP_STATUS_ARCHIVED
+    assert stored_legacy_workspace.cleanup_attempted_at is not None
+    assert stored_legacy_workspace.retention_expires_at is not None
+    assert stored_legacy_workspace.cleaned_at is not None
+    assert stored_legacy_workspace.access_revoked_at is not None
+    assert stored_legacy_workspace.cleanup_error is None
+
+    untouched_other_group = await async_session.get(WorkspaceGroup, other_group.id)
+    assert untouched_other_group is not None
+    await async_session.refresh(untouched_other_group)
+    assert untouched_other_group.cleanup_status is None
+    assert untouched_other_group.cleaned_at is None
+    assert untouched_other_group.access_revoked_at is None
+
+    second = await cleanup_handler.handle_trial_cleanup({"trialId": trial.id})
+    assert second["status"] == "completed"
+    assert second["alreadyCleaned"] == 2
+    assert calls == {"remove": 2, "archive": 2, "delete": 0}

--- a/tests/trials/services/test_trials_lifecycle_service_terminate_with_cleanup_sets_reason_and_enqueues_job_service.py
+++ b/tests/trials/services/test_trials_lifecycle_service_terminate_with_cleanup_sets_reason_and_enqueues_job_service.py
@@ -2,6 +2,12 @@ from __future__ import annotations
 
 import pytest
 
+from app.shared.jobs.repositories.shared_jobs_repositories_models_repository import (
+    JOB_STATUS_DEAD_LETTER,
+    JOB_STATUS_QUEUED,
+    JOB_STATUS_RUNNING,
+)
+from tests.shared.factories import create_candidate_session, create_job
 from tests.trials.services.trials_lifecycle_service_utils import *
 
 
@@ -64,3 +70,147 @@ async def test_terminate_with_cleanup_sets_reason_and_enqueues_job(async_session
     assert jobs[0].id == result.cleanup_job_ids[0]
     assert jobs[0].payload_json["trialId"] == trial.id
     assert jobs[0].payload_json["reason"] == "regenerate"
+
+
+@pytest.mark.asyncio
+async def test_terminate_with_cleanup_expires_pending_invites_and_cancels_trial_jobs(
+    async_session,
+):
+    company = Company(name="Terminate Cleanup Company")
+    async_session.add(company)
+    await async_session.flush()
+
+    owner = User(
+        name="Owner",
+        email="owner-terminate-side-effects@test.com",
+        role="talent_partner",
+        company_id=company.id,
+        password_hash="",
+    )
+    async_session.add(owner)
+    await async_session.flush()
+
+    trial = Trial(
+        company_id=company.id,
+        title="Terminate Side Effects",
+        role="Backend Engineer",
+        tech_stack="Python",
+        seniority="Mid",
+        focus="Termination side effects",
+        scenario_template="default-5day-node-postgres",
+        created_by=owner.id,
+        status=sim_service.TRIAL_STATUS_GENERATING,
+        generating_at=datetime.now(UTC),
+    )
+    other_trial = Trial(
+        company_id=company.id,
+        title="Other Trial",
+        role="Backend Engineer",
+        tech_stack="Python",
+        seniority="Mid",
+        focus="Unrelated trial",
+        scenario_template="default-5day-node-postgres",
+        created_by=owner.id,
+        status=sim_service.TRIAL_STATUS_GENERATING,
+        generating_at=datetime.now(UTC),
+    )
+    async_session.add_all([trial, other_trial])
+    await async_session.flush()
+    await _attach_active_scenario(async_session, trial)
+    await _attach_active_scenario(async_session, other_trial)
+    trial.status = sim_service.TRIAL_STATUS_READY_FOR_REVIEW
+    trial.ready_for_review_at = datetime.now(UTC)
+    other_trial.status = sim_service.TRIAL_STATUS_READY_FOR_REVIEW
+    other_trial.ready_for_review_at = datetime.now(UTC)
+
+    pending_session = await create_candidate_session(
+        async_session,
+        trial=trial,
+        invite_email="pending-terminate@test.com",
+        candidate_name="Pending Terminate",
+        status="not_started",
+        expires_in_days=14,
+    )
+    other_session = await create_candidate_session(
+        async_session,
+        trial=other_trial,
+        invite_email="other-terminate@test.com",
+        candidate_name="Other Terminate",
+        status="not_started",
+        expires_in_days=14,
+    )
+    pending_session.github_username = "pending-user"
+    other_session.github_username = "other-user"
+    await async_session.flush()
+
+    queued_job = await create_job(
+        async_session,
+        company=company,
+        job_type="candidate_completed_notification",
+        status=JOB_STATUS_QUEUED,
+        idempotency_key=f"candidate_completed:{pending_session.id}",
+        payload_json={
+            "trialId": trial.id,
+            "candidateSessionId": pending_session.id,
+        },
+        candidate_session=pending_session,
+        correlation_id=f"candidate_session:{pending_session.id}:candidate_completed_notification",
+    )
+    running_job = await create_job(
+        async_session,
+        company=company,
+        job_type="winoe_report_ready_notification",
+        status=JOB_STATUS_RUNNING,
+        idempotency_key=f"winoe_report_ready:{pending_session.id}",
+        payload_json={
+            "trialId": trial.id,
+            "candidateSessionId": pending_session.id,
+        },
+        candidate_session=pending_session,
+        correlation_id=f"candidate_session:{pending_session.id}:winoe_report_ready_notification",
+    )
+    other_job = await create_job(
+        async_session,
+        company=company,
+        job_type="candidate_completed_notification",
+        status=JOB_STATUS_QUEUED,
+        idempotency_key=f"candidate_completed:{other_session.id}",
+        payload_json={
+            "trialId": other_trial.id,
+            "candidateSessionId": other_session.id,
+        },
+        candidate_session=other_session,
+        correlation_id=f"candidate_session:{other_session.id}:candidate_completed_notification",
+    )
+    await async_session.commit()
+
+    result = await sim_service.terminate_trial_with_cleanup(
+        async_session,
+        trial_id=trial.id,
+        actor_user_id=owner.id,
+        reason="cleanup",
+    )
+
+    assert result.trial.status == sim_service.TRIAL_STATUS_TERMINATED
+    assert result.trial.terminated_reason == "cleanup"
+    assert result.trial.terminated_by_talent_partner_id == owner.id
+    assert len(result.cleanup_job_ids) == 1
+
+    refreshed_session = await async_session.get(
+        type(pending_session), pending_session.id
+    )
+    assert refreshed_session is not None
+    assert refreshed_session.status == "expired"
+    assert refreshed_session.expires_at is not None
+
+    refreshed_queued_job = await async_session.get(type(queued_job), queued_job.id)
+    refreshed_running_job = await async_session.get(type(running_job), running_job.id)
+    refreshed_other_job = await async_session.get(type(other_job), other_job.id)
+    assert refreshed_queued_job is not None
+    assert refreshed_running_job is not None
+    assert refreshed_other_job is not None
+    assert refreshed_queued_job.status == JOB_STATUS_DEAD_LETTER
+    assert refreshed_running_job.status == JOB_STATUS_DEAD_LETTER
+    assert refreshed_other_job.status == JOB_STATUS_QUEUED
+    assert refreshed_queued_job.last_error == "trial_terminated"
+    assert refreshed_running_job.last_error == "trial_terminated"


### PR DESCRIPTION
## TL;DR
Trial termination now runs inside a transaction, marks the Trial as `terminated`, blocks new invites, and creates a single idempotent cleanup job that is reused on reruns. The cleanup path expires pending `not_started` candidate sessions, cancels/dead-letters trial-scoped jobs, archives/deletes candidate workspace repos through the canonical cleanup record, revokes GitHub direct collaborator access, and persists the workspace cleanup fields required for auditability.

## Problem
The previous cleanup handler was a no-op skeleton returning `{"status":"noop"}`, which meant terminating a Trial did not reliably stop new work, did not clean up candidate workspaces, did not revoke GitHub access, and did not cancel queued or running trial-scoped jobs. That left the Trial lifecycle inconsistent and made termination unsafe to rerun.

## What changed
- Trial termination is now transactional.
- Termination sets the Trial state to `terminated`.
- Terminated Trials block new invites.
- Pending `not_started` candidate sessions are expired on termination.
- Pending/running trial-scoped jobs are cancelled or dead-lettered during cleanup.
- A single idempotent Trial cleanup job is created and reused across reruns.
- Trial cleanup follows the canonical cleanup path to archive/delete candidate workspace repos.
- Trial cleanup revokes GitHub direct collaborator access.
- Workspace cleanup fields are populated on the canonical cleanup record.
- Termination and cleanup reruns are idempotent.

## Why this approach
The termination path needs to be safe under retries and partial failure. Making termination transactional ensures the Trial state change and cleanup scheduling stay consistent. Reusing one canonical cleanup job avoids duplicate side effects across reruns, and routing all repository cleanup through the canonical cleanup record keeps workspace state, GitHub actions, and audit fields aligned.

## Test plan
- `bash precommit.sh`
- Final result: `1697 passed, 13 warnings`
- Coverage: `96.20%`

## Manual QA evidence
- Real backend API used.
- Real GitHub used, not a mock.
- Trial creation, activation, invite, and terminate flow were exercised end to end.
- `POST /api/trials/26/terminate` returned terminated with cleanup job id `001a7fb9-0aec-4fb8-93ba-142be4438019`.
- Repeated terminate returned the same cleanup job id.
- Candidate session `37` moved to `expired`.
- Canonical workspace group row for `winoe-ai-repos/winoe-ws-37` showed:
  - `cleanup_status=archived`
  - `cleanup_attempted_at` populated
  - `cleaned_at` populated
  - `access_revoked_at` populated
  - `retention_expires_at` populated
  - `cleanup_error=null`
- Live GitHub repo `winoe-ai-repos/winoe-ws-37` was archived.
- `RobelKDev` appeared in `affiliation=direct` before cleanup and disappeared from `affiliation=direct` after cleanup.
- Post-termination invite attempts were blocked.
- Trial cleanup job succeeded and was reused idempotently.
- Collaborator revocation was exercised through a seeded `CandidateDayAudit` cutoff row so the real revocation branch executed.
- The queued/running job cancellation proof used a synthetic trial-scoped probe job because the scenario generation job had already succeeded during QA.

## Risks / reviewer notes
- Live GitHub QA showed direct collaborator revocation by confirming the collaborator disappeared from `affiliation=direct`.
- Any remaining visibility in `affiliation=all` after cleanup was inherited org/team/admin access, not direct collaborator access.
- Grouped workspace cleanup is canonical. Duplicate legacy workspace rows for the same repo key are intentionally skipped and are not a blocker.
- Cleanup reruns are designed to be idempotent, so repeated terminate requests should return the same cleanup job id and avoid duplicate side effects.

## Follow-ups / non-blockers
- Continue monitoring cleanup telemetry for repeated termination attempts and workspace cleanup retries.
- Keep the canonical workspace cleanup path as the only place that mutates repository archive/revocation state.

Fixes #284 