### PR TITLE
Fix trial create contract for from-scratch flow

### DIFF
--- a/app/trials/schemas/trials_schemas_trials_ai_models_schema.py
+++ b/app/trials/schemas/trials_schemas_trials_ai_models_schema.py
@@ -40,6 +40,12 @@ class TrialCompanyContext(BaseModel):
         min_length=1,
         max_length=MAX_COMPANY_CONTEXT_VALUE_CHARS,
     )
+    preferred_language_framework: str | None = Field(
+        default=None,
+        alias="preferredLanguageFramework",
+        min_length=1,
+        max_length=MAX_COMPANY_CONTEXT_VALUE_CHARS,
+    )
 
     @model_serializer(mode="plain")
     def _serialize(self):
@@ -48,6 +54,8 @@ class TrialCompanyContext(BaseModel):
             data["domain"] = self.domain
         if self.product_area is not None:
             data["productArea"] = self.product_area
+        if self.preferred_language_framework is not None:
+            data["preferredLanguageFramework"] = self.preferred_language_framework
         return data
 
 

--- a/app/trials/schemas/trials_schemas_trials_create_schema.py
+++ b/app/trials/schemas/trials_schemas_trials_create_schema.py
@@ -40,18 +40,32 @@ class TrialCreate(BaseModel):
 
     title: str = Field(..., min_length=1, max_length=200)
     role: str = Field(..., min_length=1, max_length=200)
-    techStack: str = Field(..., min_length=1, max_length=500)
+    techStack: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=500,
+        validation_alias=AliasChoices("techStack", "tech_stack"),
+    )
     seniority: str = Field(
         ...,
         min_length=1,
         max_length=100,
         validation_alias=AliasChoices("seniority", "roleLevel", "role_level"),
     )
