### PR TITLE
Candidate start-date proposal flow with Talent Partner notification

### DIFF
--- a/app/candidates/candidate_sessions/services/candidates_candidate_sessions_services_candidates_candidate_sessions_schedule_flow_service.py
+++ b/app/candidates/candidate_sessions/services/candidates_candidate_sessions_services_candidates_candidate_sessions_schedule_flow_service.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, date, datetime, time
+from zoneinfo import ZoneInfo
 
 from fastapi import HTTPException, status
 
@@ -21,12 +22,36 @@ from app.shared.utils.shared_utils_errors_utils import (
 )
 
 
+def _normalize_candidate_proposed_start_at(
+    *,
+    scheduled_start_at: datetime | date,
+    normalized_timezone: str,
+    trial,
+) -> datetime:
+    window_start_local = getattr(trial, "day_window_start_local", None) or time(
+        hour=9, minute=0
+    )
+    candidate_zone = ZoneInfo(normalized_timezone)
+    if isinstance(scheduled_start_at, datetime):
+        proposed_date = (
+            coerce_utc_datetime(scheduled_start_at).astimezone(candidate_zone).date()
+            if scheduled_start_at.tzinfo is not None
+            else scheduled_start_at.date()
+        )
+    else:
+        proposed_date = scheduled_start_at
+    normalized_start = datetime.combine(
+        proposed_date, window_start_local, tzinfo=candidate_zone
+    ).astimezone(UTC)
+    return normalized_start.replace(microsecond=0)
+
+
 async def schedule_candidate_session_impl(
     db,
     *,
     token: str,
     principal,
-    scheduled_start_at: datetime,
+    scheduled_start_at: datetime | date,
     candidate_timezone: str,
     github_username: str,
     email_service,
@@ -42,16 +67,6 @@ async def schedule_candidate_session_impl(
 ):
     """Schedule candidate session impl."""
     resolved_now = coerce_utc_datetime(now or shared_utcnow())
-    scheduled_start_at_utc = coerce_utc_datetime(scheduled_start_at).replace(
-        microsecond=0
-    )
-    if scheduled_start_at_utc < resolved_now:
-        raise ApiError(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Scheduled start must be in the future.",
-            error_code=SCHEDULE_START_IN_PAST,
-            retryable=False,
-        )
     try:
         normalized_timezone = validate_timezone((candidate_timezone or "").strip())
     except ValueError as exc:
@@ -72,6 +87,18 @@ async def schedule_candidate_session_impl(
                 retryable=False,
             ) from exc
         raise
+    scheduled_start_at_utc = _normalize_candidate_proposed_start_at(
+        scheduled_start_at=scheduled_start_at,
+        normalized_timezone=normalized_timezone,
+        trial=candidate_session.trial,
+    )
+    if scheduled_start_at_utc < resolved_now:
+        raise ApiError(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Scheduled start must be in the future.",
+            error_code=SCHEDULE_START_IN_PAST,
+            retryable=False,
+        )
     changed = require_claimed_ownership(candidate_session, principal)
     existing_username = (
         getattr(candidate_session, "github_username", None) or ""

--- a/app/candidates/schemas/candidates_schemas_candidates_candidate_sessions_schedule_schema.py
+++ b/app/candidates/schemas/candidates_schemas_candidates_candidate_sessions_schedule_schema.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import date, datetime
 
 from pydantic import Field
 
@@ -42,7 +42,7 @@ class CandidateSessionResolveResponse(APIModel):
 class CandidateSessionScheduleRequest(APIModel):
     """Request payload for scheduling a candidate session."""
 
-    scheduledStartAt: datetime
+    scheduledStartAt: datetime | date
     candidateTimezone: str = Field(..., min_length=1, max_length=255)
     githubUsername: str
 

--- a/pr.md
+++ b/pr.md
@@ -1,96 +1,131 @@
-# Backend: block failed Day 4 transcript from Winoe scoring + expose retry/dead-letter state
+# Candidate start-date proposal flow with Talent Partner notification
 
 ## 1. Summary
-Day 4 transcript failure no longer silently enters Winoe evaluation.
+Candidate schedule requests now support start-date semantics correctly.
 
-Winoe Report generation excludes Day 4 when the transcript is missing, failed, empty, or not ready. Transcript jobs now retry before terminal dead-letter. Day 4 handoff/status and Talent Partner-visible detail surfaces expose transcript failure plus job retry/dead-letter metadata. Candidate progress/current-task and compare `dayCompletion` remain submission/progress-based and are not repurposed into transcript-health semantics. Compatibility was preserved for existing helper/route surfaces that use lightweight doubles or legacy tuple shapes.
+A candidate-proposed date or datetime is normalized to the Trial's Day 1 local open time in the candidate's timezone before persistence and day-window derivation. Past-date rejection now respects candidate-local scheduling semantics. Schedule confirmation emails go to both the candidate and the Talent Partner. Trial content stays locked before Day 1 opens.
+
+Local greenfield QA is now deterministic because `runBackend.sh` defaults local runtime to `WINOE_SCENARIO_GENERATION_RUNTIME_MODE=demo` unless explicitly overridden.
 
 ## 2. Problem / Why
-This was a demo-blocking trust bug. Day 4 could appear complete and influence Winoe scoring even when the transcript had failed or was empty.
+Issue #288 needed the scheduling contract to match product truth: candidates propose a start date, but the backend must normalize that proposal into the Trial's Day 1 open time in the candidate's timezone before storing it or deriving day windows.
+
+The QA blocker was separate but related to greenfield provisioning. Fresh local Trial creation could dead-letter in scenario generation unless local runtime defaulted to deterministic demo mode, which made the local QA path unreliable.
 
 ## 3. What changed
 
-### Media transcript repositories/services
-- Transcript persistence and lookup now distinguish ready, failed, empty, missing, and not-ready states instead of treating all non-ready states as scorable.
-- Talent Partner-visible transcript detail now carries failure and retry/dead-letter metadata.
+### Candidate scheduling contract / normalization
+- The schedule request now accepts either a date or a datetime.
+- Both inputs normalize to the Trial's Day 1 local open time in the candidate's timezone before persistence.
+- Day windows are derived from that normalized Day 1 local open time.
 
-### Winoe Report transcript/pipeline services
-- The evaluation pipeline now checks transcript status before including Day 4 evidence.
-- Day 4 is excluded from scoring whenever the transcript is missing, failed, empty, or not ready.
+### Candidate-local past-date validation
+- Past-date rejection now compares against the normalized candidate-local schedule semantics.
+- This prevents false positives from timezone mismatches when the candidate proposes a local date that is still in the future for the candidate but not as a raw UTC timestamp.
 
-### Handoff/presentation status and submission-detail payloads
-- Day 4 handoff/status responses surface the failed transcript state clearly.
-- Submission detail payloads expose the transcript failure and retry/dead-letter metadata so Talent Partners can see why Day 4 is not ready for scoring.
+### Existing schedule persistence + email flow retained
+- The schedule is persisted on the candidate session.
+- Schedule confirmation emails still go to both the candidate and the Talent Partner.
+- Locked schedule behavior remains idempotent for the same payload and rejects conflicting resubmits.
 
-### Shared jobs transcribe-recording handler/runtime
-- Transcript jobs now retry before reaching dead-letter.
-- The runtime now preserves the terminal dead-letter state after retries are exhausted.
+### Local runtime default for deterministic greenfield provisioning
+- `runBackend.sh` now defaults local runtime to `WINOE_SCENARIO_GENERATION_RUNTIME_MODE=demo`.
+- The default only applies in local runtime paths and remains overrideable.
+- Non-local behavior is unchanged.
 
-### Candidate progress / compare contract fixes
-- `dayCompletion` remains a submission/progress signal.
-- It is not used as transcript readiness or evaluation readiness.
-
-### Targeted tests and QA coverage tests
-- Coverage was updated around transcript readiness, retry/dead-letter behavior, Day 4 exclusion from Winoe evaluation, and the surfaced handoff/submission-detail state.
+### Automated tests added/updated
+- Route coverage now verifies date-only input normalization to Day 1 open time.
+- Service coverage now verifies local past-date rejection.
+- Shell coverage now verifies local greenfield defaults and the deterministic demo mode export.
 
 ## 4. Behavioral details
-
-### Day 4 submission progress vs Day 4 evaluation readiness
-- Day 4 submission/progress still reflects whether the candidate completed the submission flow.
-- Winoe evaluation readiness is separate and depends on transcript usability.
-
-### Transcript readiness rules
-- Missing transcript: excluded from Winoe evaluation.
-- Failed transcript: excluded from Winoe evaluation.
-- Empty transcript: excluded from Winoe evaluation.
-- Not ready transcript: excluded from Winoe evaluation.
-
-### Retry-before-dead-letter behavior
-- Transcript jobs retry multiple times before a terminal dead-letter state.
-- The final terminal state is visible and distinct from an in-flight retry state.
-
-### Where failed transcript state is surfaced to the Talent Partner
-- Day 4 handoff/status.
-- Submission detail.
-- Transcript job retry/dead-letter metadata attached to the transcript surface.
-
-### Why compare `dayCompletion` remains submission-based
-- Compare `dayCompletion` tracks candidate progress through the submission flow.
-- It intentionally stays separate from transcript evaluation gating so progress reporting does not get conflated with transcript health.
+- Date-only and datetime inputs both normalize to Day 1 local open time.
+- `scheduledStartAt`, `candidateTimezone`, `githubUsername`, `dayWindows`, and `scheduleLockedAt` remain in the schedule response.
+- Locked schedule behavior remains idempotent for the same payload and rejects conflicting resubmits.
+- The local-only runtime default is overrideable and does not change non-local behavior.
 
 ## 5. Manual QA evidence
-- Local migrate/bootstrap passed.
-- API-only runtime was used with controlled one-shot worker execution for deterministic transcript-job stepping.
-- Real Trial / candidate session / Day 4 upload were exercised through live endpoints.
-- Retry timeline was captured cleanly before dead-letter.
-- Surfaced Day 4 failed state was verified in handoff status, submission detail, and compare.
-- Evaluation bundle showed `disabled_day_indexes = [4]`.
-- Evaluation bundle included the failed Day 4 transcript reference.
-- Evaluation bundle included empty Day 4 transcript segments.
-- Transcript job retried repeatedly before dead-letter.
-- Final terminal state was `dead_letter`.
-- Transcript ended `failed`.
-- Compare `dayCompletion` stayed submission/progress-based.
-- Winoe evaluation skipped Day 4.
+Final greenfield QA succeeded with a fresh Trial created in local greenfield flow.
+
+- Trial ID: `56`
+- Scenario version ID: `41`
+- Candidate session ID: `59`
+- Invite token: `q6uBK_Q4TL3CKBBn5LEZ1EAI93R_Ytn2Uc8FHEkEjbM`
+
+Live scheduling evidence:
+
+```http
+POST /api/candidate/session/{token}/schedule
+```
+
+```json
+{
+  "scheduledStartAt": "2026-04-20T13:00:00Z",
+  "candidateTimezone": "America/New_York",
+  "githubUsername": "qa288-smtp-user"
+}
+```
+
+- 200 response with `candidateSessionId: 59`
+- 200 response with `scheduledStartAt: 2026-04-20T13:00:00Z`
+- 200 response with `candidateTimezone: America/New_York`
+- 200 response with `githubUsername: qa288-smtp-user`
+
+Timezone and day-window evidence:
+
+- `dayWindowsCount: 5`
+- First window start: `2026-04-20T13:00:00Z`
+- First window end: `2026-04-20T21:00:00Z`
+
+Email evidence from the localhost SMTP sink:
+
+- Invite email to the candidate
+- Schedule confirmation email to the candidate
+- Schedule confirmation email to the Talent Partner
+- Captured subjects:
+  - `You're invited: Issue 288 SMTP QA Trial`
+  - `Schedule confirmed: Issue 288 SMTP QA Trial`
+  - `Candidate scheduled: QA Candidate 288 SMTP`
+
+Pre-Day-1 lock evidence:
+
+- `GET /api/candidate/session/{candidate_session_id}/current_task`
+- 409 response with `errorCode: SCHEDULE_NOT_STARTED`
+- 409 response with `detail: Trial has not started yet.`
+- 409 response with `details.startAt: 2026-04-20T13:00:00Z`
+
+Past-date rejection evidence:
+
+- Scheduling payload with `2026-04-17T13:00:00Z`
+- 422 response with `errorCode: SCHEDULE_START_IN_PAST`
+
+Persistence evidence:
+
+- `candidateTimezone: America/New_York`
+- `scheduledStartAt: 2026-04-20T13:00:00+00:00`
+- `scheduleLockedAt: 2026-04-18T20:46:47.727923+00:00`
+- `githubUsername: qa288-smtp-user`
 
 ## 6. Automated verification
-- Full suite passed.
-- Final result: `1732 passed`.
-- Coverage gate passed at `96.04%`.
-- `git diff --check` passed.
+- Local migrate/bootstrap passed.
+- Backend and worker started successfully.
+- Local readiness checks passed.
+- Focused pytest slice passed:
+  `./.venv/bin/pytest -q -o addopts='' tests/scripts/test_local_qa_backend_shell.py tests/scripts/test_run_backend_bootstrap_local_shell.py tests/scripts/test_run_backend_local_defaults_shell.py tests/trials/services/test_trials_scenario_generation_env_service.py tests/trials/services/test_trials_scenario_generation_generation_service.py`
 - Pre-commit checks passed.
+- Final worker report showed `1735 passed`.
+- Final worker report showed coverage gate passing at `96.05%`.
 
 ## 7. Acceptance criteria mapping
-- Day 4 completion blocked or degraded when transcription fails: Day 4 is now excluded from Winoe evaluation when transcript readiness is missing, failed, empty, or not ready, and the surfaced status makes the failure visible.
-- Winoe evaluation skips Day 4 from failed transcript: the pipeline checks transcript status before including Day 4 evidence.
-- Transcript job has retry logic before dead-letter: transcript jobs retry before reaching the terminal dead-letter state.
-- Failed state visible to Talent Partner with retry: failed transcript state and retry/dead-letter metadata are exposed in handoff/status and submission detail.
-- Pipeline checks transcript status before including Day 4 evidence: Day 4 evidence is only considered when transcript readiness is valid.
+- Candidate proposes start date via scheduling endpoint: the schedule endpoint now accepts candidate-proposed start dates and datetimes.
+- Timezone-aware day windows computed: the proposed start normalizes to the candidate timezone before day-window derivation.
+- Email notification to both parties: schedule confirmation emails go to the candidate and the Talent Partner.
+- No Trial content before Day 1 opens: current-task access remains locked until the scheduled Day 1 start.
+- Past dates rejected: candidate-local past dates return `SCHEDULE_START_IN_PAST`.
+- Schedule persisted on candidate session: the candidate session row stores the normalized schedule, timezone, and lock timestamp.
 
-## 8. Risks / notes
-- Helper/route compatibility paths were intentionally retained for legacy test doubles and tuple-style mocks.
-- No schema migration was required.
-- Compare progress semantics were intentionally kept separate from transcript evaluation gating.
+## 8. Risks / Notes
+- The local runtime default is local-only and overrideable.
+- Production and live scenario-generation behavior outside local defaulted environments is unchanged.
+- No migration was required.
 
-## 9. Final note
-Day 4 submission/progress is not the same thing as Day 4 transcript usability for Winoe evaluation.

--- a/runBackend.sh
+++ b/runBackend.sh
@@ -34,6 +34,8 @@ apply_local_defaults() {
   if [[ -z "${WINOE_ENV:-}" || "${WINOE_ENV:-}" == "local" ]]; then
     export WINOE_ENV="${WINOE_ENV:-local}"
     export DEV_AUTH_BYPASS="${DEV_AUTH_BYPASS:-1}"
+    # Keep local greenfield provisioning deterministic unless a caller opts out.
+    export WINOE_SCENARIO_GENERATION_RUNTIME_MODE="${WINOE_SCENARIO_GENERATION_RUNTIME_MODE:-demo}"
   fi
 }
 

--- a/tests/candidates/routes/test_candidates_session_schedule_schedule_endpoint_accepts_date_and_normalizes_to_day1_open_time_routes.py
+++ b/tests/candidates/routes/test_candidates_session_schedule_schedule_endpoint_accepts_date_and_normalizes_to_day1_open_time_routes.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, time, timedelta
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from tests.candidates.routes.candidates_session_schedule_api_utils import *
+
+
+@pytest.mark.asyncio
+async def test_schedule_endpoint_accepts_date_and_normalizes_to_day1_open_time(
+    async_client, async_session, override_dependencies
+):
+    talent_partner, _trial, cs = await _seed_claimed_session(async_session)
+    await _claim(async_client, cs.token, cs.invite_email)
+
+    provider = MemoryEmailProvider()
+    email_service = EmailService(provider, sender="noreply@test.com")
+    zone = ZoneInfo("America/New_York")
+    candidate_date = datetime.now(UTC).astimezone(zone).date() + timedelta(days=1)
+    expected_start_at = datetime.combine(
+        candidate_date, time(hour=9), tzinfo=zone
+    ).astimezone(UTC)
+    payload = {
+        "scheduledStartAt": candidate_date.isoformat(),
+        "candidateTimezone": "America/New_York",
+        "githubUsername": "octocat",
+    }
+
+    with override_dependencies({get_email_service: lambda: email_service}):
+        response = await async_client.post(
+            f"/api/candidate/session/{cs.token}/schedule",
+            json=payload,
+            headers={"Authorization": f"Bearer candidate:{cs.invite_email}"},
+        )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["scheduledStartAt"] == expected_start_at.isoformat().replace(
+        "+00:00", "Z"
+    )
+    assert len(provider.sent) == 2
+    recipients = {message.to for message in provider.sent}
+    assert cs.invite_email in recipients
+    assert talent_partner.email in recipients

--- a/tests/candidates/services/test_candidates_session_schedule_service_rejects_local_past_date_service.py
+++ b/tests/candidates/services/test_candidates_session_schedule_service_rejects_local_past_date_service.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from datetime import UTC, date, datetime
+
+import pytest
+
+from tests.candidates.services.candidates_session_schedule_service_utils import *
+
+
+@pytest.mark.asyncio
+async def test_schedule_candidate_session_rejects_local_past_date(
+    async_session,
+):
+    (
+        _tasks,
+        candidate_session,
+        principal,
+        email_service,
+    ) = await _seed_claimed_schedule_context(async_session)
+    now = datetime(2026, 3, 10, 14, 0, tzinfo=UTC)
+
+    with pytest.raises(ApiError) as excinfo:
+        await schedule_service.schedule_candidate_session(
+            async_session,
+            token=candidate_session.token,
+            principal=principal,
+            scheduled_start_at=date(2026, 3, 10),
+            candidate_timezone="America/New_York",
+            github_username="octocat",
+            email_service=email_service,
+            now=now,
+        )
+
+    assert excinfo.value.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+    assert excinfo.value.error_code == "SCHEDULE_START_IN_PAST"

--- a/tests/scripts/test_run_backend_local_defaults_shell.py
+++ b/tests/scripts/test_run_backend_local_defaults_shell.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+def test_run_backend_api_exports_local_scenario_generation_demo_mode(tmp_path):
+    repo_root = Path(__file__).resolve().parents[2]
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+
+    log_file = tmp_path / "command.log"
+    env_file = tmp_path / "runtime.env"
+    env_file.write_text(
+        "\n".join(
+            [
+                "WINOE_DATABASE_URL=sqlite:///tmp/winoe.db",
+                "WINOE_DATABASE_URL_SYNC=sqlite:///tmp/winoe.db",
+            ]
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    poetry_script = bin_dir / "poetry"
+    poetry_script.write_text(
+        """#!/bin/bash
+set -euo pipefail
+{
+  echo "poetry:$*"
+  echo "scenario_generation_runtime_mode:${WINOE_SCENARIO_GENERATION_RUNTIME_MODE:-missing}"
+  echo "dev_auth_bypass:${DEV_AUTH_BYPASS:-missing}"
+  echo "winoe_env:${WINOE_ENV:-missing}"
+} >> "$TEST_COMMAND_LOG"
+shift
+if [[ "${1:-}" == "run" ]]; then
+  shift
+fi
+exec "$@"
+""",
+        encoding="utf-8",
+    )
+    poetry_script.chmod(0o755)
+
+    uvicorn_script = bin_dir / "uvicorn"
+    uvicorn_script.write_text(
+        """#!/bin/bash
+set -euo pipefail
+{
+  echo "uvicorn:$*"
+  echo "scenario_generation_runtime_mode:${WINOE_SCENARIO_GENERATION_RUNTIME_MODE:-missing}"
+  echo "dev_auth_bypass:${DEV_AUTH_BYPASS:-missing}"
+  echo "winoe_env:${WINOE_ENV:-missing}"
+} >> "$TEST_COMMAND_LOG"
+""",
+        encoding="utf-8",
+    )
+    uvicorn_script.chmod(0o755)
+
+    env = os.environ.copy()
+    env["PATH"] = f"{bin_dir}:{env.get('PATH', '')}"
+    env["ENV_FILE"] = str(env_file)
+    env["TEST_COMMAND_LOG"] = str(log_file)
+    env["WINOE_ENV"] = "local"
+
+    result = subprocess.run(
+        ["bash", "runBackend.sh", "api"],
+        cwd=repo_root,
+        env=env,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    log_output = log_file.read_text(encoding="utf-8")
+    assert (
+        "poetry:run uvicorn app.api.main:app --reload --host 0.0.0.0 --port 8000"
+        in log_output
+    )
+    assert "uvicorn:app.api.main:app --reload --host 0.0.0.0 --port 8000" in log_output
+    assert "scenario_generation_runtime_mode:demo" in log_output
+    assert "winoe_env:local" in log_output


### PR DESCRIPTION
# Candidate start-date proposal flow with Talent Partner notification

## 1. Summary
Candidate schedule requests now support start-date semantics correctly.

A candidate-proposed date or datetime is normalized to the Trial's Day 1 local open time in the candidate's timezone before persistence and day-window derivation. Past-date rejection now respects candidate-local scheduling semantics. Schedule confirmation emails go to both the candidate and the Talent Partner. Trial content stays locked before Day 1 opens.

Local greenfield QA is now deterministic because `runBackend.sh` defaults local runtime to `WINOE_SCENARIO_GENERATION_RUNTIME_MODE=demo` unless explicitly overridden.

## 2. Problem / Why
Issue #288 needed the scheduling contract to match product truth: candidates propose a start date, but the backend must normalize that proposal into the Trial's Day 1 open time in the candidate's timezone before storing it or deriving day windows.

The QA blocker was separate but related to greenfield provisioning. Fresh local Trial creation could dead-letter in scenario generation unless local runtime defaulted to deterministic demo mode, which made the local QA path unreliable.

## 3. What changed

### Candidate scheduling contract / normalization
- The schedule request now accepts either a date or a datetime.
- Both inputs normalize to the Trial's Day 1 local open time in the candidate's timezone before persistence.
- Day windows are derived from that normalized Day 1 local open time.

### Candidate-local past-date validation
- Past-date rejection now compares against the normalized candidate-local schedule semantics.
- This prevents false positives from timezone mismatches when the candidate proposes a local date that is still in the future for the candidate but not as a raw UTC timestamp.

### Existing schedule persistence + email flow retained
- The schedule is persisted on the candidate session.
- Schedule confirmation emails still go to both the candidate and the Talent Partner.
- Locked schedule behavior remains idempotent for the same payload and rejects conflicting resubmits.

### Local runtime default for deterministic greenfield provisioning
- `runBackend.sh` now defaults local runtime to `WINOE_SCENARIO_GENERATION_RUNTIME_MODE=demo`.
- The default only applies in local runtime paths and remains overrideable.
- Non-local behavior is unchanged.

### Automated tests added/updated
- Route coverage now verifies date-only input normalization to Day 1 open time.
- Service coverage now verifies local past-date rejection.
- Shell coverage now verifies local greenfield defaults and the deterministic demo mode export.

## 4. Behavioral details
- Date-only and datetime inputs both normalize to Day 1 local open time.
- `scheduledStartAt`, `candidateTimezone`, `githubUsername`, `dayWindows`, and `scheduleLockedAt` remain in the schedule response.
- Locked schedule behavior remains idempotent for the same payload and rejects conflicting resubmits.
- The local-only runtime default is overrideable and does not change non-local behavior.

## 5. Manual QA evidence
Final greenfield QA succeeded with a fresh Trial created in local greenfield flow.

- Trial ID: `56`
- Scenario version ID: `41`
- Candidate session ID: `59`
- Invite token: `q6uBK_Q4TL3CKBBn5LEZ1EAI93R_Ytn2Uc8FHEkEjbM`

Live scheduling evidence:

```http
POST /api/candidate/session/{token}/schedule
```

```json
{
  "scheduledStartAt": "2026-04-20T13:00:00Z",
  "candidateTimezone": "America/New_York",
  "githubUsername": "qa288-smtp-user"
}
```

- 200 response with `candidateSessionId: 59`
- 200 response with `scheduledStartAt: 2026-04-20T13:00:00Z`
- 200 response with `candidateTimezone: America/New_York`
- 200 response with `githubUsername: qa288-smtp-user`

Timezone and day-window evidence:

- `dayWindowsCount: 5`
- First window start: `2026-04-20T13:00:00Z`
- First window end: `2026-04-20T21:00:00Z`

Email evidence from the localhost SMTP sink:

- Invite email to the candidate
- Schedule confirmation email to the candidate
- Schedule confirmation email to the Talent Partner
- Captured subjects:
  - `You're invited: Issue 288 SMTP QA Trial`
  - `Schedule confirmed: Issue 288 SMTP QA Trial`
  - `Candidate scheduled: QA Candidate 288 SMTP`

Pre-Day-1 lock evidence:

- `GET /api/candidate/session/{candidate_session_id}/current_task`
- 409 response with `errorCode: SCHEDULE_NOT_STARTED`
- 409 response with `detail: Trial has not started yet.`
- 409 response with `details.startAt: 2026-04-20T13:00:00Z`

Past-date rejection evidence:

- Scheduling payload with `2026-04-17T13:00:00Z`
- 422 response with `errorCode: SCHEDULE_START_IN_PAST`

Persistence evidence:

- `candidateTimezone: America/New_York`
- `scheduledStartAt: 2026-04-20T13:00:00+00:00`
- `scheduleLockedAt: 2026-04-18T20:46:47.727923+00:00`
- `githubUsername: qa288-smtp-user`

## 6. Automated verification
- Local migrate/bootstrap passed.
- Backend and worker started successfully.
- Local readiness checks passed.
- Focused pytest slice passed:
  `./.venv/bin/pytest -q -o addopts='' tests/scripts/test_local_qa_backend_shell.py tests/scripts/test_run_backend_bootstrap_local_shell.py tests/scripts/test_run_backend_local_defaults_shell.py tests/trials/services/test_trials_scenario_generation_env_service.py tests/trials/services/test_trials_scenario_generation_generation_service.py`
- Pre-commit checks passed.
- Final worker report showed `1735 passed`.
- Final worker report showed coverage gate passing at `96.05%`.

## 7. Acceptance criteria mapping
- Candidate proposes start date via scheduling endpoint: the schedule endpoint now accepts candidate-proposed start dates and datetimes.
- Timezone-aware day windows computed: the proposed start normalizes to the candidate timezone before day-window derivation.
- Email notification to both parties: schedule confirmation emails go to the candidate and the Talent Partner.
- No Trial content before Day 1 opens: current-task access remains locked until the scheduled Day 1 start.
- Past dates rejected: candidate-local past dates return `SCHEDULE_START_IN_PAST`.
- Schedule persisted on candidate session: the candidate session row stores the normalized schedule, timezone, and lock timestamp.

## 8. Risks / Notes
- The local runtime default is local-only and overrideable.
- Production and live scenario-generation behavior outside local defaulted environments is unchanged.
- No migration was required.

Fixes #288 