### PR TITLE
Day 5 reflection essay with 9 AM to 9 PM local extended window

### DIFF
--- a/app/shared/jobs/handlers/shared_jobs_handlers_day_close_finalize_text_submission_handler.py
+++ b/app/shared/jobs/handlers/shared_jobs_handlers_day_close_finalize_text_submission_handler.py
@@ -6,6 +6,9 @@ from copy import deepcopy
 from types import SimpleNamespace
 
 from app.submissions.repositories.task_drafts import repository as task_drafts_repo
+from app.submissions.services import (
+    submissions_services_submissions_candidate_service as submission_service,
+)
 from app.submissions.services.task_drafts import NO_DRAFT_AT_CUTOFF_MARKER
 
 
@@ -62,6 +65,9 @@ async def _finalize_submission_from_cutoff(
         await _mark_draft_finalized_if_pending(
             db, draft=draft, submission_id=existing_submission.id, finalized_at=now
         )
+        await submission_service.progress_after_submission(
+            db, candidate_session, now=now
+        )
         logger.info(
             "Day-close finalize no-op existing submission candidateSessionId=%s taskId=%s dayIndex=%s",
             candidate_session_id,
@@ -94,6 +100,9 @@ async def _finalize_submission_from_cutoff(
         await _mark_draft_finalized_if_pending(
             db, draft=draft, submission_id=existing_submission.id, finalized_at=now
         )
+        await submission_service.progress_after_submission(
+            db, candidate_session, now=now
+        )
         logger.info(
             "Day-close finalize no-op conflict candidateSessionId=%s taskId=%s dayIndex=%s",
             candidate_session_id,
@@ -111,6 +120,7 @@ async def _finalize_submission_from_cutoff(
     await _mark_draft_finalized_if_pending(
         db, draft=draft, submission_id=submission.id, finalized_at=now
     )
+    await submission_service.progress_after_submission(db, candidate_session, now=now)
     logger.info(
         "Day-close finalize created submission candidateSessionId=%s taskId=%s dayIndex=%s source=%s",
         candidate_session_id,

--- a/app/shared/types/shared_types_types_model.py
+++ b/app/shared/types/shared_types_types_model.py
@@ -3,7 +3,7 @@
 from typing import Literal
 
 CandidateSessionStatus = Literal["not_started", "in_progress", "completed", "expired"]
-TaskType = Literal["design", "code", "debug", "handoff", "documentation"]
+TaskType = Literal["design", "code", "debug", "handoff", "documentation", "reflection"]
 TrialStatus = Literal[
     "draft",
     "generating",

--- a/app/submissions/services/submissions_services_submissions_payload_validation_service.py
+++ b/app/submissions/services/submissions_services_submissions_payload_validation_service.py
@@ -12,9 +12,9 @@ from app.submissions.constants.submissions_constants_submissions_exceptions_cons
     SubmissionValidationError,
 )
 
-TEXT_TASK_TYPES = {"design", "documentation", "handoff"}
+TEXT_TASK_TYPES = {"design", "documentation", "handoff", "reflection"}
 CODE_TASK_TYPES = {"code", "debug"}
-DAY5_REFLECTION_TASK_TYPE = "documentation"
+DAY5_REFLECTION_TASK_TYPE = "reflection"
 DAY5_REFLECTION_DAY_INDEX = 5
 DAY5_REFLECTION_KIND = "day5_reflection"
 DAY5_REFLECTION_MIN_SECTION_CHARS = 20

--- a/app/trials/constants/trials_constants_trials_blueprints_constants.py
+++ b/app/trials/constants/trials_constants_trials_blueprints_constants.py
@@ -38,7 +38,7 @@ DEFAULT_5_DAY_BLUEPRINT = [
     },
     {
         "day_index": 5,
-        "type": "documentation",
+        "type": "reflection",
         "title": "Reflection Essay",
         "description": (
             "Write a markdown reflection essay covering your experience, "
@@ -46,3 +46,5 @@ DEFAULT_5_DAY_BLUEPRINT = [
         ),
     },
 ]
+
+DEFAULT_5_DAY_DAY5_WINDOW_OVERRIDE = {"5": {"startLocal": "09:00", "endLocal": "21:00"}}

--- a/app/trials/services/trials_services_trials_creation_builder_service.py
+++ b/app/trials/services/trials_services_trials_creation_builder_service.py
@@ -5,7 +5,13 @@ from __future__ import annotations
 from datetime import UTC, datetime
 from typing import Any
 
+from fastapi import status
+
 from app.shared.database.shared_database_models_model import Trial
+from app.shared.utils.shared_utils_errors_utils import ApiError
+from app.trials.constants.trials_constants_trials_blueprints_constants import (
+    DEFAULT_5_DAY_DAY5_WINDOW_OVERRIDE,
+)
 from app.trials.repositories.trials_repositories_trials_trial_model import (
     TRIAL_STATUS_GENERATING,
 )
@@ -20,6 +26,8 @@ from .trials_services_trials_creation_extractors_service import (
     extract_day_window_config,
 )
 from .trials_services_trials_template_keys_service import resolve_template_key
+
+DAY5_DAY_WINDOW_OVERRIDE_ERROR_CODE = "TRIAL_DAY5_WINDOW_OVERRIDE_INVALID"
 
 
 def _resolve_preferred_language_framework(payload: Any) -> str | None:
@@ -37,6 +45,40 @@ def _resolve_tech_stack(payload: Any, preferred_language_framework: str | None) 
     if preferred_language_framework is not None:
         return preferred_language_framework
     return ""
+
+
+def _resolve_day_window_overrides(
+    *,
+    day_window_overrides_enabled: bool,
+    day_window_overrides_json: dict[str, dict[str, str]] | None,
+) -> tuple[bool, dict[str, dict[str, str]]]:
+    canonical_day5_override = DEFAULT_5_DAY_DAY5_WINDOW_OVERRIDE["5"]
+    resolved_overrides: dict[str, dict[str, str]] = {
+        str(day_index): {
+            "startLocal": str(window.get("startLocal")),
+            "endLocal": str(window.get("endLocal")),
+        }
+        for day_index, window in (day_window_overrides_json or {}).items()
+        if isinstance(window, dict)
+    }
+    day5_override = resolved_overrides.get("5")
+    if day5_override is not None and day5_override != canonical_day5_override:
+        raise ApiError(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "dayWindowOverrides['5'] must use the canonical Day 5 window of "
+                "09:00 to 21:00 local"
+            ),
+            error_code=DAY5_DAY_WINDOW_OVERRIDE_ERROR_CODE,
+            retryable=False,
+            details={
+                "field": "dayWindowOverrides.5",
+                "expected": dict(canonical_day5_override),
+                "actual": dict(day5_override),
+            },
+        )
+    resolved_overrides.setdefault("5", dict(canonical_day5_override))
+    return bool(day_window_overrides_enabled or resolved_overrides), resolved_overrides
 
 
 def build_trial_for_create(
@@ -68,6 +110,13 @@ def build_trial_for_create(
         day_window_overrides_enabled,
         day_window_overrides_json,
     ) = extract_day_window_config(payload)
+    (
+        day_window_overrides_enabled,
+        day_window_overrides_json,
+    ) = _resolve_day_window_overrides(
+        day_window_overrides_enabled=day_window_overrides_enabled,
+        day_window_overrides_json=day_window_overrides_json,
+    )
     preferred_language_framework = _resolve_preferred_language_framework(payload)
     company_context = extract_company_context(payload)
     if preferred_language_framework is not None:

--- a/app/trials/services/trials_services_trials_creation_service.py
+++ b/app/trials/services/trials_services_trials_creation_service.py
@@ -22,6 +22,9 @@ from .trials_services_trials_creation_extractors_service import (
     extract_company_context,
     extract_day_window_config,
 )
+from .trials_services_trials_day_five_contract_service import (
+    enforce_day_five_trial_contract,
+)
 from .trials_services_trials_scenario_generation_service import (
     SCENARIO_GENERATION_JOB_MAX_ATTEMPTS,
     SCENARIO_GENERATION_JOB_TYPE,
@@ -100,6 +103,7 @@ async def create_trial_with_tasks(
     _log_ai_config_changes(sim.id, user.id, notice_version, eval_by_day)
 
     created_tasks = await seed_default_tasks(db, sim.id, sim.template_key)
+    enforce_day_five_trial_contract(sim, tasks=created_tasks)
     payload_json = build_scenario_generation_payload(sim)
     scenario_job = await jobs_repo.create_or_get_idempotent(
         db,

--- a/app/trials/services/trials_services_trials_day_five_contract_service.py
+++ b/app/trials/services/trials_services_trials_day_five_contract_service.py
@@ -1,0 +1,38 @@
+"""Application module for trials services day five contract workflows."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.trials.constants.trials_constants_trials_blueprints_constants import (
+    DEFAULT_5_DAY_DAY5_WINDOW_OVERRIDE,
+)
+
+
+def canonical_day_five_window_override() -> dict[str, dict[str, str]]:
+    """Return the canonical Day 5 local schedule override."""
+    return {
+        day_index: dict(window)
+        for day_index, window in DEFAULT_5_DAY_DAY5_WINDOW_OVERRIDE.items()
+    }
+
+
+def enforce_day_five_trial_contract(
+    trial: Any,
+    *,
+    tasks: list[Any] | None = None,
+) -> None:
+    """Normalize the Day 5 trial contract before persistence."""
+    trial.day_window_overrides_enabled = True
+    trial.day_window_overrides_json = canonical_day_five_window_override()
+    if tasks is None:
+        return
+    for task in tasks:
+        if getattr(task, "day_index", None) == 5:
+            task.type = "reflection"
+
+
+__all__ = [
+    "canonical_day_five_window_override",
+    "enforce_day_five_trial_contract",
+]

--- a/pr.md
+++ b/pr.md
@@ -1,108 +1,74 @@
-# Day 4 handoff/demo media flow: upload, transcription, duration guard, and playback
+# Day 5 reflection essay with 9 AM to 9 PM local extended window (#291)
 
 ## 1. Summary
 
-This change completes the backend for Day 4 handoff/demo media flow in Winoe AI.
+This PR makes Day 5 canonical as `reflection`, keeps the Day 5 local window at 09:00-21:00, and aligns the backend create, detail, autosave, submission, and day-close flows with that contract.
 
-- Enforces a maximum 15-minute recording duration at upload completion.
-- Keeps the handoff upload init/complete flow reliable and idempotent.
-- Allows preview and resubmission until the cutoff, with the latest valid recording becoming active.
-- Hardens the transcription pipeline so valid uploads enqueue and complete transcript processing.
-- Returns correct playback/download URLs and the expected CSP for Talent Partner playback.
-- Supports supplemental materials alongside the main recording.
-- Cleans up the public route contract so the canonical surface is `handoff`, not legacy `presentation`.
+## 2. Problem
 
-## 2. What Changed
+Day 5 still needed the extended local window and the correct task type. Before this change, the backend could surface Day 5 as `documentation` in some paths, and the day-close flow did not consistently propagate candidate session completion when the final Day 5 text submission was finalized from draft.
 
-### Media upload validation and completion
+## 3. What Changed
 
-- Added/kept validation on handoff upload completion for content type, size, and duration.
-- Enforced the 15-minute ceiling during completion so overlong uploads are rejected before they become accepted handoff media.
-- Kept completion idempotent so repeated completion calls do not corrupt the recording state.
+### Day 5 contract
 
-### Recording selection semantics
+- Canonicalized Day 5 to `reflection` in the trial blueprint and shared task type model.
+- Added a Day 5 contract helper that normalizes the trial schedule to the canonical 09:00-21:00 local override.
+- Kept Days 1-4 on the existing 09:00-17:00 local window.
 
-- Updated resubmission behavior so the latest valid recording becomes the active one for the handoff submission.
-- Kept invalid or superseded attempts from replacing the active recording pointer.
-- Preserved preview/resubmit behavior through the Day 4 cutoff window.
+### Trial creation and validation
 
-### Transcript and job behavior
+- Trial creation now enforces the Day 5 window override during build and persistence.
+- The live create-path contract rejects a noncanonical Day 5 override and keeps the persisted trial row aligned with the canonical window.
+- Trial detail responses now surface Day 5 as `reflection` consistently.
 
-- Ensured a successful completion creates the transcript record and enqueues transcription work.
-- Verified the worker success path writes a ready transcript with text and segments.
-- Preserved readable degraded states when transcription is pending or fails, including retry metadata.
+### Submission and day-close behavior
 
-### Candidate handoff status payloads
+- Day 5 reflection payload validation now accepts `reflection` as a text task type.
+- The explicit Day 5 submit path completes the candidate session when that submission is the final outstanding task.
+- The day-close finalize-from-draft handler now propagates completion through the shared submission progress path for both new and existing submissions.
+- Day-close finalization remains idempotent and respects the extended Day 5 cutoff.
 
-- Kept `/api/tasks/{task_id}/handoff/status` returning the active recording, transcript status, and supplemental materials.
-- Ensured playback/download URLs are emitted when storage signing succeeds.
-- Ensured storage-signing failures degrade to a null download URL instead of breaking the response.
+### Backend surfaces touched
 
-### Talent Partner submission detail payloads
+- `app/trials/constants/trials_constants_trials_blueprints_constants.py`
+- `app/trials/services/trials_services_trials_creation_builder_service.py`
+- `app/trials/services/trials_services_trials_creation_service.py`
+- `app/trials/services/trials_services_trials_day_five_contract_service.py`
+- `app/shared/types/shared_types_types_model.py`
+- `app/submissions/services/submissions_services_submissions_payload_validation_service.py`
+- `app/shared/jobs/handlers/shared_jobs_handlers_day_close_finalize_text_submission_handler.py`
+- `app/candidates/candidate_sessions/services/candidates_candidate_sessions_services_candidates_candidate_sessions_progress_service.py`
 
-- Kept `/api/submissions/{submission_id}` returning the canonical handoff payload for Talent Partner review.
-- Returned the active handoff recording, transcript, and supplemental materials in the submission detail payload.
-- Returned the playback/download URL and the CSP header expected for media playback.
+## 4. QA
 
-### OpenAPI and route contract cleanup
+### Live create-path verification
 
-- Exposed the canonical `handoff` routes in OpenAPI.
-- Removed public `presentation` routes from the schema so the external contract matches the canonical route naming.
-- Kept route behavior aligned with the current backend vocabulary used by the handoff/demo flow.
+- `POST /api/trials` returns Day 5 as `reflection`.
+- The persisted trial row shows Day 5 override enabled with `09:00`-`21:00`.
+- The trial detail response also shows Day 5 as `reflection`.
 
-### Tests added and updated
+### End-to-end Day 5 verification
 
-- Added and updated route-level tests for handoff init, complete, status, playback URL handling, CSP, transcript shapes, and supplemental materials.
-- Added and updated service-level tests for upload completion, transcript job behavior, resubmission selection, and Day 4 completion gating.
-- Added an OpenAPI contract test to verify the public surface exposes canonical handoff routes only.
+- Draft save and fetch work in the open Day 5 window.
+- Closed-window draft and submit attempts are rejected.
+- Explicit submit persists Day 5 reflection content and marks the candidate session complete.
+- Day-close finalize-from-draft creates the submission, is idempotent, and marks the candidate session complete.
 
-## 3. Acceptance Criteria Mapping
+### Test coverage
 
-- Max 15-minute duration enforced: overlong uploads are rejected with `422` at completion.
-- Upload init/complete reliable: init succeeds for valid uploads, completion succeeds for valid finalized recordings, and repeated completion is safe.
-- Preview and resubmit until cutoff: the backend keeps the latest valid recording active while the Day 4 window remains open.
-- Transcription succeeds for valid files: valid handoff uploads create transcript work and reach the ready transcript state.
-- Correct playback URLs and CSP: Talent Partner detail returns playback/download URLs, and the response includes the expected CSP for media playback.
-- Supplemental materials upload: supplemental assets can be uploaded and are included in handoff/submission payloads.
-- Routes renamed from `presentation` to `handoff/demo`: the canonical OpenAPI surface exposes `handoff` routes and no public `presentation` routes.
+- Focused regression coverage passed with `--no-cov`.
+- The repository-wide coverage gate blocks narrow targeted pytest runs under the default addopts, so the focused slice was run with `--no-cov` to complete the backend verification.
 
-## 4. QA Evidence
+### Operational note
 
-- `./precommit.sh` passes on the final current branch.
-- Focused automated Day 4 media/submissions tests passed, covering:
-  - upload init and completion
-  - 15-minute duration rejection
-  - transcript creation and transcript status shaping
-  - resubmission selection
-  - playback/download URL behavior
-  - CSP behavior
-  - supplemental materials visibility
-  - OpenAPI route contract cleanup
-- Manual QA on the local backend/runtime proved the following outcomes:
-  - overlong upload rejected with `422`
-  - valid upload completes successfully
-  - repeated complete is safe
-  - replacement upload becomes active
-  - transcript success path verified
-  - degraded and missing transcript path verified
-  - Talent Partner detail returns playback URL and handoff payload
-  - CSP header is present and aligned to the playback origin
-  - supplemental material is visible in the payload
-  - OpenAPI exposes handoff routes and no public presentation routes
+- One QA run hit `GITHUB_UNAVAILABLE`.
+- Backend verification was completed using the repo-supported claimed-session fallback.
 
-## 5. Local QA Caveats
+## 5. Risks / Follow-ups
 
-- Manual QA was performed on the local backend/runtime.
-- Local validation used the dev auth bypass and demo transcription mode to exercise the backend flows end to end.
-- This is sufficient for backend acceptance on #290, but it is not the same as production infra validation.
+- The main remaining risk is the known GitHub invite/preprovision instability. The backend path is verified, but the claimed-session fallback should stay available until that operational issue is removed.
 
-## 6. Tests
+## 6. Ready for PR
 
-- Final `./precommit.sh`
-- Focused `--no-cov` Day 4 media/submissions test slice
-- Targeted service tests for upload completion, transcript job behavior, and resubmission selection
-- Route tests for status payloads, playback URL handling, CSP, supplemental materials, and OpenAPI route exposure
-
-## 7. Risks / Follow-ups
-
-None.
+This issue is ready for PR.

--- a/tests/candidates/candidate_sessions/services/test_candidates_candidate_sessions_day5_extended_window_service.py
+++ b/tests/candidates/candidate_sessions/services/test_candidates_candidate_sessions_day5_extended_window_service.py
@@ -1,0 +1,79 @@
+from __future__ import annotations
+
+import pytest
+
+from app.candidates.candidate_sessions.services import schedule_gates
+from app.candidates.candidate_sessions.services.scheduling.candidates_candidate_sessions_services_scheduling_candidates_candidate_sessions_scheduling_day_windows_service import (
+    derive_day_windows,
+    serialize_day_windows,
+)
+from tests.candidates.candidate_sessions.services.candidates_candidate_sessions_day_close_jobs_test_utils import *
+
+
+@pytest.mark.asyncio
+async def test_day5_extended_window_stays_open_until_nine_pm_local(async_session):
+    talent_partner = await create_talent_partner(
+        async_session, email="day5-window@test.com"
+    )
+    trial, tasks = await create_trial(async_session, created_by=talent_partner)
+    candidate_session = await create_candidate_session(
+        async_session,
+        trial=trial,
+        status="in_progress",
+        with_default_schedule=False,
+    )
+
+    candidate_timezone = "America/New_York"
+    scheduled_start_at = datetime(2026, 3, 10, 13, 0, tzinfo=UTC)
+    day_windows = derive_day_windows(
+        scheduled_start_at_utc=scheduled_start_at,
+        candidate_tz=candidate_timezone,
+        day_window_start_local=trial.day_window_start_local,
+        day_window_end_local=trial.day_window_end_local,
+        overrides=trial.day_window_overrides_json,
+        overrides_enabled=bool(trial.day_window_overrides_enabled),
+        total_days=5,
+    )
+
+    candidate_session.scheduled_start_at = scheduled_start_at
+    candidate_session.candidate_timezone = candidate_timezone
+    candidate_session.day_windows_json = serialize_day_windows(day_windows)
+    await async_session.commit()
+
+    day1_window = day_windows[0]
+    day5_window = day_windows[4]
+    assert day1_window["windowEndAt"] == datetime(2026, 3, 10, 21, 0, tzinfo=UTC)
+    assert day5_window["windowEndAt"] == datetime(2026, 3, 15, 1, 0, tzinfo=UTC)
+
+    day5_task = tasks[4]
+    open_window = schedule_gates.compute_task_window(
+        candidate_session,
+        day5_task,
+        now_utc=datetime(2026, 3, 14, 22, 30, tzinfo=UTC),
+    )
+    assert open_window.is_open is True
+    assert open_window.window_end_at == day5_window["windowEndAt"]
+    assert open_window.next_open_at is None
+
+    closed_window = schedule_gates.compute_task_window(
+        candidate_session,
+        day5_task,
+        now_utc=datetime(2026, 3, 15, 1, 1, tzinfo=UTC),
+    )
+    assert closed_window.is_open is False
+    assert closed_window.window_end_at == day5_window["windowEndAt"]
+    assert closed_window.next_open_at is None
+
+    jobs = await day_close_jobs.enqueue_day_close_finalize_text_jobs(
+        async_session,
+        candidate_session=candidate_session,
+        commit=True,
+    )
+    assert len(jobs) == 2
+    day5_job = next(job for job in jobs if job.payload_json["dayIndex"] == 5)
+    assert day5_job.payload_json["windowEndAt"] == "2026-03-15T01:00:00Z"
+    next_run_at = day5_job.next_run_at
+    assert next_run_at is not None
+    if next_run_at.tzinfo is None:
+        next_run_at = next_run_at.replace(tzinfo=UTC)
+    assert next_run_at == day5_window["windowEndAt"]

--- a/tests/candidates/services/test_candidates_sessions_progress_service_service.py
+++ b/tests/candidates/services/test_candidates_sessions_progress_service_service.py
@@ -18,7 +18,7 @@ def test_handoff_revisit_task_returns_prior_handoff_when_next_window_start_missi
     monkeypatch,
 ):
     handoff_task = _TaskStub(id=4, day_index=4, type="handoff")
-    day5_task = _TaskStub(id=5, day_index=5, type="documentation")
+    day5_task = _TaskStub(id=5, day_index=5, type="reflection")
 
     monkeypatch.setattr(
         progress_service,

--- a/tests/shared/factories/shared_factories_trial_utils.py
+++ b/tests/shared/factories/shared_factories_trial_utils.py
@@ -22,6 +22,9 @@ from app.trials.constants.trials_constants_trials_blueprints_constants import (
 from app.trials.constants.trials_constants_trials_defaults_constants import (
     DEFAULT_TEMPLATE_KEY,
 )
+from app.trials.services.trials_services_trials_day_five_contract_service import (
+    canonical_day_five_window_override,
+)
 
 
 async def create_trial(
@@ -58,6 +61,8 @@ async def create_trial(
         ai_notice_version=ai_notice_version,
         ai_notice_text=ai_notice_text,
         ai_eval_enabled_by_day=ai_eval_enabled_by_day,
+        day_window_overrides_enabled=True,
+        day_window_overrides_json=canonical_day_five_window_override(),
     )
     session.add(sim)
     await session.flush()

--- a/tests/shared/jobs/handlers/test_shared_jobs_handlers_day_close_finalize_text_finalize_day5_from_draft_completes_session_handler.py
+++ b/tests/shared/jobs/handlers/test_shared_jobs_handlers_day_close_finalize_text_finalize_day5_from_draft_completes_session_handler.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy.ext.asyncio import async_sessionmaker
+
+from app.shared.database.shared_database_models_model import CandidateSession
+from tests.shared.jobs.handlers.shared_jobs_handlers_day_close_finalize_text_utils import *
+
+
+@pytest.mark.asyncio
+async def test_finalize_day5_from_draft_completes_session(async_session, monkeypatch):
+    talent_partner = await create_talent_partner(
+        async_session, email="finalize-day5-complete@test.com"
+    )
+    trial, tasks = await create_trial(async_session, created_by=talent_partner)
+    candidate_session = await create_candidate_session(
+        async_session,
+        trial=trial,
+        status="in_progress",
+        with_default_schedule=False,
+    )
+    await async_session.commit()
+
+    window_end_by_day = await _set_fully_closed_schedule(
+        async_session,
+        candidate_session=candidate_session,
+    )
+    for task in tasks[:4]:
+        await create_submission(
+            async_session,
+            candidate_session=candidate_session,
+            task=task,
+            content_text=f"day{task.day_index}",
+        )
+    draft = await task_drafts_repo.upsert_draft(
+        async_session,
+        candidate_session_id=candidate_session.id,
+        task_id=tasks[4].id,
+        content_text="## Day 5 draft",
+        content_json={"reflection": {"decisions": "use queue"}},
+    )
+    assert draft.finalized_submission_id is None
+
+    monkeypatch.setattr(
+        finalize_handler,
+        "async_session_maker",
+        _session_maker(async_session),
+    )
+
+    result = await finalize_handler.handle_day_close_finalize_text(
+        _payload(
+            candidate_session_id=candidate_session.id,
+            task_id=tasks[4].id,
+            day_index=5,
+            window_end_at=window_end_by_day[5],
+        )
+    )
+
+    assert result["status"] == "created_submission"
+    assert result["source"] == "draft"
+
+    submission = (
+        await async_session.execute(
+            select(Submission).where(
+                Submission.candidate_session_id == candidate_session.id,
+                Submission.task_id == tasks[4].id,
+            )
+        )
+    ).scalar_one()
+    assert submission.content_text == "## Day 5 draft"
+    assert submission.content_json == {"reflection": {"decisions": "use queue"}}
+
+    finalized_draft = await task_drafts_repo.get_by_session_and_task(
+        async_session,
+        candidate_session_id=candidate_session.id,
+        task_id=tasks[4].id,
+    )
+    assert finalized_draft is not None
+    assert finalized_draft.finalized_submission_id == submission.id
+    assert finalized_draft.finalized_at is not None
+
+    async with async_session.bind.connect() as connection:
+        fresh_session = async_sessionmaker(
+            bind=connection, expire_on_commit=False, autoflush=False
+        )
+        async with fresh_session() as check_db:
+            refreshed_session = await check_db.get(
+                CandidateSession, candidate_session.id
+            )
+            assert refreshed_session is not None
+            assert refreshed_session.status == "completed"
+            assert refreshed_session.completed_at is not None

--- a/tests/submissions/services/test_submissions_candidate_service_validate_day5_reflection_payload_rejects_missing_and_too_short_service.py
+++ b/tests/submissions/services/test_submissions_candidate_service_validate_day5_reflection_payload_rejects_missing_and_too_short_service.py
@@ -6,7 +6,7 @@ from tests.submissions.services.test_submissions_candidate_service_utils import 
 
 
 def test_validate_day5_reflection_payload_rejects_missing_and_too_short():
-    day5_task = SimpleNamespace(type="documentation", day_index=5)
+    day5_task = SimpleNamespace(type="reflection", day_index=5)
     payload = SimpleNamespace(
         contentText="## Reflection",
         reflection={

--- a/tests/submissions/services/test_submissions_candidate_service_validate_day5_reflection_payload_rejects_missing_reflection_object_service.py
+++ b/tests/submissions/services/test_submissions_candidate_service_validate_day5_reflection_payload_rejects_missing_reflection_object_service.py
@@ -6,7 +6,7 @@ from tests.submissions.services.test_submissions_candidate_service_utils import 
 
 
 def test_validate_day5_reflection_payload_accepts_markdown_only_reflection():
-    day5_task = SimpleNamespace(type="documentation", day_index=5)
+    day5_task = SimpleNamespace(type="reflection", day_index=5)
     payload = SimpleNamespace(contentText="## Reflection summary\n\nLearned a lot.")
 
     assert svc.validate_submission_payload(day5_task, payload) == {

--- a/tests/submissions/services/test_submissions_candidate_service_validate_day5_reflection_payload_rejects_non_dict_reflection_object_service.py
+++ b/tests/submissions/services/test_submissions_candidate_service_validate_day5_reflection_payload_rejects_non_dict_reflection_object_service.py
@@ -6,7 +6,7 @@ from tests.submissions.services.test_submissions_candidate_service_utils import 
 
 
 def test_validate_day5_reflection_payload_rejects_non_dict_reflection_object():
-    day5_task = SimpleNamespace(type="documentation", day_index=5)
+    day5_task = SimpleNamespace(type="reflection", day_index=5)
     payload = SimpleNamespace(
         contentText="## Reflection summary", reflection="not-a-dict"
     )

--- a/tests/submissions/services/test_submissions_candidate_service_validate_day5_reflection_payload_rejects_non_string_section_values_service.py
+++ b/tests/submissions/services/test_submissions_candidate_service_validate_day5_reflection_payload_rejects_non_string_section_values_service.py
@@ -6,7 +6,7 @@ from tests.submissions.services.test_submissions_candidate_service_utils import 
 
 
 def test_validate_day5_reflection_payload_rejects_non_string_section_values():
-    day5_task = SimpleNamespace(type="documentation", day_index=5)
+    day5_task = SimpleNamespace(type="reflection", day_index=5)
     reflection = _valid_day5_reflection_sections()
     reflection["tradeoffs"] = 123  # type: ignore[assignment]
     payload = SimpleNamespace(

--- a/tests/submissions/services/test_submissions_candidate_service_validate_day5_reflection_payload_requires_content_text_service.py
+++ b/tests/submissions/services/test_submissions_candidate_service_validate_day5_reflection_payload_requires_content_text_service.py
@@ -6,7 +6,7 @@ from tests.submissions.services.test_submissions_candidate_service_utils import 
 
 
 def test_validate_day5_reflection_payload_requires_content_text():
-    day5_task = SimpleNamespace(type="documentation", day_index=5)
+    day5_task = SimpleNamespace(type="reflection", day_index=5)
     payload = SimpleNamespace(
         contentText="   ", reflection=_valid_day5_reflection_sections()
     )

--- a/tests/submissions/services/test_submissions_candidate_service_validate_day5_reflection_payload_returns_structured_content_json_service.py
+++ b/tests/submissions/services/test_submissions_candidate_service_validate_day5_reflection_payload_returns_structured_content_json_service.py
@@ -4,7 +4,7 @@ from tests.submissions.services.test_submissions_candidate_service_utils import 
 
 
 def test_validate_day5_reflection_payload_returns_structured_content_json():
-    day5_task = SimpleNamespace(type="documentation", day_index=5)
+    day5_task = SimpleNamespace(type="reflection", day_index=5)
     payload = SimpleNamespace(
         contentText="## Challenges\n...\n## Decisions\n...",
         reflection={

--- a/tests/trials/routes/test_trials_api_create_trial_seeds_default_tasks_routes.py
+++ b/tests/trials/routes/test_trials_api_create_trial_seeds_default_tasks_routes.py
@@ -33,3 +33,4 @@ async def test_create_trial_seeds_default_tasks(
     assert len(body["tasks"]) == 5
     assert [t["day_index"] for t in body["tasks"]] == [1, 2, 3, 4, 5]
     assert body["tasks"][0]["type"] == "design"
+    assert body["tasks"][4]["type"] == "reflection"

--- a/tests/trials/routes/test_trials_create_create_trial_creates_sim_and_5_tasks_routes.py
+++ b/tests/trials/routes/test_trials_create_create_trial_creates_sim_and_5_tasks_routes.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from sqlalchemy import select
 
 from tests.trials.routes.trials_create_api_utils import *
 
@@ -59,7 +60,7 @@ async def test_create_trial_creates_sim_and_5_tasks(
             "code",
             "code",
             "handoff",
-            "documentation",
+            "reflection",
         ]
         assert [t["title"] for t in data["tasks"]] == [
             "Architecture Plan",
@@ -88,3 +89,27 @@ async def test_create_trial_creates_sim_and_5_tasks(
                 "5": True,
             },
         }
+
+        persisted_trial = (
+            await async_session.execute(select(Trial).where(Trial.id == data["id"]))
+        ).scalar_one()
+        assert persisted_trial.day_window_overrides_enabled is True
+        assert persisted_trial.day_window_overrides_json == {
+            "5": {"startLocal": "09:00", "endLocal": "21:00"}
+        }
+        assert persisted_trial.day_window_start_local.strftime("%H:%M") == "09:00"
+        assert persisted_trial.day_window_end_local.strftime("%H:%M") == "17:00"
+
+        detail = await async_client.get(
+            f"/api/trials/{data['id']}",
+            headers={"Authorization": f"Bearer talent_partner:{user.email}"},
+        )
+        assert detail.status_code == 200, detail.text
+        detail_body = detail.json()
+        assert [task["type"] for task in detail_body["tasks"]] == [
+            "design",
+            "code",
+            "code",
+            "handoff",
+            "reflection",
+        ]

--- a/tests/trials/routes/trials_create_api_utils.py
+++ b/tests/trials/routes/trials_create_api_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 from sqlalchemy import select
 
 from app.shared.auth.shared_auth_current_user_utils import get_current_user
-from app.shared.database.shared_database_models_model import Company, Task, User
+from app.shared.database.shared_database_models_model import Company, Task, Trial, User
 from app.trials.constants.trials_constants_trials_ai_config_constants import (
     AI_NOTICE_DEFAULT_TEXT,
     AI_NOTICE_DEFAULT_VERSION,

--- a/tests/trials/services/test_trials_service_create_trial_with_tasks_flow_service.py
+++ b/tests/trials/services/test_trials_service_create_trial_with_tasks_flow_service.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import pytest
 
+from app.shared.utils.shared_utils_errors_utils import ApiError
 from tests.trials.services.trials_core_service_utils import *
 
 
@@ -26,8 +27,36 @@ async def test_create_trial_with_tasks_flow(async_session, monkeypatch):
     assert sim.id is not None
     assert sim.active_scenario_version_id is None
     assert sim.status == "generating"
+    assert sim.day_window_overrides_enabled is True
+    assert sim.day_window_overrides_json == {
+        "5": {"startLocal": "09:00", "endLocal": "21:00"}
+    }
     assert scenario_job.job_type == "scenario_generation"
     assert scenario_job.payload_json["trialId"] == sim.id
     assert len(tasks) == len(sim_service.DEFAULT_5_DAY_BLUEPRINT)
     # ensure tasks are sorted and refreshed
     assert tasks[0].day_index == 1
+    assert tasks[-1].type == "reflection"
+
+
+def test_build_trial_for_create_rejects_conflicting_day5_override():
+    payload = SimpleNamespace(
+        title="Title",
+        role="Role",
+        techStack="Python",
+        seniority="Mid",
+        focus="Build",
+        templateKey="python-fastapi",
+        dayWindowOverridesEnabled=True,
+        dayWindowOverrides={
+            "5": {"startLocal": "10:00", "endLocal": "18:00"},
+        },
+    )
+    user = SimpleNamespace(company_id=1, id=2)
+
+    with pytest.raises(ApiError) as excinfo:
+        sim_creation.build_trial_for_create(payload, user)
+
+    assert excinfo.value.status_code == 400
+    assert excinfo.value.error_code == "TRIAL_DAY5_WINDOW_OVERRIDE_INVALID"
+    assert excinfo.value.details["field"] == "dayWindowOverrides.5"


### PR DESCRIPTION
# Day 5 reflection essay with 9 AM to 9 PM local extended window (#291)

## 1. Summary

This PR makes Day 5 canonical as `reflection`, keeps the Day 5 local window at 09:00-21:00, and aligns the backend create, detail, autosave, submission, and day-close flows with that contract.

## 2. Problem

Day 5 still needed the extended local window and the correct task type. Before this change, the backend could surface Day 5 as `documentation` in some paths, and the day-close flow did not consistently propagate candidate session completion when the final Day 5 text submission was finalized from draft.

## 3. What Changed

### Day 5 contract

- Canonicalized Day 5 to `reflection` in the trial blueprint and shared task type model.
- Added a Day 5 contract helper that normalizes the trial schedule to the canonical 09:00-21:00 local override.
- Kept Days 1-4 on the existing 09:00-17:00 local window.

### Trial creation and validation

- Trial creation now enforces the Day 5 window override during build and persistence.
- The live create-path contract rejects a noncanonical Day 5 override and keeps the persisted trial row aligned with the canonical window.
- Trial detail responses now surface Day 5 as `reflection` consistently.

### Submission and day-close behavior

- Day 5 reflection payload validation now accepts `reflection` as a text task type.
- The explicit Day 5 submit path completes the candidate session when that submission is the final outstanding task.
- The day-close finalize-from-draft handler now propagates completion through the shared submission progress path for both new and existing submissions.
- Day-close finalization remains idempotent and respects the extended Day 5 cutoff.

### Backend surfaces touched

- `app/trials/constants/trials_constants_trials_blueprints_constants.py`
- `app/trials/services/trials_services_trials_creation_builder_service.py`
- `app/trials/services/trials_services_trials_creation_service.py`
- `app/trials/services/trials_services_trials_day_five_contract_service.py`
- `app/shared/types/shared_types_types_model.py`
- `app/submissions/services/submissions_services_submissions_payload_validation_service.py`
- `app/shared/jobs/handlers/shared_jobs_handlers_day_close_finalize_text_submission_handler.py`
- `app/candidates/candidate_sessions/services/candidates_candidate_sessions_services_candidates_candidate_sessions_progress_service.py`

## 4. QA

### Live create-path verification

- `POST /api/trials` returns Day 5 as `reflection`.
- The persisted trial row shows Day 5 override enabled with `09:00`-`21:00`.
- The trial detail response also shows Day 5 as `reflection`.

### End-to-end Day 5 verification

- Draft save and fetch work in the open Day 5 window.
- Closed-window draft and submit attempts are rejected.
- Explicit submit persists Day 5 reflection content and marks the candidate session complete.
- Day-close finalize-from-draft creates the submission, is idempotent, and marks the candidate session complete.

### Test coverage

- Focused regression coverage passed with `--no-cov`.
- The repository-wide coverage gate blocks narrow targeted pytest runs under the default addopts, so the focused slice was run with `--no-cov` to complete the backend verification.

### Operational note

- One QA run hit `GITHUB_UNAVAILABLE`.
- Backend verification was completed using the repo-supported claimed-session fallback.

## 5. Risks / Follow-ups

- The main remaining risk is the known GitHub invite/preprovision instability. The backend path is verified, but the claimed-session fallback should stay available until that operational issue is removed.

## 6. Ready for PR

Fixes #291 
