### PR TITLE
Replace Day 3 debugging with same-repo implementation wrap-up

### DIFF
--- a/app/submissions/services/submissions_services_submissions_payload_validation_service.py
+++ b/app/submissions/services/submissions_services_submissions_payload_validation_service.py
@@ -30,7 +30,7 @@ logger = logging.getLogger(__name__)
 
 
 def is_code_task(task: Task) -> bool:
-    """Return True if the task requires code (code/debug)."""
+    """Return True if the task requires code."""
     return (task.type or "").lower() in CODE_TASK_TYPES
 
 
@@ -159,7 +159,7 @@ def validate_submission_payload(task: Task, payload) -> dict[str, object] | None
 
 
 def validate_run_allowed(task: Task) -> None:
-    """Run tests only applies to code/debug tasks."""
+    """Run tests only applies to code tasks."""
     if not is_code_task(task):
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,

--- a/app/submissions/services/submissions_services_submissions_workspace_creation_provision_service.py
+++ b/app/submissions/services/submissions_services_submissions_workspace_creation_provision_service.py
@@ -88,7 +88,10 @@ async def provision_workspace(
         and existing_group is None
     ):
         raise WorkspaceMissing(
-            detail="Workspace not initialized. Call Day 2 /codespace/init first."
+            detail=(
+                "Workspace not initialized. "
+                "Call Day 2 /codespace/init first on the shared coding workspace."
+            )
         )
     if uses_grouped_workspace:
         return await provision_grouped_workspace(

--- a/app/tasks/routes/tasks/tasks_routes_tasks_tasks_codespace_init_routes.py
+++ b/app/tasks/routes/tasks/tasks_routes_tasks_tasks_codespace_init_routes.py
@@ -26,6 +26,7 @@ router = APIRouter()
 @router.post(
     "/{task_id}/codespace/init",
     response_model=CodespaceInitResponse,
+    response_model_exclude_none=True,
     status_code=status.HTTP_200_OK,
 )
 async def init_codespace_route(

--- a/app/tasks/routes/tasks/tasks_routes_tasks_tasks_submit_routes.py
+++ b/app/tasks/routes/tasks/tasks_routes_tasks_tasks_submit_routes.py
@@ -40,7 +40,7 @@ async def submit_task_route(
     github_client: Annotated[GithubClient, Depends(get_github_client)],
     actions_runner: Annotated[GithubActionsRunner, Depends(get_actions_runner)],
 ) -> SubmissionCreateResponse:
-    """Submit a task, optionally running GitHub tests for code/debug types."""
+    """Submit a task, optionally running GitHub tests for code tasks."""
     return await handle_submit_task(
         task_id=task_id,
         payload=payload,

--- a/app/trials/constants/trials_constants_trials_blueprints_constants.py
+++ b/app/trials/constants/trials_constants_trials_blueprints_constants.py
@@ -19,11 +19,12 @@ DEFAULT_5_DAY_BLUEPRINT = [
     },
     {
         "day_index": 3,
-        "type": "debug",
-        "title": "Debugging Exercise",
+        "type": "code",
+        "title": "Implementation Wrap-Up",
         "description": (
-            "Investigate failing tests or bugs in the codebase and "
-            "apply fixes with regression coverage."
+            "Continue in the same repository used on Day 2. "
+            "Finish implementation details, tighten tests, improve docs, and "
+            "polish the codebase for handoff."
         ),
     },
     {

--- a/app/trials/services/trials_services_trials_invite_preprovision_service.py
+++ b/app/trials/services/trials_services_trials_invite_preprovision_service.py
@@ -44,8 +44,7 @@ async def preprovision_workspaces(
         "hydrate_precommit_bundle" in ensure_workspace_params
     )
     for task in tasks:
-        task_type = str(task.type or "").lower()
-        if task.day_index not in {2, 3} or task_type not in {"code", "debug"}:
+        if task.day_index not in {2, 3} or not submission_service.is_code_task(task):
             continue
         workspace_key = resolve_workspace_key_for_task(task)
         if workspace_key and workspace_key in processed_workspace_keys:

--- a/app/trials/services/trials_services_trials_scenario_generation_constants.py
+++ b/app/trials/services/trials_services_trials_scenario_generation_constants.py
@@ -33,21 +33,21 @@ CODE_PRIORITIES = (
     "defensive validation and error handling",
     "traceable behavior with useful diagnostics",
 )
-DEBUG_SIGNALS = (
-    "a flaky production-like test signal",
-    "an intermittent regression after a recent refactor",
-    "inconsistent behavior across environments",
-    "a correctness bug hidden by shallow happy-path tests",
-    "a state-management bug triggered by retry paths",
+IMPLEMENTATION_WRAP_UP_SIGNALS = (
+    "production-ready handoff readiness",
+    "test coverage and regression hardening",
+    "documentation polish and release notes",
+    "code quality cleanup and consistency",
+    "final validation across the core user flow",
 )
 
 __all__ = [
     "ANTHROPIC_API_ENV_KEYS",
     "CODE_PRIORITIES",
-    "DEBUG_SIGNALS",
     "DEMO_MODE_ENV_KEYS",
     "FALLBACK_MODEL_NAME",
     "FALLBACK_MODEL_VERSION",
+    "IMPLEMENTATION_WRAP_UP_SIGNALS",
     "OPENAI_API_ENV_KEYS",
     "SCENARIO_GENERATION_JOB_TYPE",
     "SCENARIO_PROMPT_VERSION",

--- a/app/trials/services/trials_services_trials_scenario_generation_payloads_service.py
+++ b/app/trials/services/trials_services_trials_scenario_generation_payloads_service.py
@@ -44,7 +44,7 @@ def build_rubric_json(*, role: str) -> dict[str, Any]:
     """Build rubric json."""
     role_label = normalize_text(role) or "Engineer"
     return {
-        "summary": f"Evaluate {role_label} performance across planning, implementation, debugging, demo presentation, and reflection in a from-scratch build.",
+        "summary": f"Evaluate {role_label} performance across planning, implementation, wrap-up, demo presentation, and reflection in a from-scratch build.",
         "dayWeights": {"1": 20, "2": 30, "3": 25, "4": 15, "5": 10},
         "dimensions": [
             {
@@ -58,9 +58,9 @@ def build_rubric_json(*, role: str) -> dict[str, Any]:
                 "description": "Ships correct, maintainable changes with useful tests.",
             },
             {
-                "name": "Debugging rigor",
+                "name": "Implementation completeness and handoff readiness",
                 "weight": 20,
-                "description": "Finds root cause methodically and verifies the fix.",
+                "description": "Finishes the core implementation, hardens edge cases, and leaves the codebase ready for reviewer handoff.",
             },
             {
                 "name": "Communication and presentation",

--- a/app/trials/services/trials_services_trials_scenario_generation_runtime_service.py
+++ b/app/trials/services/trials_services_trials_scenario_generation_runtime_service.py
@@ -11,9 +11,9 @@ from app.trials.constants.trials_constants_trials_blueprints_constants import (
 )
 from app.trials.services.trials_services_trials_scenario_generation_constants import (
     CODE_PRIORITIES,
-    DEBUG_SIGNALS,
     FALLBACK_MODEL_NAME,
     FALLBACK_MODEL_VERSION,
+    IMPLEMENTATION_WRAP_UP_SIGNALS,
     SCENARIO_PROMPT_VERSION,
     SCENARIO_RUBRIC_VERSION,
     SCENARIO_SOURCE_TEMPLATE_FALLBACK,
@@ -54,7 +54,7 @@ def _task_description_for_day(
         tech_stack=tech_stack,
         template_key=template_key,
         code_priorities=CODE_PRIORITIES,
-        debug_signals=DEBUG_SIGNALS,
+        implementation_wrap_up_signals=IMPLEMENTATION_WRAP_UP_SIGNALS,
         pick=pick,
     )
 

--- a/app/trials/services/trials_services_trials_scenario_generation_story_service.py
+++ b/app/trials/services/trials_services_trials_scenario_generation_story_service.py
@@ -143,19 +143,23 @@ def build_task_description(
     tech_stack: str,
     template_key: str,
     code_priorities: tuple[str, ...],
-    debug_signals: tuple[str, ...],
+    implementation_wrap_up_signals: tuple[str, ...],
     pick: PickFn,
 ) -> str:
     """Build task description."""
     seed = seed_from_inputs(role, tech_stack, template_key)
     priority = pick(code_priorities, seed, 10 + day_index)
-    debug_signal = pick(debug_signals, seed, 20 + day_index)
+    wrap_up_signal = pick(implementation_wrap_up_signals, seed, 20 + day_index)
     if day_index == 1:
         return "Draft an implementation plan that defines service boundaries, key data flows, API contracts, and risk controls. Include concrete tradeoffs and how you will validate correctness with tests and reviewable artifacts."
     if day_index == 2:
         return f"Implement the primary backend slice in code with tests. Prioritize {priority} and keep the solution aligned with the brief."
     if day_index == 3:
-        return f"Investigate and fix a failing behavior path. Treat {debug_signal} as the anchor signal, isolate root cause, and add regression coverage."
+        return (
+            "Continue the implementation wrap-up in the same repository used on Day 2. "
+            f"Focus on {wrap_up_signal} while finishing implementation details, "
+            "tightening tests, improving docs, and polishing the codebase for handoff."
+        )
     if day_index == 4:
         return "Prepare a concise demo presentation that walks through the implemented solution, key decisions, tradeoffs, outcomes, and remaining risks for reviewers."
     return "Write a markdown reflection essay covering your experience, challenges, decisions, tradeoffs, communication, and what you would do next."

--- a/docs/mvp1/evidence_traceability.md
+++ b/docs/mvp1/evidence_traceability.md
@@ -61,6 +61,7 @@ Consumer behavior uses pinned cutoff basis:
 - Submission responses and talent_partner submission presenters resolve `commitSha` from cutoff when available, and expose `cutoffCommitSha` and `evalBasisRef`.
 - Winoe Report generation uses day-audit cutoff SHAs first when building `day2_checkpoint_sha`, `day3_final_sha`, and run basis references.
 - Run metadata stores `basisRefs`; `basis_fingerprint` hashes the complete basis payload.
+- Day 3 wrap-up captures the candidate-owned repository head as the final evidence state. There is no baseline artifact or diff-based model for the repository itself.
 
 Conservative interpretation: each run is a traceable snapshot of the evidence basis used at generation time. Re-runs create new `EvaluationRun` records instead of mutating prior run records.
 

--- a/pr.md
+++ b/pr.md
@@ -1,131 +1,99 @@
-# Candidate start-date proposal flow with Talent Partner notification
+# Replace Day 3 debugging with same-repo implementation wrap-up
 
 ## 1. Summary
-Candidate schedule requests now support start-date semantics correctly.
+Day 3 now reflects the product truth for Winoe AI v4:
 
-A candidate-proposed date or datetime is normalized to the Trial's Day 1 local open time in the candidate's timezone before persistence and day-window derivation. Past-date rejection now respects candidate-local scheduling semantics. Schedule confirmation emails go to both the candidate and the Talent Partner. Trial content stays locked before Day 1 opens.
+- It seeds as `type: "code"`.
+- Its title is `Implementation Wrap-Up`.
+- It continues in the same repository and workspace used on Day 2.
+- It persists `finalSha` on Day 3 submission.
+- It treats the repository as candidate-owned work, not a debugging exercise.
+- It removes debug-era framing from runtime Trial generation.
+- It omits legacy `baseTemplateSha` and `precommitSha` from `/api/tasks/{task_id}/codespace/init` responses when those values are null.
 
-Local greenfield QA is now deterministic because `runBackend.sh` defaults local runtime to `WINOE_SCENARIO_GENERATION_RUNTIME_MODE=demo` unless explicitly overridden.
+The backend now tells the truth in seeded tasks, scenario payloads, rubric text, and candidate-facing API responses.
 
-## 2. Problem / Why
-Issue #288 needed the scheduling contract to match product truth: candidates propose a start date, but the backend must normalize that proposal into the Trial's Day 1 open time in the candidate's timezone before storing it or deriving day windows.
+## 2. What Changed
 
-The QA blocker was separate but related to greenfield provisioning. Fresh local Trial creation could dead-letter in scenario generation unless local runtime defaulted to deterministic demo mode, which made the local QA path unreliable.
+### Day 3 blueprint / seeded task truth
+- Updated the Day 3 seeded blueprint to `Implementation Wrap-Up`.
+- Kept Day 3 as a code task.
+- Kept Day 3 explicitly tied to the same repo/workspace used on Day 2.
 
-## 3. What changed
+### Scenario generation copy for Day 3
+- Updated runtime Day 3 prompt copy to frame the day as continuation work in the same repository.
+- Removed debugging language from the Day 3 prompt path.
+- Kept the copy focused on finishing implementation details, tightening tests, improving docs, and polishing for handoff.
 
-### Candidate scheduling contract / normalization
-- The schedule request now accepts either a date or a datetime.
-- Both inputs normalize to the Trial's Day 1 local open time in the candidate's timezone before persistence.
-- Day windows are derived from that normalized Day 1 local open time.
+### Rubric summary and dimensions
+- Updated the rubric summary to describe planning, implementation, wrap-up, demo presentation, and reflection in a from-scratch build.
+- Renamed the Day 3-facing rubric dimension away from debugging and toward implementation completeness and handoff readiness.
 
-### Candidate-local past-date validation
-- Past-date rejection now compares against the normalized candidate-local schedule semantics.
-- This prevents false positives from timezone mismatches when the candidate proposes a local date that is still in the future for the candidate but not as a raw UTC timestamp.
+### Runtime init response cleanup
+- Cleaned up `/api/tasks/{task_id}/codespace/init` responses so null legacy fields are not emitted.
+- The response now returns the workspace identity and repo identity needed by the candidate without exposing null `baseTemplateSha` / `precommitSha` fields.
 
-### Existing schedule persistence + email flow retained
-- The schedule is persisted on the candidate session.
-- Schedule confirmation emails still go to both the candidate and the Talent Partner.
-- Locked schedule behavior remains idempotent for the same payload and rejects conflicting resubmits.
+### Test updates
+- Updated trial creation and scenario-generation tests to assert Day 3 is `Implementation Wrap-Up`.
+- Updated submission tests to verify Day 3 persists `finalSha` and reuses the Day 2 repository.
+- Updated codespace-init tests to verify the legacy null fields are omitted.
+- Added/kept the missing-workspace path test returning `WORKSPACE_NOT_INITIALIZED`.
 
-### Local runtime default for deterministic greenfield provisioning
-- `runBackend.sh` now defaults local runtime to `WINOE_SCENARIO_GENERATION_RUNTIME_MODE=demo`.
-- The default only applies in local runtime paths and remains overrideable.
-- Non-local behavior is unchanged.
+### Deterministic precommit stabilization
+- Stabilized `test_schedule_candidate_session_validation_errors` by moving the past timestamp farther into the past so `SCHEDULE_START_IN_PAST` is deterministic in precommit.
 
-### Automated tests added/updated
-- Route coverage now verifies date-only input normalization to Day 1 open time.
-- Service coverage now verifies local past-date rejection.
-- Shell coverage now verifies local greenfield defaults and the deterministic demo mode export.
+## 3. Why
+Winoe AI v4 is from scratch. There is no precommit baseline to debug against, so Day 3 must be framed as same-repo implementation wrap-up.
 
-## 4. Behavioral details
-- Date-only and datetime inputs both normalize to Day 1 local open time.
-- `scheduledStartAt`, `candidateTimezone`, `githubUsername`, `dayWindows`, and `scheduleLockedAt` remain in the schedule response.
-- Locked schedule behavior remains idempotent for the same payload and rejects conflicting resubmits.
-- The local-only runtime default is overrideable and does not change non-local behavior.
+That means the backend has to be truthful in every place candidates and reviewers see Day 3:
 
-## 5. Manual QA evidence
-Final greenfield QA succeeded with a fresh Trial created in local greenfield flow.
+- seeded tasks
+- runtime Trial generation
+- rubric copy
+- codespace init responses
+- submission persistence
 
-- Trial ID: `56`
-- Scenario version ID: `41`
-- Candidate session ID: `59`
-- Invite token: `q6uBK_Q4TL3CKBBn5LEZ1EAI93R_Ytn2Uc8FHEkEjbM`
+If those surfaces still talk about debugging or legacy baseline concepts, the product story is wrong.
 
-Live scheduling evidence:
+## 4. Acceptance Criteria
 
-```http
-POST /api/candidate/session/{token}/schedule
-```
+- [x] Day 3 title is `Implementation Wrap-Up`
+- [x] Day 3 uses the same repo/workspace as Day 2
+- [x] Day 3 captures and persists `finalSha`
+- [x] Runtime scenario/task/rubric payloads use wrap-up framing instead of debugging framing
+- [x] `/codespace/init` omits `baseTemplateSha` and `precommitSha` when null
+- [x] Missing Day 2 workspace returns `WORKSPACE_NOT_INITIALIZED`
 
-```json
-{
-  "scheduledStartAt": "2026-04-20T13:00:00Z",
-  "candidateTimezone": "America/New_York",
-  "githubUsername": "qa288-smtp-user"
-}
-```
+## 5. Testing / QA
 
-- 200 response with `candidateSessionId: 59`
-- 200 response with `scheduledStartAt: 2026-04-20T13:00:00Z`
-- 200 response with `candidateTimezone: America/New_York`
-- 200 response with `githubUsername: qa288-smtp-user`
+### Live QA evidence
+- Trial create/detail showed Day 3:
+  - `type: "code"`
+  - `title: "Implementation Wrap-Up"`
+  - scenario Day 3 prompt uses wrap-up framing
+  - rubric summary uses wrap-up framing, not debugging framing
+- Day 2 init and Day 3 init used the same repo/workspace:
+  - `repoFullName: winoe-ai-repos/winoe-ws-82`
+  - `workspaceId: 9988df21-aac5-4126-9885-f23efb643b67`
+- Day 2 and Day 3 init payloads omitted:
+  - `baseTemplateSha`
+  - `precommitSha`
+- Day 3 submit returned and persisted:
+  - `finalSha: "abc123"`
+- Missing-workspace path returned:
+  - `errorCode: "WORKSPACE_NOT_INITIALIZED"`
 
-Timezone and day-window evidence:
+### DB verification
+- Day 2 submission repo matched Day 3 submission repo.
+- Day 3 submission stored `finalSha`.
+- A single workspace was reused for Day 2 and Day 3.
 
-- `dayWindowsCount: 5`
-- First window start: `2026-04-20T13:00:00Z`
-- First window end: `2026-04-20T21:00:00Z`
+### Validation commands
+- `./precommit.sh`
+  - `1735 passed`
+  - coverage `96.05%`
+  - `✅ All pre-commit checks passed!`
 
-Email evidence from the localhost SMTP sink:
-
-- Invite email to the candidate
-- Schedule confirmation email to the candidate
-- Schedule confirmation email to the Talent Partner
-- Captured subjects:
-  - `You're invited: Issue 288 SMTP QA Trial`
-  - `Schedule confirmed: Issue 288 SMTP QA Trial`
-  - `Candidate scheduled: QA Candidate 288 SMTP`
-
-Pre-Day-1 lock evidence:
-
-- `GET /api/candidate/session/{candidate_session_id}/current_task`
-- 409 response with `errorCode: SCHEDULE_NOT_STARTED`
-- 409 response with `detail: Trial has not started yet.`
-- 409 response with `details.startAt: 2026-04-20T13:00:00Z`
-
-Past-date rejection evidence:
-
-- Scheduling payload with `2026-04-17T13:00:00Z`
-- 422 response with `errorCode: SCHEDULE_START_IN_PAST`
-
-Persistence evidence:
-
-- `candidateTimezone: America/New_York`
-- `scheduledStartAt: 2026-04-20T13:00:00+00:00`
-- `scheduleLockedAt: 2026-04-18T20:46:47.727923+00:00`
-- `githubUsername: qa288-smtp-user`
-
-## 6. Automated verification
-- Local migrate/bootstrap passed.
-- Backend and worker started successfully.
-- Local readiness checks passed.
-- Focused pytest slice passed:
-  `./.venv/bin/pytest -q -o addopts='' tests/scripts/test_local_qa_backend_shell.py tests/scripts/test_run_backend_bootstrap_local_shell.py tests/scripts/test_run_backend_local_defaults_shell.py tests/trials/services/test_trials_scenario_generation_env_service.py tests/trials/services/test_trials_scenario_generation_generation_service.py`
-- Pre-commit checks passed.
-- Final worker report showed `1735 passed`.
-- Final worker report showed coverage gate passing at `96.05%`.
-
-## 7. Acceptance criteria mapping
-- Candidate proposes start date via scheduling endpoint: the schedule endpoint now accepts candidate-proposed start dates and datetimes.
-- Timezone-aware day windows computed: the proposed start normalizes to the candidate timezone before day-window derivation.
-- Email notification to both parties: schedule confirmation emails go to the candidate and the Talent Partner.
-- No Trial content before Day 1 opens: current-task access remains locked until the scheduled Day 1 start.
-- Past dates rejected: candidate-local past dates return `SCHEDULE_START_IN_PAST`.
-- Schedule persisted on candidate session: the candidate session row stores the normalized schedule, timezone, and lock timestamp.
-
-## 8. Risks / Notes
-- The local runtime default is local-only and overrideable.
-- Production and live scenario-generation behavior outside local defaulted environments is unchanged.
-- No migration was required.
-
+## 6. Risks / Follow-ups
+- Local live QA used demo/stubbed GitHub and Actions setup for deterministic validation.
+- One legacy test filename may still contain `debug`, but shipped runtime behavior and assertions now reflect Implementation Wrap-Up.

--- a/tests/candidates/services/test_candidates_session_schedule_service_schedule_candidate_session_validation_and_claim_errors_service.py
+++ b/tests/candidates/services/test_candidates_session_schedule_service_schedule_candidate_session_validation_and_claim_errors_service.py
@@ -33,7 +33,7 @@ async def test_schedule_candidate_session_validation_errors(async_session):
             async_session,
             token=claimed.token,
             principal=claimed_principal,
-            scheduled_start_at=datetime.now(UTC) - timedelta(minutes=1),
+            scheduled_start_at=datetime.now(UTC) - timedelta(days=1),
             candidate_timezone="America/New_York",
             github_username="octocat",
             email_service=email_service,

--- a/tests/submissions/repositories/github_native/workspaces/test_submissions_github_native_workspaces_workspace_keys_repository.py
+++ b/tests/submissions/repositories/github_native/workspaces/test_submissions_github_native_workspaces_workspace_keys_repository.py
@@ -6,10 +6,11 @@ from app.submissions.repositories.github_native.workspaces.submissions_repositor
 )
 
 
-def test_resolve_workspace_key_maps_day2_day3_code_and_debug():
+def test_resolve_workspace_key_maps_day2_day3_code_tasks_to_coding_workspace():
     assert resolve_workspace_key(day_index=2, task_type="code") == CODING_WORKSPACE_KEY
-    assert resolve_workspace_key(day_index=3, task_type="debug") == CODING_WORKSPACE_KEY
+    assert resolve_workspace_key(day_index=3, task_type="code") == CODING_WORKSPACE_KEY
     assert resolve_workspace_key(day_index=2, task_type="DEBUG") == CODING_WORKSPACE_KEY
+    assert resolve_workspace_key(day_index=3, task_type="debug") == CODING_WORKSPACE_KEY
 
 
 def test_resolve_workspace_key_ignores_non_coding_days():

--- a/tests/submissions/services/test_submissions_workspace_creation_provision_workspace_day3_requires_existing_coding_group_service.py
+++ b/tests/submissions/services/test_submissions_workspace_creation_provision_workspace_day3_requires_existing_coding_group_service.py
@@ -8,7 +8,7 @@ from tests.submissions.services.test_submissions_workspace_creation_service_util
 @pytest.mark.asyncio
 async def test_provision_workspace_day3_requires_existing_coding_group(monkeypatch):
     candidate_session = SimpleNamespace(id=11)
-    task = SimpleNamespace(id=101, day_index=3, type="debug")
+    task = SimpleNamespace(id=101, day_index=3, type="code")
 
     async def _session_uses_grouped_workspace(*_args, **_kwargs):
         return True

--- a/tests/submissions/services/test_submissions_workspace_creation_provision_workspace_day3_uses_existing_coding_group_service.py
+++ b/tests/submissions/services/test_submissions_workspace_creation_provision_workspace_day3_uses_existing_coding_group_service.py
@@ -8,7 +8,7 @@ from tests.submissions.services.test_submissions_workspace_creation_service_util
 @pytest.mark.asyncio
 async def test_provision_workspace_day3_uses_existing_coding_group(monkeypatch):
     candidate_session = SimpleNamespace(id=11)
-    task = SimpleNamespace(id=101, day_index=3, type="debug")
+    task = SimpleNamespace(id=101, day_index=3, type="code")
     grouped_workspace = SimpleNamespace(id="ws-grouped")
     calls = {"grouped": 0}
 

--- a/tests/talent_partners/routes/test_talent_partners_trials_invites_routes.py
+++ b/tests/talent_partners/routes/test_talent_partners_trials_invites_routes.py
@@ -30,7 +30,7 @@ async def test_create_candidate_invite_happy_path(monkeypatch):
         id=10, day_index=2, type="code", template_repo="org/template"
     )
     task_day3 = SimpleNamespace(
-        id=11, day_index=3, type="debug", template_repo="org/template"
+        id=11, day_index=3, type="code", template_repo="org/template"
     )
 
     async def _require_owned_with_tasks(db, trial_id, talent_partner_id):

--- a/tests/tasks/routes/test_tasks_run_codespace_init_day3_reuses_existing_workspace_when_template_missing_routes.py
+++ b/tests/tasks/routes/test_tasks_run_codespace_init_day3_reuses_existing_workspace_when_template_missing_routes.py
@@ -38,7 +38,7 @@ async def test_codespace_init_day3_reuses_existing_workspace_when_template_missi
         async_session, candidate_session=cs, task=tasks[1], content_text="day2"
     )
 
-    # Day 3 template is unused when reusing unified coding workspace.
+    # Day 3 reuses the unified coding workspace from Day 2.
     tasks[2].template_repo = None
     await async_session.commit()
 

--- a/tests/tasks/routes/test_tasks_run_codespace_init_response_shape_no_bundle_routes.py
+++ b/tests/tasks/routes/test_tasks_run_codespace_init_response_shape_no_bundle_routes.py
@@ -97,6 +97,8 @@ async def test_codespace_init_response_shape_no_bundle(
         "defaultBranch": "main",
         "workspaceId": body["workspaceId"],
     }
+    assert "baseTemplateSha" not in body
+    assert "precommitSha" not in body
     assert isinstance(body["workspaceId"], str)
     assert body["workspaceId"]
 

--- a/tests/tasks/routes/test_tasks_run_codespace_init_works_for_debug_task_routes.py
+++ b/tests/tasks/routes/test_tasks_run_codespace_init_works_for_debug_task_routes.py
@@ -6,12 +6,12 @@ from tests.tasks.routes.test_tasks_run_api_utils import *
 
 
 @pytest.mark.asyncio
-async def test_codespace_init_works_for_debug_task(
+async def test_codespace_init_works_for_day3_implementation_wrap_up(
     async_client, async_session, candidate_header_factory, actions_stubber
 ):
     actions_stubber()
     talent_partner = await create_talent_partner(
-        async_session, email="debug-task@sim.com"
+        async_session, email="wrap-up-task@sim.com"
     )
     sim, tasks = await create_trial(async_session, created_by=talent_partner)
     cs = await create_candidate_session(

--- a/tests/tasks/routes/test_tasks_submit_submit_day3_debug_returns_and_persists_final_sha_routes.py
+++ b/tests/tasks/routes/test_tasks_submit_submit_day3_debug_returns_and_persists_final_sha_routes.py
@@ -6,7 +6,7 @@ from tests.tasks.routes.test_tasks_submit_api_utils import *
 
 
 @pytest.mark.asyncio
-async def test_submit_day3_debug_returns_and_persists_final_sha(
+async def test_submit_day3_implementation_wrap_up_returns_and_persists_final_sha(
     async_client, async_session: AsyncSession, monkeypatch, actions_stubber
 ):
     monkeypatch.setenv("DEV_AUTH_BYPASS", "1")

--- a/tests/tasks/routes/test_tasks_submit_submitting_all_tasks_marks_session_complete_routes.py
+++ b/tests/tasks/routes/test_tasks_submit_submitting_all_tasks_marks_session_complete_routes.py
@@ -38,7 +38,7 @@ async def test_submitting_all_tasks_marks_session_complete(
         assert current["currentDayIndex"] == day_index
         task_id = current["currentTask"]["id"]
 
-        if current["currentTask"]["type"] in {"code", "debug"}:
+        if current["currentTask"]["type"] == "code":
             init_resp = await async_client.post(
                 f"/api/tasks/{task_id}/codespace/init",
                 headers=candidate_headers(cs_id, access_token),

--- a/tests/trials/routes/test_trials_api_invite_github_failure_reuses_candidate_session_routes.py
+++ b/tests/trials/routes/test_trials_api_invite_github_failure_reuses_candidate_session_routes.py
@@ -16,7 +16,7 @@ async def test_invite_github_failure_does_not_persist_failed_candidate_session(
     day2_task = next(t for t in tasks if t.day_index == 2)
     day3_task = next(t for t in tasks if t.day_index == 3)
     day2_task.type = "code"
-    day3_task.type = "debug"
+    day3_task.type = "code"
     day2_task_id = day2_task.id
     day3_task_id = day3_task.id
     await async_session.commit()

--- a/tests/trials/routes/test_trials_api_invite_preprovisions_day2_day3_workspaces_routes.py
+++ b/tests/trials/routes/test_trials_api_invite_preprovisions_day2_day3_workspaces_routes.py
@@ -21,7 +21,7 @@ async def test_invite_preprovisions_day2_day3_workspaces(
     day3_tasks = [t for t in tasks if t.day_index == 3]
     assert day2_tasks and day3_tasks
     day2_tasks[0].type = "code"
-    day3_tasks[0].type = "debug"
+    day3_tasks[0].type = "code"
     await async_session.commit()
     monkeypatch.setattr(settings.github, "GITHUB_ORG", "winoe-ai-repos")
 

--- a/tests/trials/routes/test_trials_create_create_trial_creates_sim_and_5_tasks_routes.py
+++ b/tests/trials/routes/test_trials_create_create_trial_creates_sim_and_5_tasks_routes.py
@@ -57,9 +57,16 @@ async def test_create_trial_creates_sim_and_5_tasks(
         assert [t["type"] for t in data["tasks"]] == [
             "design",
             "code",
-            "debug",
+            "code",
             "handoff",
             "documentation",
+        ]
+        assert [t["title"] for t in data["tasks"]] == [
+            "Architecture Plan",
+            "Feature Implementation",
+            "Implementation Wrap-Up",
+            "Demo Presentation",
+            "Reflection Essay",
         ]
         assert data["techStack"] == "Node.js, PostgreSQL"
         assert data["focus"] == ""

--- a/tests/trials/routes/test_trials_scenario_generation_flow_success_routes.py
+++ b/tests/trials/routes/test_trials_scenario_generation_flow_success_routes.py
@@ -118,6 +118,10 @@ async def test_scenario_generation_job_creates_v1_and_updates_detail_read(
     assert sorted(prompts_by_day) == [1, 2, 3, 4, 5]
     assert sorted(tasks_by_day) == [1, 2, 3, 4, 5]
     rubric_day_weights = detail["scenario"]["rubricJson"]["dayWeights"]
+    assert prompts_by_day[3]["title"] == "Implementation Wrap-Up"
+    assert "wrap-up" in prompts_by_day[3]["description"].lower()
+    assert "debug" not in prompts_by_day[3]["description"].lower()
+    assert "debug" not in detail["scenario"]["rubricJson"]["summary"].lower()
     for day_index in [1, 2, 3, 4, 5]:
         assert (
             tasks_by_day[day_index]["description"]

--- a/tests/trials/services/test_trials_scenario_generation_generation_service.py
+++ b/tests/trials/services/test_trials_scenario_generation_generation_service.py
@@ -200,11 +200,26 @@ def test_deterministic_template_generation_uses_demo_and_reflection_language() -
         prompt for prompt in payload.task_prompts_json if prompt["dayIndex"] == 5
     )
 
+    day3 = next(
+        prompt for prompt in payload.task_prompts_json if prompt["dayIndex"] == 3
+    )
     assert "demo presentation" in day4["description"].lower()
     assert "reflection essay" in day5["description"].lower()
-    assert "demo presentation" in payload.rubric_json["summary"].lower()
+    assert "implementation wrap-up" in day3["title"].lower()
+    assert "wrap-up" in day3["description"].lower()
+    assert "debug" not in day3["description"].lower()
+    assert "wrap-up" in payload.rubric_json["summary"].lower()
     assert any(
         dimension["name"] == "Communication and presentation"
+        for dimension in payload.rubric_json["dimensions"]
+    )
+    assert any(
+        dimension["name"] == "Implementation completeness and handoff readiness"
+        for dimension in payload.rubric_json["dimensions"]
+    )
+    assert all(
+        "debug" not in dimension["name"].lower()
+        and "debug" not in dimension["description"].lower()
         for dimension in payload.rubric_json["dimensions"]
     )
 


### PR DESCRIPTION
## 1. Summary
Day 3 now reflects the product truth for Winoe AI v4:

- It seeds as `type: "code"`.
- Its title is `Implementation Wrap-Up`.
- It continues in the same repository and workspace used on Day 2.
- It persists `finalSha` on Day 3 submission.
- It treats the repository as candidate-owned work, not a debugging exercise.
- It removes debug-era framing from runtime Trial generation.
- It omits legacy `baseTemplateSha` and `precommitSha` from `/api/tasks/{task_id}/codespace/init` responses when those values are null.

The backend now tells the truth in seeded tasks, scenario payloads, rubric text, and candidate-facing API responses.

## 2. What Changed

### Day 3 blueprint / seeded task truth
- Updated the Day 3 seeded blueprint to `Implementation Wrap-Up`.
- Kept Day 3 as a code task.
- Kept Day 3 explicitly tied to the same repo/workspace used on Day 2.

### Scenario generation copy for Day 3
- Updated runtime Day 3 prompt copy to frame the day as continuation work in the same repository.
- Removed debugging language from the Day 3 prompt path.
- Kept the copy focused on finishing implementation details, tightening tests, improving docs, and polishing for handoff.

### Rubric summary and dimensions
- Updated the rubric summary to describe planning, implementation, wrap-up, demo presentation, and reflection in a from-scratch build.
- Renamed the Day 3-facing rubric dimension away from debugging and toward implementation completeness and handoff readiness.

### Runtime init response cleanup
- Cleaned up `/api/tasks/{task_id}/codespace/init` responses so null legacy fields are not emitted.
- The response now returns the workspace identity and repo identity needed by the candidate without exposing null `baseTemplateSha` / `precommitSha` fields.

### Test updates
- Updated trial creation and scenario-generation tests to assert Day 3 is `Implementation Wrap-Up`.
- Updated submission tests to verify Day 3 persists `finalSha` and reuses the Day 2 repository.
- Updated codespace-init tests to verify the legacy null fields are omitted.
- Added/kept the missing-workspace path test returning `WORKSPACE_NOT_INITIALIZED`.

### Deterministic precommit stabilization
- Stabilized `test_schedule_candidate_session_validation_errors` by moving the past timestamp farther into the past so `SCHEDULE_START_IN_PAST` is deterministic in precommit.

## 3. Why
Winoe AI v4 is from scratch. There is no precommit baseline to debug against, so Day 3 must be framed as same-repo implementation wrap-up.

That means the backend has to be truthful in every place candidates and reviewers see Day 3:

- seeded tasks
- runtime Trial generation
- rubric copy
- codespace init responses
- submission persistence

If those surfaces still talk about debugging or legacy baseline concepts, the product story is wrong.

## 4. Acceptance Criteria

- [x] Day 3 title is `Implementation Wrap-Up`
- [x] Day 3 uses the same repo/workspace as Day 2
- [x] Day 3 captures and persists `finalSha`
- [x] Runtime scenario/task/rubric payloads use wrap-up framing instead of debugging framing
- [x] `/codespace/init` omits `baseTemplateSha` and `precommitSha` when null
- [x] Missing Day 2 workspace returns `WORKSPACE_NOT_INITIALIZED`

## 5. Testing / QA

### Live QA evidence
- Trial create/detail showed Day 3:
  - `type: "code"`
  - `title: "Implementation Wrap-Up"`
  - scenario Day 3 prompt uses wrap-up framing
  - rubric summary uses wrap-up framing, not debugging framing
- Day 2 init and Day 3 init used the same repo/workspace:
  - `repoFullName: winoe-ai-repos/winoe-ws-82`
  - `workspaceId: 9988df21-aac5-4126-9885-f23efb643b67`
- Day 2 and Day 3 init payloads omitted:
  - `baseTemplateSha`
  - `precommitSha`
- Day 3 submit returned and persisted:
  - `finalSha: "abc123"`
- Missing-workspace path returned:
  - `errorCode: "WORKSPACE_NOT_INITIALIZED"`

### DB verification
- Day 2 submission repo matched Day 3 submission repo.
- Day 3 submission stored `finalSha`.
- A single workspace was reused for Day 2 and Day 3.

### Validation commands
- `./precommit.sh`
  - `1735 passed`
  - coverage `96.05%`
  - `✅ All pre-commit checks passed!`

## 6. Risks / Follow-ups
- Local live QA used demo/stubbed GitHub and Actions setup for deterministic validation.
- One legacy test filename may still contain `debug`, but shipped runtime behavior and assertions now reflect Implementation Wrap-Up.

Fixes #289 