### PR TITLE
Enforce Codespace-only Day 2/3 workflow and remove offline/local work permission

### DIFF
--- a/app/shared/jobs/handlers/shared_jobs_handlers_day_close_enforcement_runtime_handler.py
+++ b/app/shared/jobs/handlers/shared_jobs_handlers_day_close_enforcement_runtime_handler.py
@@ -125,6 +125,16 @@ async def handle_day_close_enforcement_impl(
             candidate_session_id=candidate_session.id,
             day_index=task.day_index,
         )
+        if revoke_status in {"collaborator_removed", "collaborator_not_found"}:
+            revoked_at = cutoff_at
+            if revoked_at.tzinfo is None:
+                revoked_at = revoked_at.replace(tzinfo=UTC)
+            await workspace_repo.set_access_revocation_state(
+                db,
+                workspace=workspace,
+                access_revoked_at=revoked_at,
+                access_revocation_error=None,
+            )
         default_branch = await resolve_default_branch(
             github_client,
             repo_full_name=repo_full_name,

--- a/app/submissions/repositories/github_native/workspaces/submissions_repositories_github_native_workspaces_submissions_github_native_workspaces_core_repository.py
+++ b/app/submissions/repositories/github_native/workspaces/submissions_repositories_github_native_workspaces_submissions_github_native_workspaces_core_repository.py
@@ -13,6 +13,7 @@ from app.submissions.repositories.github_native.workspaces.submissions_repositor
 from app.submissions.repositories.github_native.workspaces.submissions_repositories_github_native_workspaces_submissions_github_native_workspaces_mutations_repository import (
     create_workspace,
     create_workspace_group,
+    set_access_revocation_state,
     set_precommit_details,
     set_precommit_sha,
 )
@@ -81,6 +82,7 @@ __all__ = [
     "get_workspace_group",
     "resolve_workspace_resolution",
     "session_uses_grouped_workspace",
+    "set_access_revocation_state",
     "set_precommit_details",
     "set_precommit_sha",
 ]

--- a/app/submissions/repositories/github_native/workspaces/submissions_repositories_github_native_workspaces_submissions_github_native_workspaces_mutations_repository.py
+++ b/app/submissions/repositories/github_native/workspaces/submissions_repositories_github_native_workspaces_submissions_github_native_workspaces_mutations_repository.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import datetime
+
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.submissions.repositories.github_native.workspaces.submissions_repositories_github_native_workspaces_submissions_github_native_workspaces_core_model import (
@@ -133,9 +135,28 @@ async def set_codespace_state(
     return workspace
 
 
+async def set_access_revocation_state(
+    db: AsyncSession,
+    *,
+    workspace: Workspace,
+    access_revoked_at: datetime | None,
+    access_revocation_error: str | None,
+    commit: bool = True,
+    refresh: bool = True,
+) -> Workspace:
+    """Persist workspace access revocation state."""
+    workspace.access_revoked_at = access_revoked_at
+    workspace.access_revocation_error = access_revocation_error
+    await (db.commit() if commit else db.flush())
+    if refresh:
+        await db.refresh(workspace)
+    return workspace
+
+
 __all__ = [
     "create_workspace",
     "create_workspace_group",
+    "set_access_revocation_state",
     "set_codespace_state",
     "set_precommit_details",
     "set_precommit_sha",

--- a/app/submissions/schemas/submissions_schemas_submissions_requests_schema.py
+++ b/app/submissions/schemas/submissions_schemas_submissions_requests_schema.py
@@ -57,8 +57,6 @@ class CodespaceInitResponse(APIModel):
     codespaceUrl: str
     codespaceState: str | None = None
     defaultBranch: str | None = None
-    baseTemplateSha: str | None = None
-    precommitSha: str | None = None
     workspaceId: str
 
 
@@ -69,8 +67,6 @@ class CodespaceStatusResponse(APIModel):
     codespaceUrl: str | None = None
     codespaceState: str | None = None
     defaultBranch: str | None = None
-    baseTemplateSha: str | None = None
-    precommitSha: str | None = None
     latestCommitSha: str | None = None
     lastWorkflowRunId: str | None = None
     lastWorkflowConclusion: str | None = None

--- a/app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_codespace_init_service.py
+++ b/app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_codespace_init_service.py
@@ -32,6 +32,9 @@ from app.submissions.services.submissions_services_submissions_workspace_repo_st
 from app.submissions.services.use_cases.submissions_services_use_cases_submissions_use_cases_codespace_validations_service import (
     validate_codespace_request,
 )
+from app.submissions.services.use_cases.submissions_services_use_cases_submissions_use_cases_day_flow_gate_service import (
+    ensure_day_flow_open,
+)
 from app.trials.repositories.scenario_versions import (
     trials_repositories_scenario_versions_trials_scenario_versions_repository as scenario_repo,
 )
@@ -86,6 +89,25 @@ async def init_codespace(
         candidate_session.github_username = normalized_username
     task = await _validate_codespace_request_with_legacy_fallback(
         db, candidate_session, task_id
+    )
+    task_day_index = getattr(task, "day_index", None)
+    task_type = getattr(task, "type", None)
+    existing_workspace = None
+    if task_day_index is not None and task_type is not None:
+        existing_workspace = (
+            await submission_service.workspace_repo.get_by_session_and_task(
+                db,
+                candidate_session_id=candidate_session.id,
+                task_id=task.id,
+                task_day_index=task_day_index,
+                task_type=task_type,
+            )
+        )
+    await ensure_day_flow_open(
+        db,
+        candidate_session=candidate_session,
+        task=task,
+        workspace=existing_workspace,
     )
     trial = None
     if getattr(task, "trial_id", None) is not None:

--- a/app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_codespace_status_service.py
+++ b/app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_codespace_status_service.py
@@ -21,6 +21,9 @@ from app.submissions.services.submissions_services_submissions_codespace_urls_se
 from app.submissions.services.submissions_services_submissions_workspace_repo_state_service import (
     refresh_codespace_state,
 )
+from app.submissions.services.use_cases.submissions_services_use_cases_submissions_use_cases_day_flow_gate_service import (
+    ensure_day_flow_open,
+)
 
 
 async def codespace_status(
@@ -40,6 +43,9 @@ async def codespace_status(
     )
     if workspace is None:
         raise WorkspaceMissing(detail="Workspace not initialized", status_code=404)
+    await ensure_day_flow_open(
+        db, candidate_session=candidate_session, task=task, workspace=workspace
+    )
     if github_client is not None:
         workspace = await refresh_codespace_state(
             db,

--- a/app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_day_flow_gate_service.py
+++ b/app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_day_flow_gate_service.py
@@ -1,0 +1,106 @@
+"""Application module for submissions day flow cutoff gate service workflows."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from fastapi import status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.candidates.candidate_sessions.repositories import (
+    repository_day_audits as cs_repo,
+)
+from app.shared.database.shared_database_models_model import CandidateSession
+from app.shared.utils.shared_utils_errors_utils import (
+    TASK_WINDOW_CLOSED,
+    ApiError,
+)
+
+_DAY_FLOW_INDEXES = {2, 3}
+
+
+def _serialize_optional_datetime(value: datetime | None) -> str | None:
+    if value is None:
+        return None
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return (
+        value.replace(microsecond=0)
+        .isoformat(timespec="seconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _build_day_flow_cutoff_error(
+    *,
+    candidate_session_id: int | None,
+    task_id: int | None,
+    day_index: int | None,
+    cutoff_commit_sha: str | None,
+    cutoff_at: datetime | None,
+    eval_basis_ref: str | None,
+    access_revoked_at: datetime | None = None,
+) -> ApiError:
+    details: dict[str, object | None] = {
+        "candidateSessionId": candidate_session_id,
+        "taskId": task_id,
+        "dayIndex": day_index,
+        "cutoffCommitSha": cutoff_commit_sha,
+        "cutoffAt": _serialize_optional_datetime(cutoff_at),
+        "evalBasisRef": eval_basis_ref,
+    }
+    if access_revoked_at is not None:
+        details["accessRevokedAt"] = _serialize_optional_datetime(access_revoked_at)
+    return ApiError(
+        status_code=status.HTTP_409_CONFLICT,
+        detail="Task is closed after the recorded cutoff.",
+        error_code=TASK_WINDOW_CLOSED,
+        retryable=False,
+        details=details,
+    )
+
+
+async def ensure_day_flow_open(
+    db: AsyncSession,
+    *,
+    candidate_session: CandidateSession,
+    task,
+    workspace=None,
+) -> None:
+    """Reject active Day 2/3 work once the cutoff is recorded or revoked."""
+    day_index = getattr(task, "day_index", None)
+    if day_index not in _DAY_FLOW_INDEXES:
+        return
+
+    day_audit = await cs_repo.get_day_audit(
+        db,
+        candidate_session_id=candidate_session.id,
+        day_index=day_index,
+    )
+    if day_audit is not None:
+        raise _build_day_flow_cutoff_error(
+            candidate_session_id=candidate_session.id,
+            task_id=getattr(task, "id", None),
+            day_index=day_index,
+            cutoff_commit_sha=getattr(day_audit, "cutoff_commit_sha", None),
+            cutoff_at=getattr(day_audit, "cutoff_at", None),
+            eval_basis_ref=getattr(day_audit, "eval_basis_ref", None),
+        )
+
+    if workspace is None:
+        return
+    access_revoked_at = getattr(workspace, "access_revoked_at", None)
+    if access_revoked_at is None:
+        return
+    raise _build_day_flow_cutoff_error(
+        candidate_session_id=candidate_session.id,
+        task_id=getattr(task, "id", None),
+        day_index=day_index,
+        cutoff_commit_sha=None,
+        cutoff_at=access_revoked_at,
+        eval_basis_ref=None,
+        access_revoked_at=access_revoked_at,
+    )
+
+
+__all__ = ["ensure_day_flow_open"]

--- a/app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_fetch_run_service.py
+++ b/app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_fetch_run_service.py
@@ -17,6 +17,9 @@ from app.submissions.services.submissions_services_submissions_rate_limits_const
     concurrency_guard,
     throttle_poll,
 )
+from app.submissions.services.use_cases.submissions_services_use_cases_submissions_use_cases_day_flow_gate_service import (
+    ensure_day_flow_open,
+)
 
 
 async def fetch_run_result(
@@ -32,6 +35,7 @@ async def fetch_run_result(
     throttle_poll(candidate_session.id, run_id)
     task = await submission_service.load_task_or_404(db, task_id)
     submission_service.ensure_task_belongs(task, candidate_session)
+    await ensure_day_flow_open(db, candidate_session=candidate_session, task=task)
     submission_service.validate_run_allowed(task)
 
     workspace = await submission_service.workspace_repo.get_by_session_and_task(

--- a/app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_run_tests_service.py
+++ b/app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_run_tests_service.py
@@ -17,6 +17,9 @@ from app.submissions.services.submissions_services_submissions_rate_limits_const
     apply_rate_limit,
     concurrency_guard,
 )
+from app.submissions.services.use_cases.submissions_services_use_cases_submissions_use_cases_day_flow_gate_service import (
+    ensure_day_flow_open,
+)
 
 
 async def run_task_tests(
@@ -33,6 +36,7 @@ async def run_task_tests(
     task = await submission_service.load_task_or_404(db, task_id)
     submission_service.ensure_task_belongs(task, candidate_session)
     cs_service.require_active_window(candidate_session, task)
+    await ensure_day_flow_open(db, candidate_session=candidate_session, task=task)
     submission_service.validate_run_allowed(task)
 
     workspace = await submission_service.workspace_repo.get_by_session_and_task(

--- a/app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_submit_task_runner_service.py
+++ b/app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_submit_task_runner_service.py
@@ -27,10 +27,8 @@ from app.submissions.services.use_cases.submissions_services_use_cases_submissio
 async def run_code_submission(
     *,
     db: AsyncSession,
-    candidate_session_id: int,
-    task_id: int,
-    task_day_index: int | None = None,
-    task_type: str | None = None,
+    candidate_session,
+    task,
     payload,
     github_client: GithubClient,
     actions_runner,
@@ -38,11 +36,9 @@ async def run_code_submission(
     """Run code submission."""
     workspace, branch = await fetch_workspace_and_branch(
         db,
-        candidate_session_id,
-        task_id,
-        payload,
-        task_day_index=task_day_index,
-        task_type=task_type,
+        candidate_session=candidate_session,
+        task=task,
+        payload=payload,
     )
     try:
         actions_result = await submission_service.run_actions_tests(

--- a/app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_submit_task_service.py
+++ b/app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_submit_task_service.py
@@ -47,10 +47,8 @@ async def submit_task(
     if submission_service.is_code_task(task):
         actions_result, diff_summary_json, workspace = await run_code_submission(
             db=db,
-            candidate_session_id=candidate_session.id,
-            task_id=task.id,
-            task_day_index=getattr(task, "day_index", None),
-            task_type=getattr(task, "type", None),
+            candidate_session=candidate_session,
+            task=task,
             payload=payload,
             github_client=github_client,
             actions_runner=actions_runner,

--- a/app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_submit_validation_service.py
+++ b/app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_submit_validation_service.py
@@ -12,6 +12,9 @@ from app.submissions.constants.submissions_constants_submissions_exceptions_cons
 from app.submissions.services import (
     submissions_services_submissions_candidate_service as submission_service,
 )
+from app.submissions.services.use_cases.submissions_services_use_cases_submissions_use_cases_day_flow_gate_service import (
+    ensure_day_flow_open,
+)
 
 
 async def validate_submission_flow(
@@ -24,6 +27,7 @@ async def validate_submission_flow(
     task = await submission_service.load_task_or_404(db, task_id)
     submission_service.ensure_task_belongs(task, candidate_session)
     cs_service.require_active_window(candidate_session, task)
+    await ensure_day_flow_open(db, candidate_session=candidate_session, task=task)
     task_list, completed_ids, current_task, *_ = await cs_service.progress_snapshot(
         db, candidate_session
     )

--- a/app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_submit_workspace_service.py
+++ b/app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_submit_workspace_service.py
@@ -19,33 +19,37 @@ from app.submissions.repositories.github_native.workspaces.submissions_repositor
 from app.submissions.services import (
     submissions_services_submissions_candidate_service as submission_service,
 )
+from app.submissions.services.use_cases.submissions_services_use_cases_submissions_use_cases_day_flow_gate_service import (
+    ensure_day_flow_open,
+)
 
 
 async def fetch_workspace_and_branch(
     db: AsyncSession,
-    candidate_session_id: int,
-    task_id: int,
+    candidate_session,
+    task,
     payload,
-    *,
-    task_day_index: int | None = None,
-    task_type: str | None = None,
 ) -> tuple[Workspace, str]:
     # Favor a direct task-scoped lookup first. This avoids extra resolution
     # queries on the submit hot path while preserving grouped fallback behavior.
     """Return workspace and branch."""
     workspace = await submission_service.workspace_repo.get_by_session_and_task(
         db,
-        candidate_session_id=candidate_session_id,
-        task_id=task_id,
+        candidate_session_id=candidate_session.id,
+        task_id=task.id,
         workspace_resolution=WorkspaceResolution(
             workspace_key=None,
             uses_grouped_workspace=False,
         ),
     )
-    if workspace is None and task_day_index is not None and task_type is not None:
+    if (
+        workspace is None
+        and getattr(task, "day_index", None) is not None
+        and getattr(task, "type", None) is not None
+    ):
         workspace_key = resolve_workspace_key(
-            day_index=task_day_index,
-            task_type=task_type,
+            day_index=getattr(task, "day_index", None),
+            task_type=getattr(task, "type", None),
         )
         if workspace_key:
             lookup_by_key = getattr(
@@ -56,17 +60,23 @@ async def fetch_workspace_and_branch(
             if callable(lookup_by_key):
                 workspace = await lookup_by_key(
                     db,
-                    candidate_session_id=candidate_session_id,
+                    candidate_session_id=candidate_session.id,
                     workspace_key=workspace_key,
                 )
     if workspace is None:
         workspace = await submission_service.workspace_repo.get_by_session_and_task(
             db,
-            candidate_session_id=candidate_session_id,
-            task_id=task_id,
+            candidate_session_id=candidate_session.id,
+            task_id=task.id,
         )
     if workspace is None:  # pragma: no cover - defensive guard
         raise WorkspaceMissing()
+    await ensure_day_flow_open(
+        db,
+        candidate_session=candidate_session,
+        task=task,
+        workspace=workspace,
+    )
     branch = submission_service.validate_branch(
         getattr(payload, "branch", None) or workspace.default_branch or "main"
     )

--- a/app/tasks/routes/tasks/handlers/tasks_routes_tasks_handlers_tasks_codespace_init_handler.py
+++ b/app/tasks/routes/tasks/handlers/tasks_routes_tasks_handlers_tasks_codespace_init_handler.py
@@ -52,7 +52,5 @@ async def handle_codespace_init(
         codespaceUrl=codespace_url,
         codespaceState=getattr(workspace, "codespace_state", None),
         defaultBranch=workspace.default_branch,
-        baseTemplateSha=getattr(workspace, "base_template_sha", None),
-        precommitSha=getattr(workspace, "precommit_sha", None),
         workspaceId=workspace.id,
     )

--- a/app/tasks/routes/tasks/tasks_routes_tasks_tasks_codespace_status_routes.py
+++ b/app/tasks/routes/tasks/tasks_routes_tasks_tasks_codespace_status_routes.py
@@ -69,8 +69,6 @@ async def codespace_status_route(
         codespaceUrl=codespace_url,
         codespaceState=getattr(workspace, "codespace_state", None),
         defaultBranch=workspace.default_branch,
-        baseTemplateSha=getattr(workspace, "base_template_sha", None),
-        precommitSha=getattr(workspace, "precommit_sha", None),
         latestCommitSha=workspace.latest_commit_sha,
         lastWorkflowRunId=workspace.last_workflow_run_id,
         lastWorkflowConclusion=workspace.last_workflow_conclusion,

--- a/pr.md
+++ b/pr.md
@@ -1,74 +1,74 @@
-# Require GitHub username capture before Day 2 Codespace init #285
+# Enforce Codespace-only Day 2/3 workflow and remove offline/local work permission #286
 
-## Title
-Require GitHub username capture before Day 2 Codespace init #285
+## 1. Summary
+Winoe AI now enforces a Codespace-only Day 2/3 workflow end to end. Active Day 2 and Day 3 flows no longer expose legacy workspace fields, post-cutoff access is locked down with `TASK_WINDOW_CLOSED`, and cutoff evidence is recorded separately so evaluation stays anchored to the recorded cutoff SHA rather than mutable later workspace state.
 
-## Summary
-Winoe AI now captures, validates, normalizes, and persists `githubUsername` earlier in the from-scratch Trial flow, so Codespace init and repo permissioning use the stored candidate session value instead of relying on transient request data.
+## 2. Problem
+The product requires canadidates to build from scratch in Codespaces, with the entire repo being their work. The backend still exposed legacy copy and response fields that suggested offline/local work was acceptable, and cutoff enforcement was not consistently applied across active Day 2/3 flows.
 
-## Problem
-- Frontend/init contract expected `githubUsername`, but GitHub username was not guaranteed to be captured and persisted before Day 2.
-- This created a mismatch between candidate flow, Codespace init, and repo permissioning.
+## 3. Root cause
+- Contract issue: active Codespace init/status responses still exposed legacy fields that implied a pre-cutoff workspace basis.
+- Enforcement issue: the backend did not uniformly block active Day 2/3 actions after cutoff across init, status, run, and submit.
 
-## Root cause
-- `candidate_sessions.github_username` existed, but the schedule flow did not capture it.
-- Codespace init was effectively the first reliable place the backend saw the username.
-- Some frontend-facing payloads did not expose the stored username consistently.
+## 4. Implementation summary
+- Active Day 2/3 Codespace init/status responses now omit `baseTemplateSha` and `precommitSha`.
+- Active Day 2/3 flows now call the shared cutoff gate before init, status, run, and submit.
+- Day 2 and Day 3 cutoff evidence is written as separate `candidate_day_audits` rows.
+- Day 2 submit persists `checkpointSha`.
+- Day 3 submit persists `finalSha`.
+- The response mapping and handler tests now reflect the cutoff contract directly.
 
-## Implementation summary
-- Schedule flow now accepts, validates, normalizes, and persists `githubUsername`.
-- Candidate session resolve/invites payloads expose stored `githubUsername`.
-- Talent Partner trial candidate list exposes stored `githubUsername`.
-- Codespace init validates request input, backfills legacy-null sessions, and treats stored session username as canonical.
-- Mismatch policy is explicit: `409 GITHUB_USERNAME_MISMATCH`.
+## 5. API contract changes
+- `baseTemplateSha` was removed from active Day 2/3 Codespace init/status responses.
+- `precommitSha` was removed from active Day 2/3 Codespace init/status responses.
+- Day 2 submit responses return `checkpointSha` for the Day 2 checkpoint.
+- Day 3 submit responses return `finalSha` for the Day 3 final state.
+- Post-cutoff error payloads include the cutoff basis fields needed for evaluation and audit traceability.
 
-## API contract changes
-- Candidate schedule request now requires `githubUsername`.
-- Candidate schedule response includes `githubUsername`.
-- Candidate session resolve payload includes `githubUsername`.
-- Candidate invites payload includes `githubUsername`.
-- Trial candidate list payload includes `githubUsername`.
-- Codespace init still accepts `githubUsername` for compatibility, but persisted session state is canonical.
+## 6. Cutoff enforcement behavior
+- Active Day 2/3 `codespace/init`, `codespace/status`, `run`, and `submit` requests now reject after cutoff with `409 TASK_WINDOW_CLOSED`.
+- Rejection payloads include cutoff details such as `cutoffCommitSha`, `cutoffAt`, and `evalBasisRef`.
+- The same cutoff gate is used consistently across the active Day 2/3 backend paths, so post-cutoff behavior is uniform instead of route-specific.
 
-## Persistence / model impact
-- No new column added.
-- Existing `candidate_sessions.github_username` is now part of the normal pre-Day-2 flow.
-- Legacy null rows are safely backfilled on init.
+## 7. Evaluation basis behavior
+- The evaluation basis is pinned to the recorded cutoff SHA after cutoff, even if `workspace.latest_commit_sha` changes later.
+- Successful pre-cutoff Day 2/Day 3 submit responses may still return `cutoffCommitSha = null` and `evalBasisRef = null` because the cutoff audit row does not exist yet at that moment.
+- Once the cutoff audit exists, later active requests resolve cutoff details from the audit row rather than from mutable workspace state.
 
-## Repo permissioning / provisioning impact
-- Codespace init no longer relies only on transient request data.
-- Stored `candidate_sessions.github_username` is the durable source of truth passed into workspace provisioning and repo permissioning flow.
+## 8. Persistence / model impact
+- `candidate_day_audits` now carries the authoritative Day 2 and Day 3 cutoff record.
+- Separate audit rows are persisted for `dayIndex = 2` and `dayIndex = 3`.
+- The recorded cutoff SHA and evaluation basis reference are stored per day, which keeps Day 2 and Day 3 evaluation inputs distinct.
 
-## Tests added / updated
-- Schedule persistence: `tests/candidates/routes/test_candidates_session_schedule_schedule_endpoint_persists_and_sends_emails_routes.py`
-- Invalid GitHub username rejection: `tests/candidates/routes/test_candidates_session_schedule_schedule_endpoint_rejects_invalid_github_username_routes.py`
-- Resolve/invites exposure: `tests/candidates/routes/test_candidates_session_schedule_resolve_and_invites_include_schedule_fields_routes.py`
-- Trial candidate list exposure: `tests/trials/routes/test_trials_candidates_list_populated_routes.py`
-- Codespace init backfill: `tests/candidates/routes/test_candidates_submissions_router_init_codespace_username_contract_routes.py::test_init_codespace_backfills_missing_github_username`
-- Codespace init mismatch behavior: `tests/candidates/routes/test_candidates_submissions_router_init_codespace_username_contract_routes.py::test_init_codespace_rejects_github_username_mismatch`
+## 9. Tests added / updated
+- `tests/candidates/routes/test_candidates_submissions_router_init_codespace_success_path_routes.py`
+- `tests/candidates/routes/test_candidates_schedule_gates_run_and_submit_post_cutoff_return_task_window_closed_routes.py`
+- `tests/tasks/routes/test_tasks_run_codespace_init_rejects_after_day_audit_routes.py`
+- `tests/tasks/routes/test_tasks_run_submit_rejects_after_day_audit_routes.py`
+- `tests/tasks/routes/test_tasks_run_codespace_status_returns_summary_routes.py`
+- `tests/tasks/routes/test_tasks_run_codespace_status_naive_cutoff_routes.py`
+- `tests/tasks/routes/test_tasks_submit_submit_day3_debug_returns_and_persists_final_sha_routes.py`
+- `tests/candidates/routes/test_candidates_session_api_current_task_includes_cutoff_fields_when_day_audit_exists_routes.py`
+- `tests/candidates/routes/test_candidates_session_api_current_task_returns_null_cutoff_fields_when_day_audit_missing_routes.py`
+- `tests/tasks/routes/test_tasks_run_codespace_init_works_for_debug_task_routes.py`
 
-## Manual QA evidence
-- Invalid schedule request with `bad user` returned `400 INVALID_GITHUB_USERNAME`.
-- Valid schedule request persisted `github_username = "octocat"`.
-- Resolve payload returned `githubUsername: "octocat"`.
-- Invites payload returned `githubUsername: "octocat"`.
-- Trial candidate list returned stored usernames.
-- Backfill init succeeded for null stored username and persisted `"octocat"`.
-- Mismatch init returned `409 GITHUB_USERNAME_MISMATCH`.
-- Workspace rows were created for successful init paths and not created for mismatch path.
+## 10. Manual QA evidence
+- Command: `poetry run pytest -o addopts='' tests/candidates/routes/test_candidates_submissions_router_init_codespace_success_path_routes.py tests/candidates/routes/test_candidates_schedule_gates_run_and_submit_post_cutoff_return_task_window_closed_routes.py tests/tasks/routes/test_tasks_submit_submit_day3_debug_returns_and_persists_final_sha_routes.py tests/tasks/routes/test_tasks_run_codespace_init_rejects_after_day_audit_routes.py tests/tasks/routes/test_tasks_run_submit_rejects_after_day_audit_routes.py tests/tasks/routes/test_tasks_run_codespace_status_returns_summary_routes.py tests/tasks/routes/test_tasks_run_codespace_status_naive_cutoff_routes.py`
+- Result: `7 passed`
+- Command: `poetry run pytest`
+- Result: `1711 passed`, coverage `96.15%`
+- Day 2 init success response did not include legacy bundle fields.
+- Day 2 status before cutoff returned normal status with `cutoffCommitSha = null` and `cutoffAt = null`.
+- Day 2 submit returned `checkpointSha` and null cutoff fields before cutoff.
+- Day 2 post-cutoff `status`, `run`, and `submit` rejected with `409 TASK_WINDOW_CLOSED` and cutoff details.
+- Day 3 submit returned `finalSha`.
+- Day 3 post-cutoff `status` rejected with `409 TASK_WINDOW_CLOSED` and cutoff details.
+- Separate Day 2 and Day 3 audit rows existed in the database with different `dayIndex` values and different cutoff SHAs.
+- Mutating `workspace.latest_commit_sha` after cutoff did not change the cutoff details returned by later active requests.
+- Focused tests passed.
+- Full repo test suite passed.
 
-## Exact QA commands run
-- `poetry run pytest -o addopts='' tests/candidates/routes/test_candidates_session_schedule_schedule_endpoint_persists_and_sends_emails_routes.py tests/candidates/routes/test_candidates_session_schedule_schedule_endpoint_rejects_invalid_github_username_routes.py tests/candidates/routes/test_candidates_session_schedule_resolve_and_invites_include_schedule_fields_routes.py tests/candidates/routes/test_candidates_submissions_router_init_codespace_username_contract_routes.py tests/candidates/routes/test_candidates_submissions_router_init_codespace_success_path_routes.py tests/candidates/routes/test_candidates_submissions_router_init_codespace_normalizes_legacy_url_routes.py tests/trials/routes/test_trials_candidates_list_populated_routes.py`
-- Result: `8 passed`
-- `poetry run pytest tests/candidates/routes/test_candidates_session_schedule_schedule_endpoint_persists_and_sends_emails_routes.py`
-- Result: test passed, but the repo-wide coverage gate failed with `Required test coverage of 96% not reached. Total coverage: 49.75%`
-- Narrow pytest slices therefore required `-o addopts=''` to bypass the repo-wide coverage gate.
+## 11. Risks / follow-ups
+- Frontend copy and UI should stay aligned with the tightened backend cutoff contract so candidates do not see outdated offline/local wording.
 
-## Rollout / compatibility notes
-- Frontend can continue sending `githubUsername` to Codespace init.
-- Backend now guarantees persistence earlier in the candidate flow.
-- Legacy sessions with null usernames are backfilled on first successful init.
-
-## Risks / follow-ups
-- Case-sensitive mismatch policy is intentional for now; case-insensitive reconciliation can be a follow-up if desired.
-- Live external GitHub/email integration was stubbed in local QA; this PR validates backend contract and flow correctness.
+## 12. Fixes #286

--- a/tests/candidates/repositories/test_candidates_day_audits_repository_basics_repository.py
+++ b/tests/candidates/repositories/test_candidates_day_audits_repository_basics_repository.py
@@ -90,6 +90,43 @@ async def test_create_day_audit_once_returns_existing_when_already_present(
 
 
 @pytest.mark.asyncio
+async def test_create_day_audit_once_keeps_day2_and_day3_separate(async_session):
+    candidate_session = await seed_candidate_session(async_session)
+
+    day2_audit, day2_created = await day_audit_repo.create_day_audit_once(
+        async_session,
+        candidate_session_id=candidate_session.id,
+        day_index=2,
+        cutoff_at=cutoff_at_2026_03_10(),
+        cutoff_commit_sha="sha-day2",
+        eval_basis_ref="refs/heads/main@cutoff",
+        commit=True,
+    )
+    day3_audit, day3_created = await day_audit_repo.create_day_audit_once(
+        async_session,
+        candidate_session_id=candidate_session.id,
+        day_index=3,
+        cutoff_at=cutoff_at_2026_03_10(),
+        cutoff_commit_sha="sha-day3",
+        eval_basis_ref="refs/heads/main@cutoff",
+        commit=True,
+    )
+
+    assert day2_created is True
+    assert day3_created is True
+    assert day2_audit.id != day3_audit.id
+    assert day2_audit.day_index == 2
+    assert day3_audit.day_index == 3
+    listed = await day_audit_repo.list_day_audits(
+        async_session,
+        candidate_session_ids=[candidate_session.id],
+        day_indexes=[2, 3],
+    )
+    assert [row.day_index for row in listed] == [2, 3]
+    assert [row.cutoff_commit_sha for row in listed] == ["sha-day2", "sha-day3"]
+
+
+@pytest.mark.asyncio
 async def test_list_day_audits_without_day_indexes_returns_rows(async_session):
     candidate_session = await seed_candidate_session(async_session)
     await day_audit_repo.create_day_audit_once(

--- a/tests/candidates/routes/test_candidates_submissions_router_codespace_status_invalid_summary_routes.py
+++ b/tests/candidates/routes/test_candidates_submissions_router_codespace_status_invalid_summary_routes.py
@@ -40,5 +40,5 @@ async def test_codespace_status_invalid_summary(monkeypatch, async_session):
     assert resp.lastTestSummary is None
     assert resp.repoFullName == workspace.repo_full_name
     assert resp.codespaceUrl == "https://codespaces.new/org/repo?quickstart=1"
-    assert resp.baseTemplateSha == "base"
-    assert resp.precommitSha == "precommit-sha-2"
+    assert not hasattr(resp, "baseTemplateSha")
+    assert not hasattr(resp, "precommitSha")

--- a/tests/candidates/routes/test_candidates_submissions_router_init_codespace_success_path_routes.py
+++ b/tests/candidates/routes/test_candidates_submissions_router_init_codespace_success_path_routes.py
@@ -65,7 +65,7 @@ async def test_init_codespace_success_path(monkeypatch, async_session):
     )
     assert result.repoFullName == workspace.repo_full_name
     assert result.workspaceId == workspace.id
-    assert result.baseTemplateSha == "base"
-    assert result.precommitSha == "precommit-sha-1"
+    assert not hasattr(result, "baseTemplateSha")
+    assert not hasattr(result, "precommitSha")
     assert captured["github_username"] == "octocat"
     assert cs.github_username == "octocat"

--- a/tests/shared/jobs/handlers/test_shared_jobs_handlers_day_close_enforcement_handle_day_close_enforcement_persists_cutoff_and_revokes_collaborator_handler.py
+++ b/tests/shared/jobs/handlers/test_shared_jobs_handlers_day_close_enforcement_handle_day_close_enforcement_persists_cutoff_and_revokes_collaborator_handler.py
@@ -67,3 +67,12 @@ async def test_handle_day_close_enforcement_persists_cutoff_and_revokes_collabor
         observed_cutoff_at = observed_cutoff_at.replace(tzinfo=UTC)
     assert observed_cutoff_at == cutoff_at
     assert day_audit.eval_basis_ref == "refs/heads/main@cutoff"
+
+    workspace = await workspace_repo.get_by_session_and_task(
+        async_session,
+        candidate_session_id=candidate_session.id,
+        task_id=day2_task.id,
+    )
+    assert workspace is not None
+    assert workspace.access_revoked_at is not None
+    assert workspace.access_revocation_error is None

--- a/tests/shared/utils/test_shared_coverage_gaps_run_code_submission_returns_without_diff_when_head_sha_missing_utils.py
+++ b/tests/shared/utils/test_shared_coverage_gaps_run_code_submission_returns_without_diff_when_head_sha_missing_utils.py
@@ -48,8 +48,8 @@ async def test_run_code_submission_returns_without_diff_when_head_sha_missing(
         used_workspace,
     ) = await submit_task_runner.run_code_submission(
         db=object(),
-        candidate_session_id=1,
-        task_id=2,
+        candidate_session=SimpleNamespace(id=1),
+        task=SimpleNamespace(id=2),
         payload=SimpleNamespace(workflowInputs=None, branch="main"),
         github_client=object(),
         actions_runner=object(),

--- a/tests/shared/utils/test_shared_perf_pass2_branch_coverage_submit_workspace_uses_grouped_lookup_when_available_utils.py
+++ b/tests/shared/utils/test_shared_perf_pass2_branch_coverage_submit_workspace_uses_grouped_lookup_when_available_utils.py
@@ -26,14 +26,17 @@ async def test_submit_workspace_uses_grouped_lookup_when_available(monkeypatch):
         "validate_branch",
         lambda branch: branch,
     )
+    monkeypatch.setattr(
+        submit_workspace_use_case,
+        "ensure_day_flow_open",
+        _async_return(None),
+    )
 
     found, branch = await fetch_workspace_and_branch(
         object(),
-        candidate_session_id=1,
-        task_id=2,
+        candidate_session=SimpleNamespace(id=1),
+        task=SimpleNamespace(id=2, day_index=2, type="code"),
         payload=SimpleNamespace(branch=None),
-        task_day_index=2,
-        task_type="code",
     )
     assert found is workspace
     assert branch == "main"
@@ -71,14 +74,17 @@ async def test_submit_workspace_falls_back_to_task_lookup_when_workspace_key_mis
         "validate_branch",
         lambda branch: branch,
     )
+    monkeypatch.setattr(
+        submit_workspace_use_case,
+        "ensure_day_flow_open",
+        _async_return(None),
+    )
 
     found, branch = await fetch_workspace_and_branch(
         object(),
-        candidate_session_id=11,
-        task_id=22,
+        candidate_session=SimpleNamespace(id=11),
+        task=SimpleNamespace(id=22, day_index=2, type="code"),
         payload=SimpleNamespace(branch=None),
-        task_day_index=2,
-        task_type="code",
     )
     assert found is workspace
     assert branch == "main"

--- a/tests/submissions/presentation/test_submissions_list_presenter_utils.py
+++ b/tests/submissions/presentation/test_submissions_list_presenter_utils.py
@@ -6,6 +6,9 @@ from types import SimpleNamespace
 from app.submissions.presentation import (
     submissions_presentation_submissions_list_presenter_utils as presenter,
 )
+from app.submissions.presentation.submissions_presentation_submissions_commit_basis_utils import (
+    resolve_commit_basis,
+)
 
 
 def _submission(**overrides):
@@ -105,3 +108,21 @@ def test_present_list_item_does_not_overwrite_existing_result_links(monkeypatch)
 
     assert payload["testResults"]["commitUrl"] == "https://custom/commit"
     assert payload["testResults"]["workflowUrl"] == "https://custom/workflow"
+
+
+def test_resolve_commit_basis_prefers_cutoff_sha_over_mutable_head():
+    submission = SimpleNamespace(commit_sha="mutable-head")
+    day_audit = SimpleNamespace(
+        cutoff_commit_sha="pinned-cutoff",
+        cutoff_at=datetime(2026, 3, 20, 14, 0, tzinfo=UTC),
+        eval_basis_ref="refs/heads/main@cutoff",
+    )
+
+    commit_sha, cutoff_commit_sha, cutoff_at, eval_basis_ref = resolve_commit_basis(
+        submission, day_audit
+    )
+
+    assert commit_sha == "pinned-cutoff"
+    assert cutoff_commit_sha == "pinned-cutoff"
+    assert cutoff_at == day_audit.cutoff_at
+    assert eval_basis_ref == "refs/heads/main@cutoff"

--- a/tests/tasks/routes/handlers/test_tasks_submit_handler_handler.py
+++ b/tests/tasks/routes/handlers/test_tasks_submit_handler_handler.py
@@ -54,6 +54,8 @@ async def test_handle_submit_task_uses_pinned_cutoff_commit_basis(monkeypatch):
     assert response.commitSha == response.cutoffCommitSha
     assert response.commitSha != submission.commit_sha
     assert response.evalBasisRef == "refs/heads/main@cutoff"
+    assert response.checkpointSha == "checkpoint-sha"
+    assert response.finalSha is None
 
 
 @pytest.mark.asyncio
@@ -96,6 +98,51 @@ async def test_handle_submit_task_normalizes_naive_cutoff_timestamp(monkeypatch)
 
     assert response.cutoffAt is not None
     assert response.cutoffAt.tzinfo is UTC
+
+
+@pytest.mark.asyncio
+async def test_handle_submit_task_uses_final_sha_for_day3(monkeypatch):
+    task = SimpleNamespace(id=23, day_index=3)
+    submission = SimpleNamespace(
+        id=101,
+        submitted_at=datetime(2026, 3, 8, 15, 0, tzinfo=UTC),
+        commit_sha="mutable-head-sha",
+        checkpoint_sha=None,
+        final_sha="final-sha",
+    )
+    day_audit = SimpleNamespace(
+        cutoff_commit_sha="cutoff-day3-sha",
+        cutoff_at=datetime(2026, 3, 8, 18, 0, tzinfo=UTC),
+        eval_basis_ref="refs/heads/main@cutoff",
+    )
+
+    async def _fake_submit_task(*_args, **_kwargs):
+        return task, submission, 3, 5, False
+
+    async def _fake_get_day_audit(*_args, **_kwargs):
+        return day_audit
+
+    monkeypatch.setattr(submit_task_handler, "submit_task", _fake_submit_task)
+    monkeypatch.setattr(
+        submit_task_handler.cs_repo,
+        "get_day_audit",
+        _fake_get_day_audit,
+    )
+
+    response = await submit_task_handler.handle_submit_task(
+        task_id=task.id,
+        payload=SubmissionCreateRequest(contentText=None),
+        candidate_session=SimpleNamespace(id=7),
+        db=object(),
+        github_client=object(),
+        actions_runner=object(),
+    )
+
+    assert response.commitSha == "cutoff-day3-sha"
+    assert response.cutoffCommitSha == "cutoff-day3-sha"
+    assert response.checkpointSha is None
+    assert response.finalSha == "final-sha"
+    assert response.evalBasisRef == "refs/heads/main@cutoff"
 
 
 @pytest.mark.asyncio

--- a/tests/tasks/routes/test_tasks_run_codespace_init_rejects_after_day_audit_routes.py
+++ b/tests/tasks/routes/test_tasks_run_codespace_init_rejects_after_day_audit_routes.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.candidates.candidate_sessions.repositories import (
+    repository_day_audits as cs_repo,
+)
+from tests.tasks.routes.test_tasks_run_api_utils import *
+
+
+@pytest.mark.asyncio
+async def test_codespace_init_rejects_after_day_audit_exists(
+    async_client, async_session, candidate_header_factory, actions_stubber
+):
+    actions_stubber()
+    talent_partner = await create_talent_partner(
+        async_session, email="init-cutoff@sim.com"
+    )
+    sim, tasks = await create_trial(async_session, created_by=talent_partner)
+    cs = await create_candidate_session(
+        async_session,
+        trial=sim,
+        status="in_progress",
+        with_default_schedule=True,
+    )
+    await create_submission(
+        async_session, candidate_session=cs, task=tasks[0], content_text="day1"
+    )
+    await cs_repo.create_day_audit_once(
+        async_session,
+        candidate_session_id=cs.id,
+        day_index=tasks[1].day_index,
+        cutoff_at=datetime(2026, 3, 8, 18, 0, tzinfo=UTC),
+        cutoff_commit_sha="cutoff-day2-sha",
+        eval_basis_ref="refs/heads/main@cutoff",
+        commit=True,
+    )
+    await async_session.commit()
+
+    response = await async_client.post(
+        f"/api/tasks/{tasks[1].id}/codespace/init",
+        headers=candidate_header_factory(cs),
+        json={"githubUsername": "octocat"},
+    )
+
+    assert response.status_code == 409, response.text
+    body = response.json()
+    assert body["errorCode"] == "TASK_WINDOW_CLOSED"
+    assert body["details"]["cutoffCommitSha"] == "cutoff-day2-sha"
+    assert body["details"]["evalBasisRef"] == "refs/heads/main@cutoff"

--- a/tests/tasks/routes/test_tasks_run_codespace_init_response_shape_no_bundle_routes.py
+++ b/tests/tasks/routes/test_tasks_run_codespace_init_response_shape_no_bundle_routes.py
@@ -95,8 +95,6 @@ async def test_codespace_init_response_shape_no_bundle(
         "codespaceUrl": "https://codespace-909.github.dev",
         "codespaceState": "available",
         "defaultBranch": "main",
-        "baseTemplateSha": "commit-sha",
-        "precommitSha": None,
         "workspaceId": body["workspaceId"],
     }
     assert isinstance(body["workspaceId"], str)

--- a/tests/tasks/routes/test_tasks_run_codespace_init_works_for_debug_task_routes.py
+++ b/tests/tasks/routes/test_tasks_run_codespace_init_works_for_debug_task_routes.py
@@ -49,5 +49,5 @@ async def test_codespace_init_works_for_debug_task(
     body = resp.json()
     assert body["repoFullName"]
     assert body["workspaceId"]
-    assert body["baseTemplateSha"] == "base-sha-123"
-    assert body["precommitSha"] is None
+    assert "baseTemplateSha" not in body
+    assert "precommitSha" not in body

--- a/tests/tasks/routes/test_tasks_run_codespace_run_rejects_after_day_audit_routes.py
+++ b/tests/tasks/routes/test_tasks_run_codespace_run_rejects_after_day_audit_routes.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.candidates.candidate_sessions.repositories import (
+    repository_day_audits as cs_repo,
+)
+from tests.tasks.routes.test_tasks_run_api_utils import *
+
+
+@pytest.mark.asyncio
+async def test_run_rejects_after_day_audit_exists(
+    async_client, async_session, candidate_header_factory, actions_stubber
+):
+    actions_stubber()
+    talent_partner = await create_talent_partner(
+        async_session, email="run-cutoff@sim.com"
+    )
+    sim, tasks = await create_trial(async_session, created_by=talent_partner)
+    cs = await create_candidate_session(
+        async_session,
+        trial=sim,
+        status="in_progress",
+        with_default_schedule=True,
+    )
+    await create_submission(
+        async_session, candidate_session=cs, task=tasks[0], content_text="day1"
+    )
+    await cs_repo.create_day_audit_once(
+        async_session,
+        candidate_session_id=cs.id,
+        day_index=tasks[1].day_index,
+        cutoff_at=datetime(2026, 3, 8, 18, 15, tzinfo=UTC),
+        cutoff_commit_sha="cutoff-day2-run-sha",
+        eval_basis_ref="refs/heads/main@cutoff",
+        commit=True,
+    )
+    await async_session.commit()
+
+    response = await async_client.post(
+        f"/api/tasks/{tasks[1].id}/run",
+        headers=candidate_header_factory(cs),
+        json={},
+    )
+
+    assert response.status_code == 409, response.text
+    body = response.json()
+    assert body["errorCode"] == "TASK_WINDOW_CLOSED"
+    assert body["details"]["cutoffCommitSha"] == "cutoff-day2-run-sha"
+    assert body["details"]["evalBasisRef"] == "refs/heads/main@cutoff"

--- a/tests/tasks/routes/test_tasks_run_codespace_status_includes_cutoff_fields_when_day_audit_exists_routes.py
+++ b/tests/tasks/routes/test_tasks_run_codespace_status_includes_cutoff_fields_when_day_audit_exists_routes.py
@@ -6,7 +6,7 @@ from tests.tasks.routes.test_tasks_run_api_utils import *
 
 
 @pytest.mark.asyncio
-async def test_codespace_status_includes_cutoff_fields_when_day_audit_exists(
+async def test_codespace_status_rejects_when_day_audit_exists(
     async_client, async_session, candidate_header_factory
 ):
     talent_partner = await create_talent_partner(
@@ -54,10 +54,8 @@ async def test_codespace_status_includes_cutoff_fields_when_day_audit_exists(
         f"/api/tasks/{day2_task.id}/codespace/status",
         headers=headers,
     )
-    assert resp.status_code == 200, resp.text
+    assert resp.status_code == 409, resp.text
     data = resp.json()
-    assert data["repoFullName"] == "org/status-repo-with-cutoff"
-    assert data["baseTemplateSha"] == "base"
-    assert data["precommitSha"] == "precommit-sha-xyz"
-    assert data["cutoffCommitSha"] == "abc123def456"
-    assert data["cutoffAt"] == "2026-03-08T17:45:00Z"
+    assert data["errorCode"] == "TASK_WINDOW_CLOSED"
+    assert data["details"]["cutoffCommitSha"] == "abc123def456"
+    assert data["details"]["evalBasisRef"] == "refs/heads/main@cutoff"

--- a/tests/tasks/routes/test_tasks_run_codespace_status_returns_summary_routes.py
+++ b/tests/tasks/routes/test_tasks_run_codespace_status_returns_summary_routes.py
@@ -48,8 +48,6 @@ async def test_codespace_status_returns_summary(
         "codespaceUrl": "https://codespaces.new/org/status-repo?quickstart=1",
         "codespaceState": None,
         "defaultBranch": "main",
-        "baseTemplateSha": "base",
-        "precommitSha": None,
         "latestCommitSha": None,
         "lastWorkflowRunId": None,
         "lastWorkflowConclusion": None,

--- a/tests/tasks/routes/test_tasks_run_submit_rejects_after_day_audit_routes.py
+++ b/tests/tasks/routes/test_tasks_run_submit_rejects_after_day_audit_routes.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from app.candidates.candidate_sessions.repositories import (
+    repository_day_audits as cs_repo,
+)
+from tests.tasks.routes.test_tasks_run_api_utils import *
+
+
+@pytest.mark.asyncio
+async def test_submit_rejects_after_day_audit_exists(
+    async_client, async_session, candidate_header_factory, actions_stubber
+):
+    actions_stubber()
+    talent_partner = await create_talent_partner(
+        async_session, email="submit-cutoff@sim.com"
+    )
+    sim, tasks = await create_trial(async_session, created_by=talent_partner)
+    cs = await create_candidate_session(
+        async_session,
+        trial=sim,
+        status="in_progress",
+        with_default_schedule=True,
+    )
+    await create_submission(
+        async_session, candidate_session=cs, task=tasks[0], content_text="day1"
+    )
+    await cs_repo.create_day_audit_once(
+        async_session,
+        candidate_session_id=cs.id,
+        day_index=tasks[1].day_index,
+        cutoff_at=datetime(2026, 3, 8, 18, 30, tzinfo=UTC),
+        cutoff_commit_sha="cutoff-day2-submit-sha",
+        eval_basis_ref="refs/heads/main@cutoff",
+        commit=True,
+    )
+    await async_session.commit()
+
+    response = await async_client.post(
+        f"/api/tasks/{tasks[1].id}/submit",
+        headers=candidate_header_factory(cs),
+        json={},
+    )
+
+    assert response.status_code == 409, response.text
+    body = response.json()
+    assert body["errorCode"] == "TASK_WINDOW_CLOSED"
+    assert body["details"]["cutoffCommitSha"] == "cutoff-day2-submit-sha"
+    assert body["details"]["evalBasisRef"] == "refs/heads/main@cutoff"


### PR DESCRIPTION
## 1. Summary
Winoe AI now enforces a Codespace-only Day 2/3 workflow end to end. Active Day 2 and Day 3 flows no longer expose legacy workspace fields, post-cutoff access is locked down with `TASK_WINDOW_CLOSED`, and cutoff evidence is recorded separately so evaluation stays anchored to the recorded cutoff SHA rather than mutable later workspace state.

## 2. Problem
The product requires canadidates to build from scratch in Codespaces, with the entire repo being their work. The backend still exposed legacy copy and response fields that suggested offline/local work was acceptable, and cutoff enforcement was not consistently applied across active Day 2/3 flows.

## 3. Root cause
- Contract issue: active Codespace init/status responses still exposed legacy fields that implied a pre-cutoff workspace basis.
- Enforcement issue: the backend did not uniformly block active Day 2/3 actions after cutoff across init, status, run, and submit.

## 4. Implementation summary
- Active Day 2/3 Codespace init/status responses now omit `baseTemplateSha` and `precommitSha`.
- Active Day 2/3 flows now call the shared cutoff gate before init, status, run, and submit.
- Day 2 and Day 3 cutoff evidence is written as separate `candidate_day_audits` rows.
- Day 2 submit persists `checkpointSha`.
- Day 3 submit persists `finalSha`.
- The response mapping and handler tests now reflect the cutoff contract directly.

## 5. API contract changes
- `baseTemplateSha` was removed from active Day 2/3 Codespace init/status responses.
- `precommitSha` was removed from active Day 2/3 Codespace init/status responses.
- Day 2 submit responses return `checkpointSha` for the Day 2 checkpoint.
- Day 3 submit responses return `finalSha` for the Day 3 final state.
- Post-cutoff error payloads include the cutoff basis fields needed for evaluation and audit traceability.

## 6. Cutoff enforcement behavior
- Active Day 2/3 `codespace/init`, `codespace/status`, `run`, and `submit` requests now reject after cutoff with `409 TASK_WINDOW_CLOSED`.
- Rejection payloads include cutoff details such as `cutoffCommitSha`, `cutoffAt`, and `evalBasisRef`.
- The same cutoff gate is used consistently across the active Day 2/3 backend paths, so post-cutoff behavior is uniform instead of route-specific.

## 7. Evaluation basis behavior
- The evaluation basis is pinned to the recorded cutoff SHA after cutoff, even if `workspace.latest_commit_sha` changes later.
- Successful pre-cutoff Day 2/Day 3 submit responses may still return `cutoffCommitSha = null` and `evalBasisRef = null` because the cutoff audit row does not exist yet at that moment.
- Once the cutoff audit exists, later active requests resolve cutoff details from the audit row rather than from mutable workspace state.

## 8. Persistence / model impact
- `candidate_day_audits` now carries the authoritative Day 2 and Day 3 cutoff record.
- Separate audit rows are persisted for `dayIndex = 2` and `dayIndex = 3`.
- The recorded cutoff SHA and evaluation basis reference are stored per day, which keeps Day 2 and Day 3 evaluation inputs distinct.

## 9. Tests added / updated
- `tests/candidates/routes/test_candidates_submissions_router_init_codespace_success_path_routes.py`
- `tests/candidates/routes/test_candidates_schedule_gates_run_and_submit_post_cutoff_return_task_window_closed_routes.py`
- `tests/tasks/routes/test_tasks_run_codespace_init_rejects_after_day_audit_routes.py`
- `tests/tasks/routes/test_tasks_run_submit_rejects_after_day_audit_routes.py`
- `tests/tasks/routes/test_tasks_run_codespace_status_returns_summary_routes.py`
- `tests/tasks/routes/test_tasks_run_codespace_status_naive_cutoff_routes.py`
- `tests/tasks/routes/test_tasks_submit_submit_day3_debug_returns_and_persists_final_sha_routes.py`
- `tests/candidates/routes/test_candidates_session_api_current_task_includes_cutoff_fields_when_day_audit_exists_routes.py`
- `tests/candidates/routes/test_candidates_session_api_current_task_returns_null_cutoff_fields_when_day_audit_missing_routes.py`
- `tests/tasks/routes/test_tasks_run_codespace_init_works_for_debug_task_routes.py`

## 10. Manual QA evidence
- Command: `poetry run pytest -o addopts='' tests/candidates/routes/test_candidates_submissions_router_init_codespace_success_path_routes.py tests/candidates/routes/test_candidates_schedule_gates_run_and_submit_post_cutoff_return_task_window_closed_routes.py tests/tasks/routes/test_tasks_submit_submit_day3_debug_returns_and_persists_final_sha_routes.py tests/tasks/routes/test_tasks_run_codespace_init_rejects_after_day_audit_routes.py tests/tasks/routes/test_tasks_run_submit_rejects_after_day_audit_routes.py tests/tasks/routes/test_tasks_run_codespace_status_returns_summary_routes.py tests/tasks/routes/test_tasks_run_codespace_status_naive_cutoff_routes.py`
- Result: `7 passed`
- Command: `poetry run pytest`
- Result: `1711 passed`, coverage `96.15%`
- Day 2 init success response did not include legacy bundle fields.
- Day 2 status before cutoff returned normal status with `cutoffCommitSha = null` and `cutoffAt = null`.
- Day 2 submit returned `checkpointSha` and null cutoff fields before cutoff.
- Day 2 post-cutoff `status`, `run`, and `submit` rejected with `409 TASK_WINDOW_CLOSED` and cutoff details.
- Day 3 submit returned `finalSha`.
- Day 3 post-cutoff `status` rejected with `409 TASK_WINDOW_CLOSED` and cutoff details.
- Separate Day 2 and Day 3 audit rows existed in the database with different `dayIndex` values and different cutoff SHAs.
- Mutating `workspace.latest_commit_sha` after cutoff did not change the cutoff details returned by later active requests.
- Focused tests passed.
- Full repo test suite passed.

## 11. Risks / follow-ups
- Frontend copy and UI should stay aligned with the tightened backend cutoff contract so candidates do not see outdated offline/local wording.

Fixes #286
