### PR TITLE
Patch for 177: Restore Trial detail preview for the v4 project brief flow

### DIFF
--- a/app/shared/utils/shared_utils_project_brief_service.py
+++ b/app/shared/utils/shared_utils_project_brief_service.py
@@ -2,8 +2,36 @@
 
 from __future__ import annotations
 
+import json
 from collections.abc import Mapping
 from typing import Any
+
+
+def _field_value(value: Any, field_name: str) -> Any:
+    if isinstance(value, Mapping):
+        return value.get(field_name)
+    return getattr(value, field_name, None)
+
+
+def _string_value(value: Any) -> str:
+    if isinstance(value, str):
+        return value.strip()
+    if isinstance(value, Mapping):
+        markdown = value.get("markdown") or value.get("projectBriefMd")
+        if isinstance(markdown, str) and markdown.strip():
+            return markdown.strip()
+        nested = value.get("project_brief_md") or value.get("projectBriefMd")
+        if isinstance(nested, str) and nested.strip():
+            return nested.strip()
+        if isinstance(nested, Mapping):
+            return _string_value(nested)
+        derived = _legacy_brief_lines(value)
+        if derived:
+            return derived
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    if value is None:
+        return ""
+    return str(value).strip()
 
 
 def _legacy_brief_lines(legacy_brief: Mapping[str, Any]) -> str:
@@ -76,13 +104,13 @@ def canonical_project_brief_markdown(
     storyline_md: str | None = None,
 ) -> str:
     """Return the canonical project brief markdown for a scenario version."""
-    project_brief_md = (
-        getattr(scenario_version, "project_brief_md", None) or ""
-    ).strip()
+    project_brief_md = _string_value(
+        _field_value(scenario_version, "project_brief_md")
+    )
     if project_brief_md:
         return project_brief_md
 
-    legacy_brief = getattr(scenario_version, "codespace_spec_json", None)
+    legacy_brief = _field_value(scenario_version, "codespace_spec_json")
     if isinstance(legacy_brief, str) and legacy_brief.strip():
         return legacy_brief.strip()
     if isinstance(legacy_brief, Mapping):

--- a/app/shared/utils/shared_utils_project_brief_service.py
+++ b/app/shared/utils/shared_utils_project_brief_service.py
@@ -104,9 +104,7 @@ def canonical_project_brief_markdown(
     storyline_md: str | None = None,
 ) -> str:
     """Return the canonical project brief markdown for a scenario version."""
-    project_brief_md = _string_value(
-        _field_value(scenario_version, "project_brief_md")
-    )
+    project_brief_md = _string_value(_field_value(scenario_version, "project_brief_md"))
     if project_brief_md:
         return project_brief_md
 

--- a/app/trials/services/trials_services_trials_scenario_versions_regeneration_service.py
+++ b/app/trials/services/trials_services_trials_scenario_versions_regeneration_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from datetime import UTC, datetime
 