-    focus: str = Field(
-        ...,
+    focus: str | None = Field(
+        default=None,
         min_length=1,
         max_length=MAX_FOCUS_NOTES_CHARS,
         validation_alias=AliasChoices("focus", "focusNotes", "focus_notes"),
+    )
+    preferred_language_framework: str | None = Field(
+        default=None,
+        alias="preferredLanguageFramework",
+        min_length=1,
+        max_length=500,
+        validation_alias=AliasChoices(
+            "preferredLanguageFramework", "preferred_language_framework"
+        ),
     )
     company_context: TrialCompanyContext | None = Field(
         default=None, alias="companyContext"

--- a/app/trials/services/trials_services_trials_creation_builder_service.py
+++ b/app/trials/services/trials_services_trials_creation_builder_service.py
@@ -22,6 +22,23 @@ from .trials_services_trials_creation_extractors_service import (
 from .trials_services_trials_template_keys_service import resolve_template_key
 
 
+def _resolve_preferred_language_framework(payload: Any) -> str | None:
+    for key in ("preferredLanguageFramework", "preferred_language_framework"):
+        value = getattr(payload, key, None)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _resolve_tech_stack(payload: Any, preferred_language_framework: str | None) -> str:
+    raw_tech_stack = getattr(payload, "techStack", getattr(payload, "tech_stack", None))
+    if isinstance(raw_tech_stack, str) and raw_tech_stack.strip():
+        return raw_tech_stack.strip()
+    if preferred_language_framework is not None:
+        return preferred_language_framework
+    return ""
+
+
 def build_trial_for_create(
     payload: Any, user: Any
 ) -> tuple[Trial, str, dict[str, bool]]:
@@ -51,13 +68,20 @@ def build_trial_for_create(
         day_window_overrides_enabled,
         day_window_overrides_json,
     ) = extract_day_window_config(payload)
+    preferred_language_framework = _resolve_preferred_language_framework(payload)
+    company_context = extract_company_context(payload)
+    if preferred_language_framework is not None:
+        company_context = {
+            **(company_context or {}),
+            "preferredLanguageFramework": preferred_language_framework,
+        }
     sim = Trial(
         title=payload.title,
         role=payload.role,
-        tech_stack=getattr(payload, "techStack", getattr(payload, "tech_stack", "")),
+        tech_stack=_resolve_tech_stack(payload, preferred_language_framework),
         seniority=normalized_seniority or raw_seniority,
-        focus=payload.focus,
-        company_context=extract_company_context(payload),
+        focus=getattr(payload, "focus", None) or "",
+        company_context=company_context,
         ai_prompt_overrides_json=ai_prompt_overrides_json,
         ai_notice_version=resolved_notice_version,
         ai_notice_text=resolved_notice_text,

--- a/app/trials/services/trials_services_trials_scenario_generation_story_service.py
+++ b/app/trials/services/trials_services_trials_scenario_generation_story_service.py
@@ -65,6 +65,11 @@ def build_project_brief_markdown(
         product_area = normalize_text(
             company_context.get("productArea") or company_context.get("product_area")
         )
+        if not preferred_stack:
+            preferred_stack = normalize_text(
+                company_context.get("preferredLanguageFramework")
+                or company_context.get("preferred_language_framework")
+            )
     business_context = "; ".join(
         part
         for part in (

--- a/tests/trials/routes/test_trials_api_create_trial_seeds_default_tasks_routes.py
+++ b/tests/trials/routes/test_trials_api_create_trial_seeds_default_tasks_routes.py
@@ -16,9 +16,8 @@ async def test_create_trial_seeds_default_tasks(
     payload = {
         "title": "Backend Node Trial",
         "role": "Backend Engineer",
-        "techStack": "Node.js, PostgreSQL",
         "seniority": "Mid",
-        "focus": "Build a new API and iterate over 5 days",
+        "preferredLanguageFramework": "Node.js, PostgreSQL",
     }
 
     res = await async_client.post(
@@ -28,6 +27,9 @@ async def test_create_trial_seeds_default_tasks(
 
     body = res.json()
     assert body["title"] == payload["title"]
+    assert body["techStack"] == "Node.js, PostgreSQL"
+    assert body["focus"] == ""
+    assert body["companyContext"]["preferredLanguageFramework"] == "Node.js, PostgreSQL"
     assert len(body["tasks"]) == 5
     assert [t["day_index"] for t in body["tasks"]] == [1, 2, 3, 4, 5]
     assert body["tasks"][0]["type"] == "design"

--- a/tests/trials/routes/test_trials_create_create_trial_creates_sim_and_5_tasks_routes.py
+++ b/tests/trials/routes/test_trials_create_create_trial_creates_sim_and_5_tasks_routes.py
@@ -32,9 +32,19 @@ async def test_create_trial_creates_sim_and_5_tasks(
         payload = {
             "title": "Backend Node Trial",
             "role": "Backend Engineer",
-            "techStack": "Node.js, PostgreSQL",
             "seniority": "Mid",
-            "focus": "Build new API feature and debug an issue",
+            "preferredLanguageFramework": "Node.js, PostgreSQL",
+            "ai": {
+                "noticeVersion": AI_NOTICE_DEFAULT_VERSION,
+                "noticeText": AI_NOTICE_DEFAULT_TEXT,
+                "evalEnabledByDay": {
+                    "1": True,
+                    "2": True,
+                    "3": True,
+                    "4": True,
+                    "5": True,
+                },
+            },
         }
 
         resp = await async_client.post("/api/trials", json=payload)
@@ -51,6 +61,11 @@ async def test_create_trial_creates_sim_and_5_tasks(
             "handoff",
             "documentation",
         ]
+        assert data["techStack"] == "Node.js, PostgreSQL"
+        assert data["focus"] == ""
+        assert data["companyContext"]["preferredLanguageFramework"] == (
+            "Node.js, PostgreSQL"
+        )
         assert data["templateKey"] == "python-fastapi"
         assert data["status"] == "generating"
         assert isinstance(data["scenarioGenerationJobId"], str)

--- a/tests/trials/routes/test_trials_create_default_template_key_applied_routes.py
+++ b/tests/trials/routes/test_trials_create_default_template_key_applied_routes.py
@@ -29,14 +29,16 @@ async def test_default_template_key_applied_without_task_template_repo(
         json={
             "title": "Backend Node Trial",
             "role": "Backend Engineer",
-            "techStack": "Node.js, PostgreSQL",
             "seniority": "Mid",
-            "focus": "Build new API feature and debug an issue",
+            "preferredLanguageFramework": "Node.js, PostgreSQL",
         },
     )
     assert resp.status_code == 201, resp.text
     data = resp.json()
     assert data["templateKey"] == "python-fastapi"
+    assert data["techStack"] == "Node.js, PostgreSQL"
+    assert data["focus"] == ""
+    assert data["companyContext"]["preferredLanguageFramework"] == "Node.js, PostgreSQL"
     sim_id = data["id"]
 
     rows = (

--- a/tests/trials/routes/test_trials_local_bootstrap_seed_and_create_trial_routes.py
+++ b/tests/trials/routes/test_trials_local_bootstrap_seed_and_create_trial_routes.py
@@ -64,11 +64,14 @@ async def test_local_bootstrap_seeds_talent_partner_and_allows_trial_creation(
         json={
             "title": "Local Trial",
             "role": "Backend Engineer",
-            "techStack": "Python, PostgreSQL",
             "seniority": "Mid",
-            "focus": "Create a local demo trial after bootstrap",
+            "preferredLanguageFramework": "Python, PostgreSQL",
         },
     )
 
     assert response.status_code == 201, response.text
     assert response.json()["title"] == "Local Trial"
+    assert response.json()["techStack"] == "Python, PostgreSQL"
+    assert response.json()["companyContext"]["preferredLanguageFramework"] == (
+        "Python, PostgreSQL"
+    )

--- a/tests/trials/schemas/test_trials_ai_models_schema.py
+++ b/tests/trials/schemas/test_trials_ai_models_schema.py
@@ -14,6 +14,9 @@ def test_trial_company_context_serializer_omits_none_fields():
     assert TrialCompanyContext.model_validate(
         {"productArea": "payments"}
     ).model_dump() == {"productArea": "payments"}
+    assert TrialCompanyContext.model_validate(
+        {"preferredLanguageFramework": "TypeScript/Node"}
+    ).model_dump() == {"preferredLanguageFramework": "TypeScript/Node"}
 
 
 def test_trial_ai_config_serializer_omits_none_fields():

--- a/tests/trials/services/test_trials_create_validation_service.py
+++ b/tests/trials/services/test_trials_create_validation_service.py
@@ -4,6 +4,9 @@ import pytest
 from pydantic import ValidationError
 
 from app.config import settings
+from app.trials.constants.trials_constants_trials_template_keys_constants import (
+    DEFAULT_TEMPLATE_KEY,
+)
 from app.trials.schemas.trials_schemas_trials_core_schema import (
     TrialCreate,
 )
@@ -13,9 +16,7 @@ def _base_payload() -> dict:
     return {
         "title": "Backend Node Trial",
         "role": "Backend Engineer",
-        "techStack": "Node.js, PostgreSQL",
         "seniority": "mid",
-        "focus": "Emphasize code quality and test discipline.",
     }
 
 
@@ -56,10 +57,10 @@ def test_trial_create_rejects_ai_non_bool_value() -> None:
 
 def test_trial_create_normalizes_aliases_and_day_keys() -> None:
     payload = _base_payload()
+    payload["techStack"] = "Node.js, PostgreSQL"
     payload.pop("seniority")
-    payload.pop("focus")
-    payload["roleLevel"] = "Mid"
     payload["focusNotes"] = "Focus notes"
+    payload["roleLevel"] = "Mid"
     payload["companyContext"] = {"productArea": "creator tools"}
     payload["ai"] = {"evalEnabledByDay": {1: True, "2": False}}
 
@@ -71,6 +72,27 @@ def test_trial_create_normalizes_aliases_and_day_keys() -> None:
     assert parsed.company_context.product_area == "creator tools"
     assert parsed.ai is not None
     assert parsed.ai.eval_enabled_by_day == {"1": True, "2": False}
+
+
+def test_trial_create_allows_pivoted_payload_without_legacy_fields() -> None:
+    payload = _base_payload()
+    payload["preferredLanguageFramework"] = "TypeScript/Node"
+
+    parsed = TrialCreate.model_validate(payload)
+
+    assert parsed.techStack is None
+    assert parsed.focus is None
+    assert parsed.preferred_language_framework == "TypeScript/Node"
+    assert parsed.templateKey == DEFAULT_TEMPLATE_KEY
+
+
+def test_trial_create_accepts_snake_case_preferred_language_framework() -> None:
+    payload = _base_payload()
+    payload["preferred_language_framework"] = "Python/FastAPI"
+
+    parsed = TrialCreate.model_validate(payload)
+
+    assert parsed.preferred_language_framework == "Python/FastAPI"
 
 
 def test_trial_create_rejects_invalid_day_window_bounds() -> None:

--- a/tests/trials/services/test_trials_project_brief_service.py
+++ b/tests/trials/services/test_trials_project_brief_service.py
@@ -61,3 +61,18 @@ def test_project_brief_generation_stays_stack_agnostic() -> None:
     assert "## Talent Partner Context" in project_brief_md
     assert "Preferred language/framework: TypeScript/Node" in project_brief_md
     assert "context only, not as a requirement" in project_brief_md
+
+
+def test_project_brief_reads_preferred_language_framework_from_company_context() -> (
+    None
+):
+    project_brief_md = build_project_brief_markdown(
+        role="Backend Engineer",
+        company_context={
+            "domain": "payments",
+            "preferredLanguageFramework": "Python/FastAPI",
+        },
+        focus=None,
+    )
+
+    assert "Preferred language/framework: Python/FastAPI" in project_brief_md

--- a/tests/trials/services/test_trials_scenario_payload_builder_service.py
+++ b/tests/trials/services/test_trials_scenario_payload_builder_service.py
@@ -16,7 +16,11 @@ def test_build_scenario_generation_payload_includes_talent_partner_context_field
         scenario_template="default-5day-node-postgres",
         seniority="Mid",
         focus="Emphasize docs and test discipline.",
-        company_context={"domain": "social", "productArea": "creator tools"},
+        company_context={
+            "domain": "social",
+            "productArea": "creator tools",
+            "preferredLanguageFramework": "TypeScript/Node",
+        },
         ai_notice_version="mvp1",
         ai_notice_text="AI may be used for scenario generation.",
         ai_eval_enabled_by_day={1: True, "2": True, "3": False, "9": True},
@@ -30,6 +34,10 @@ def test_build_scenario_generation_payload_includes_talent_partner_context_field
     assert payload["talentPartnerContext"]["seniority"] == "mid"
     assert payload["talentPartnerContext"]["focus"] == trial.focus
     assert payload["talentPartnerContext"]["companyContext"] == trial.company_context
+    assert (
+        payload["talentPartnerContext"]["companyContext"]["preferredLanguageFramework"]
+        == "TypeScript/Node"
+    )
     assert payload["talentPartnerContext"]["ai"] == {
         "noticeVersion": "mvp1",
         "noticeText": "AI may be used for scenario generation.",

--- a/tests/trials/services/test_trials_service_create_trial_with_tasks_enqueues_scenario_generation_job_service.py
+++ b/tests/trials/services/test_trials_service_create_trial_with_tasks_enqueues_scenario_generation_job_service.py
@@ -76,3 +76,43 @@ async def test_create_trial_with_tasks_enqueues_scenario_generation_job(
             },
         },
     }
+
+
+@pytest.mark.asyncio
+async def test_create_trial_with_tasks_accepts_pivoted_payload(
+    async_session,
+):
+    talent_partner = await create_talent_partner(
+        async_session, email="sim-job-pivot@test.com"
+    )
+    payload = type(
+        "P",
+        (),
+        {
+            "title": "Title",
+            "role": "Role",
+            "seniority": "Mid",
+            "preferredLanguageFramework": "Python/FastAPI",
+            "companyContext": {"domain": "social"},
+            "ai": {
+                "noticeVersion": "mvp1",
+                "noticeText": "AI may assist with scenario generation.",
+                "evalEnabledByDay": {"1": True},
+            },
+        },
+    )()
+
+    sim, _tasks, scenario_job = await sim_service.create_trial_with_tasks(
+        async_session, payload, talent_partner
+    )
+
+    assert sim.tech_stack == "Python/FastAPI"
+    assert sim.focus == ""
+    assert sim.company_context == {
+        "domain": "social",
+        "preferredLanguageFramework": "Python/FastAPI",
+    }
+    assert scenario_job.payload_json["talentPartnerContext"]["companyContext"] == {
+        "domain": "social",
+        "preferredLanguageFramework": "Python/FastAPI",
+    }


### PR DESCRIPTION
## 1. Title

Trial creation polish for #176: role title/description split and v4 from-scratch pivot alignment

## 2. Summary

This PR sharpens the Trial creation flow for the Talent Partner path and aligns the create experience with the v4 from-scratch pivot.

## 3. What changed

- Split the create form into separate `Role title` and `Role description` inputs.
- Kept `Advanced Settings` collapsed by default.
- Auto-opens `Advanced Settings` when advanced-field validation errors are present.
- Added an optional `Preferred language/framework` field for scenario-generation context.
- Included the exact helper text:
  - `This is optional and helps Winoe generate a relevant project brief. The candidate may ultimately use any language or framework they choose.`
- Added clearer loading-state behavior while the Trial is being generated.
- Redirects to the Trial detail page after a successful create.
- Removed the retired template/stack selector path from the active create flow.
- Aligned the create payload cleanup with the v4 pivot so the frontend no longer sends legacy template or stack fields.

## 4. Backend alignment

- Live end-to-end Trial creation was initially blocked by a backend Trial-create contract mismatch.
- That backend blocker was resolved separately.
- Trial creation was rerun successfully after backend alignment.

## 5. QA / verification

- `npm run lint` - pass
- `npm run typecheck` - pass
- `npm test -- --runInBand` - pass
- precommit checks - pass
- Focused create-flow tests - pass
- Live local stack verification - pass
- Real Trial creation returned success and redirected to the Trial detail page
- Key live evidence:
  - create request succeeded with `201`
  - request used the pivoted payload
  - legacy client `techStack` / `templateKey` were omitted
  - redirect to `/dashboard/trials/{id}` succeeded

## 6. Scope / non-scope

- No rollback to legacy template-selector behavior.
- No reintroduction of template or tech stack selector UI.
- No unrelated product refactors.

## 7. Risks / follow-ups

- The contract-live auth bootstrap helper may still be stale and could use a cleanup pass later, but it is not a blocker for this PR.