+from sqlalchemy import desc, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.shared.database.shared_database_models_model import (
@@ -12,19 +13,35 @@ from app.shared.database.shared_database_models_model import (
     ScenarioVersion,
     Trial,
 )
+from app.shared.jobs.repositories import repository as jobs_repo
+from app.shared.jobs.repositories.shared_jobs_repositories_models_repository import (
+    JOB_STATUS_DEAD_LETTER,
+)
 from app.shared.utils.shared_utils_errors_utils import ApiError
 from app.trials.repositories.scenario_versions import (
     trials_repositories_scenario_versions_trials_scenario_versions_repository as scenario_repo,
 )
+from app.trials.repositories.scenario_versions.trials_repositories_scenario_versions_trials_scenario_versions_model import (
+    SCENARIO_VERSION_STATUS_GENERATING,
+)
 from app.trials.repositories.trials_repositories_trials_trial_model import (
+    TRIAL_STATUS_GENERATING,
     TRIAL_STATUS_READY_FOR_REVIEW,
 )
 from app.trials.services.trials_services_trials_lifecycle_service import (
     apply_status_transition,
 )
+from app.trials.services.trials_services_trials_scenario_generation_service import (
+    SCENARIO_GENERATION_JOB_MAX_ATTEMPTS,
+    SCENARIO_GENERATION_JOB_TYPE,
+)
+from app.trials.services.trials_services_trials_scenario_payload_builder_service import (
+    build_scenario_generation_payload,
+)
 from app.trials.services.trials_services_trials_scenario_versions_access_service import (
     get_active_scenario_for_update,
     require_owned_trial_for_update,
+    scenario_generation_idempotency_key,
 )
 from app.trials.services.trials_services_trials_scenario_versions_regeneration_helpers_service import (
     clone_pending_scenario,
@@ -32,6 +49,67 @@ from app.trials.services.trials_services_trials_scenario_versions_regeneration_h
 )
 
 logger = logging.getLogger(__name__)
+PUBLIC_JOB_STATUS_FAILED = "failed"
+
+
+async def _load_latest_scenario_generation_job(
+    db: AsyncSession, *, trial_id: int, company_id: int
+) -> Job | None:
+    stmt = (
+        select(Job)
+        .where(
+            Job.company_id == company_id,
+            Job.job_type == SCENARIO_GENERATION_JOB_TYPE,
+            Job.correlation_id.like(f"trial:{trial_id}%"),
+        )
+        .order_by(desc(Job.created_at), desc(Job.updated_at))
+    )
+    return await db.scalar(stmt)
+
+
+async def _restore_placeholder_scenario_version(
+    db: AsyncSession,
+    *,
+    trial: Trial,
+) -> ScenarioVersion:
+    existing = (
+        await db.execute(
+            select(ScenarioVersion)
+            .where(ScenarioVersion.trial_id == trial.id)
+            .order_by(ScenarioVersion.version_index.asc(), ScenarioVersion.id.asc())
+            .with_for_update()
+        )
+    ).scalar_one_or_none()
+    if existing is None:
+        existing = ScenarioVersion(
+            trial_id=trial.id,
+            version_index=1,
+            status=SCENARIO_VERSION_STATUS_GENERATING,
+            storyline_md="",
+            task_prompts_json=[],
+            project_brief_md="",
+            rubric_json={},
+            focus_notes=trial.focus or "",
+            template_key=trial.template_key,
+            tech_stack=trial.tech_stack,
+            seniority=trial.seniority,
+        )
+        db.add(existing)
+        await db.flush()
+    else:
+        existing.status = SCENARIO_VERSION_STATUS_GENERATING
+        existing.storyline_md = ""
+        existing.task_prompts_json = []
+        existing.project_brief_md = ""
+        existing.rubric_json = {}
+        existing.focus_notes = trial.focus or ""
+        existing.template_key = trial.template_key
+        existing.tech_stack = trial.tech_stack
+        existing.seniority = trial.seniority
+        existing.locked_at = None
+        await db.flush()
+    trial.active_scenario_version_id = existing.id
+    return existing
 
 
 async def regenerate_active_scenario_version(
@@ -56,6 +134,9 @@ async def request_scenario_regeneration(
     """Execute request scenario regeneration."""
     regenerated_at = datetime.now(UTC)
     trial = await require_owned_trial_for_update(db, trial_id, actor_user_id)
+    latest_scenario_job = await _load_latest_scenario_generation_job(
+        db, trial_id=trial.id, company_id=trial.company_id
+    )
     if trial.pending_scenario_version_id is not None:
         raise ApiError(
             status_code=409,
@@ -64,7 +145,51 @@ async def request_scenario_regeneration(
             retryable=False,
             details={"pendingScenarioVersionId": trial.pending_scenario_version_id},
         )
-    active = await get_active_scenario_for_update(db, trial)
+    try:
+        active = await get_active_scenario_for_update(db, trial)
+    except ApiError as exc:
+        if exc.error_code != "SCENARIO_ACTIVE_VERSION_MISSING":
+            raise
+        latest_job_is_failed = bool(
+            latest_scenario_job
+            and getattr(latest_scenario_job, "status", None)
+            in {JOB_STATUS_DEAD_LETTER, PUBLIC_JOB_STATUS_FAILED}
+        )
+        if trial.status != TRIAL_STATUS_GENERATING and not latest_job_is_failed:
+            raise
+        active = None
+
+    if active is None:
+        regenerated = await _restore_placeholder_scenario_version(db, trial=trial)
+        scenario_job = latest_scenario_job
+        if scenario_job is None:
+            payload_json = build_scenario_generation_payload(trial)
+            scenario_job = await jobs_repo.create_or_get_idempotent(
+                db,
+                job_type=SCENARIO_GENERATION_JOB_TYPE,
+                idempotency_key=scenario_generation_idempotency_key(trial.id),
+                payload_json=payload_json,
+                company_id=trial.company_id,
+                correlation_id=f"trial:{trial.id}",
+                max_attempts=SCENARIO_GENERATION_JOB_MAX_ATTEMPTS,
+                commit=False,
+            )
+        elif scenario_job.status == JOB_STATUS_DEAD_LETTER:
+            await jobs_repo.requeue_dead_letter_jobs(
+                db, now=regenerated_at, job_ids=[str(scenario_job.id)]
+            )
+        await db.commit()
+        await db.refresh(trial)
+        await db.refresh(regenerated)
+        await db.refresh(scenario_job)
+        logger.info(
+            "Scenario generation retry restored placeholder trialId=%s scenarioVersionId=%s jobId=%s",
+            trial.id,
+            regenerated.id,
+            scenario_job.id,
+        )
+        return trial, regenerated, scenario_job
+
     new_index = await scenario_repo.next_version_index(db, trial.id)
     regenerated = clone_pending_scenario(trial, active, new_index)
     db.add(regenerated)

--- a/tests/trials/routes/test_trials_scenario_generation_flow_failure_routes.py
+++ b/tests/trials/routes/test_trials_scenario_generation_flow_failure_routes.py
@@ -90,3 +90,13 @@ async def test_scenario_generation_failure_marks_job_failed_and_keeps_generating
     assert detail["generationFailure"]["canRetry"] is True
     assert detail["canRetryGeneration"] is True
     assert detail["scenario"] is None
+
+    retry_response = await async_client.post(
+        f"/api/trials/{trial_id}/scenario/regenerate",
+        headers=auth_header_factory(talent_partner),
+    )
+    assert retry_response.status_code == 200, retry_response.text
+    retry_body = retry_response.json()
+    assert retry_body["scenarioVersionId"] is not None
+    assert retry_body["jobId"] is not None
+    assert retry_body["status"] == "generating"

--- a/tests/trials/services/test_trials_project_brief_service.py
+++ b/tests/trials/services/test_trials_project_brief_service.py
@@ -21,6 +21,47 @@ def test_canonical_project_brief_uses_new_string_payload() -> None:
     )
 
 
+def test_canonical_project_brief_normalizes_dict_project_brief_payload() -> None:
+    scenario_version = SimpleNamespace(
+        project_brief_md={
+            "summary": "Build a candidate-facing workflow.",
+            "candidateGoal": "Deliver the core system from scratch.",
+            "acceptance_criteria": [
+                "The repo ships with a working README.",
+                "The implementation stays within the brief.",
+            ],
+        },
+        codespace_spec_json=None,
+    )
+
+    project_brief_md = canonical_project_brief_markdown(scenario_version)
+
+    assert project_brief_md.startswith("# Project Brief")
+    assert "Build a candidate-facing workflow." in project_brief_md
+    assert "Deliver the core system from scratch." in project_brief_md
+    assert "The repo ships with a working README." in project_brief_md
+    assert "The implementation stays within the brief." in project_brief_md
+
+
+def test_canonical_project_brief_accepts_mapping_like_scenario_version() -> None:
+    scenario_version = {
+        "project_brief_md": {
+            "summary": "Build a candidate-facing workflow.",
+            "deliverables": ["Ship the README", "Keep the repo open-ended"],
+        },
+        "codespace_spec_json": {
+            "summary": "Unused fallback",
+        },
+    }
+
+    project_brief_md = canonical_project_brief_markdown(scenario_version)
+
+    assert project_brief_md.startswith("# Project Brief")
+    assert "Build a candidate-facing workflow." in project_brief_md
+    assert "Ship the README" in project_brief_md
+    assert "Keep the repo open-ended" in project_brief_md
+
+
 def test_canonical_project_brief_derives_legacy_dict_payload() -> None:
     scenario_version = SimpleNamespace(
         project_brief_md=None,

--- a/tests/trials/services/test_trials_scenario_versions_regenerate_active_scenario_version_owner_and_active_guards_service.py
+++ b/tests/trials/services/test_trials_scenario_versions_regenerate_active_scenario_version_owner_and_active_guards_service.py
@@ -2,6 +2,9 @@ from __future__ import annotations
 
 import pytest
 
+from app.shared.jobs.repositories.shared_jobs_repositories_models_repository import (
+    JOB_STATUS_QUEUED,
+)
 from tests.trials.services.trials_scenario_versions_service_utils import *
 
 
@@ -28,10 +31,15 @@ async def test_regenerate_active_scenario_version_owner_and_active_guards(
     sim.status = "generating"
     sim.active_scenario_version_id = None
     await async_session.commit()
-    with pytest.raises(ApiError) as missing_exc:
-        await scenario_service.regenerate_active_scenario_version(
+    updated_sim, regenerated, scenario_job = (
+        await scenario_service.request_scenario_regeneration(
             async_session,
             trial_id=sim.id,
             actor_user_id=owner.id,
         )
-    assert missing_exc.value.error_code == "SCENARIO_ACTIVE_VERSION_MISSING"
+    )
+    assert regenerated.id == sim.active_scenario_version_id
+    assert regenerated.status == "generating"
+    assert updated_sim.active_scenario_version_id == regenerated.id
+    assert updated_sim.status == "generating"
+    assert scenario_job.status == JOB_STATUS_QUEUED

--- a/tests/trials/services/test_trials_scenario_versions_regenerate_active_scenario_version_owner_and_active_guards_service.py
+++ b/tests/trials/services/test_trials_scenario_versions_regenerate_active_scenario_version_owner_and_active_guards_service.py
@@ -31,12 +31,14 @@ async def test_regenerate_active_scenario_version_owner_and_active_guards(
     sim.status = "generating"
     sim.active_scenario_version_id = None
     await async_session.commit()
-    updated_sim, regenerated, scenario_job = (
-        await scenario_service.request_scenario_regeneration(
-            async_session,
-            trial_id=sim.id,
-            actor_user_id=owner.id,
-        )
+    (
+        updated_sim,
+        regenerated,
+        scenario_job,
+    ) = await scenario_service.request_scenario_regeneration(
+        async_session,
+        trial_id=sim.id,
+        actor_user_id=owner.id,
     )
     assert regenerated.id == sim.active_scenario_version_id
     assert regenerated.status == "generating"


### PR DESCRIPTION
## 1. Title

Restore Trial detail preview for the v4 project brief flow

## 2. Summary

This PR restores the Talent Partner Trial detail page and aligns it to the v4 from-scratch pivot. The Trial preview now shows the Project Brief, scenario storyline, task descriptions, rubric summary, scenario version, and frozen AI snapshot metadata.

## 3. What changed

- Rebuilt the Trial detail preview so it renders the full scenario experience again after the backend contract fixes.
- Replaced legacy codespace/template framing with Project Brief language throughout the active Trial detail UI.
- Removed template name, template repo, and tech stack from the active Trial detail surface.
- Kept preferred language/framework visible only as informational context when present.
- Aligned the 5-day labels to the product spec:
  - Planning and Design Doc
  - Implementation Kickoff
  - Implementation Wrap-Up
  - Handoff + Demo
  - Reflection Essay
- Restored lifecycle controls for approve, activate, and terminate flows.
- Restored the generation failure state with a clear message and retry action.
- Kept invite controls disabled until the Trial reaches active inviting.

## 4. Backend alignment

- Backend normalization and retry blockers were resolved enough to complete full real-stack QA on the Trial detail experience.
- Live validation used the running frontend and backend, not mocked data.

## 5. QA / verification

- `npm run lint` - pass
- `npm run typecheck` - pass
- Live browser QA on the local stack - pass
- Trial 67 verified approve, activate, invite gating, and terminate behavior
- Trial 49 verified the failure state, retry flow, and Project Brief preview
- Verified outcomes:
  - scenario storyline loaded
  - task descriptions loaded
  - rubric summary loaded
  - scenario version and frozen AI snapshot metadata were visible
  - invite controls stayed disabled until activation
  - Project Brief replaced legacy codespace/template framing
  - no template name, template repo, or tech stack appeared in the active Trial detail UI
  - `codespace structure` does not appear in the restored Trial detail surface

## 6. Scope / non-scope

- No reintroduction of legacy template-selection UI.
- No claim of backend permanence beyond the live QA proof captured here.
