### PR TITLE
Verify invite, scheduling, and Winoe Report notifications

### DIFF
--- a/alembic/versions/202604170001_add_notification_delivery_audits.py
+++ b/alembic/versions/202604170001_add_notification_delivery_audits.py
@@ -1,0 +1,86 @@
+"""Add notification delivery audit records.
+
+Revision ID: 202604170001
+Revises: 202604160001
+Create Date: 2026-04-17 00:01:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "202604170001"
+down_revision: str | Sequence[str] | None = "202604160001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "notification_delivery_audits",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("notification_type", sa.String(length=100), nullable=False),
+        sa.Column(
+            "candidate_session_id",
+            sa.Integer(),
+            sa.ForeignKey("candidate_sessions.id"),
+            nullable=True,
+        ),
+        sa.Column(
+            "trial_id",
+            sa.Integer(),
+            sa.ForeignKey("trials.id"),
+            nullable=True,
+        ),
+        sa.Column("recipient_email", sa.String(length=255), nullable=False),
+        sa.Column("recipient_role", sa.String(length=50), nullable=False),
+        sa.Column("subject", sa.String(length=255), nullable=False),
+        sa.Column("status", sa.String(length=50), nullable=False),
+        sa.Column("provider_message_id", sa.String(length=255), nullable=True),
+        sa.Column("error", sa.String(length=500), nullable=True),
+        sa.Column("correlation_id", sa.String(length=255), nullable=True),
+        sa.Column("idempotency_key", sa.String(length=255), nullable=True),
+        sa.Column("payload_json", sa.JSON(), nullable=True),
+        sa.Column(
+            "attempted_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+        sa.Column("sent_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_notification_delivery_audits_candidate_session_attempted_at",
+        "notification_delivery_audits",
+        ["candidate_session_id", "attempted_at"],
+    )
+    op.create_index(
+        "ix_notification_delivery_audits_notification_type_attempted_at",
+        "notification_delivery_audits",
+        ["notification_type", "attempted_at"],
+    )
+    op.create_index(
+        "ix_notification_delivery_audits_status_attempted_at",
+        "notification_delivery_audits",
+        ["status", "attempted_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_notification_delivery_audits_status_attempted_at",
+        table_name="notification_delivery_audits",
+    )
+    op.drop_index(
+        "ix_notification_delivery_audits_notification_type_attempted_at",
+        table_name="notification_delivery_audits",
+    )
+    op.drop_index(
+        "ix_notification_delivery_audits_candidate_session_attempted_at",
+        table_name="notification_delivery_audits",
+    )
+    op.drop_table("notification_delivery_audits")

--- a/app/candidates/candidate_sessions/services/candidates_candidate_sessions_services_candidates_candidate_sessions_schedule_flow_service.py
+++ b/app/candidates/candidate_sessions/services/candidates_candidate_sessions_services_candidates_candidate_sessions_schedule_flow_service.py
@@ -146,6 +146,7 @@ async def schedule_candidate_session_impl(
     if changed:
         await db.commit()
     if schedule_created:
+        trial_for_email = trial_for_email or getattr(candidate_session, "trial", None)
         logger.info(
             "Candidate schedule set candidateSessionId=%s candidateTimezone=%s scheduledStartAt=%s correlationId=%s",
             candidate_session.id,

--- a/app/notifications/repositories/__init__.py
+++ b/app/notifications/repositories/__init__.py
@@ -1,0 +1,1 @@
+"""Notification delivery audit repository package."""

--- a/app/notifications/repositories/notifications_repositories_notifications_delivery_audits_core_model.py
+++ b/app/notifications/repositories/notifications_repositories_notifications_delivery_audits_core_model.py
@@ -1,0 +1,56 @@
+"""SQLAlchemy model for immutable notification delivery audit records."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import JSON, DateTime, ForeignKey, Index, Integer, String, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.shared.database.shared_database_base_model import Base
+
+
+class NotificationDeliveryAudit(Base):
+    """Audit record for notification delivery attempts."""
+
+    __tablename__ = "notification_delivery_audits"
+    __table_args__ = (
+        Index(
+            "ix_notification_delivery_audits_candidate_session_attempted_at",
+            "candidate_session_id",
+            "attempted_at",
+        ),
+        Index(
+            "ix_notification_delivery_audits_notification_type_attempted_at",
+            "notification_type",
+            "attempted_at",
+        ),
+        Index(
+            "ix_notification_delivery_audits_status_attempted_at",
+            "status",
+            "attempted_at",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    notification_type: Mapped[str] = mapped_column(String(100), nullable=False)
+    candidate_session_id: Mapped[int | None] = mapped_column(
+        ForeignKey("candidate_sessions.id"), nullable=True
+    )
+    trial_id: Mapped[int | None] = mapped_column(ForeignKey("trials.id"), nullable=True)
+    recipient_email: Mapped[str] = mapped_column(String(255), nullable=False)
+    recipient_role: Mapped[str] = mapped_column(String(50), nullable=False)
+    subject: Mapped[str] = mapped_column(String(255), nullable=False)
+    status: Mapped[str] = mapped_column(String(50), nullable=False)
+    provider_message_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    error: Mapped[str | None] = mapped_column(String(500), nullable=True)
+    correlation_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    idempotency_key: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    payload_json: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    attempted_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+    sent_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )

--- a/app/notifications/repositories/notifications_repositories_notifications_delivery_audits_repository.py
+++ b/app/notifications/repositories/notifications_repositories_notifications_delivery_audits_repository.py
@@ -1,0 +1,83 @@
+"""Repository helpers for notification delivery audit rows."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.notifications.repositories.notifications_repositories_notifications_delivery_audits_core_model import (
+    NotificationDeliveryAudit,
+)
+
+
+def sanitize_error(error: str | None, *, limit: int = 500) -> str | None:
+    if error is None:
+        return None
+    return error[:limit]
+
+
+async def record_notification_delivery_audit(
+    db: AsyncSession,
+    *,
+    notification_type: str,
+    recipient_email: str,
+    recipient_role: str,
+    subject: str,
+    status: str,
+    candidate_session_id: int | None = None,
+    trial_id: int | None = None,
+    provider_message_id: str | None = None,
+    error: str | None = None,
+    correlation_id: str | None = None,
+    idempotency_key: str | None = None,
+    payload_json: dict[str, Any] | None = None,
+    attempted_at: datetime | None = None,
+    sent_at: datetime | None = None,
+) -> NotificationDeliveryAudit:
+    """Persist a notification delivery audit row."""
+    audit = NotificationDeliveryAudit(
+        notification_type=notification_type,
+        candidate_session_id=candidate_session_id,
+        trial_id=trial_id,
+        recipient_email=recipient_email,
+        recipient_role=recipient_role,
+        subject=subject,
+        status=status,
+        provider_message_id=provider_message_id,
+        error=sanitize_error(error),
+        correlation_id=correlation_id,
+        idempotency_key=idempotency_key,
+        payload_json=payload_json,
+        attempted_at=attempted_at or sent_at or datetime.now(UTC),
+        sent_at=sent_at,
+    )
+    db.add(audit)
+    await db.flush()
+    return audit
+
+
+async def has_successful_notification_delivery(
+    db: AsyncSession,
+    *,
+    candidate_session_id: int,
+    notification_type: str,
+    recipient_email: str,
+    recipient_role: str,
+) -> bool:
+    """Return whether a successful delivery already exists."""
+    stmt = (
+        select(NotificationDeliveryAudit.id)
+        .where(
+            NotificationDeliveryAudit.candidate_session_id == candidate_session_id,
+            NotificationDeliveryAudit.notification_type == notification_type,
+            NotificationDeliveryAudit.recipient_role == recipient_role,
+            NotificationDeliveryAudit.recipient_email == recipient_email,
+            NotificationDeliveryAudit.status == "sent",
+        )
+        .limit(1)
+    )
+    row = await db.execute(stmt)
+    return row.scalar_one_or_none() is not None

--- a/app/notifications/services/notifications_services_notifications_invite_dispatch_service.py
+++ b/app/notifications/services/notifications_services_notifications_invite_dispatch_service.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from app.notifications.repositories.notifications_repositories_notifications_delivery_audits_repository import (
+    record_notification_delivery_audit,
+)
 from app.notifications.services.notifications_services_notifications_email_sender_service import (
     EmailSendResult,
     EmailService,
@@ -38,9 +41,21 @@ async def dispatch_invite_email(
 
 
 async def record_send_result(
-    db, candidate_session, now: datetime, result: EmailSendResult
+    db,
+    *,
+    candidate_session,
+    trial,
+    invite_url: str,
+    now: datetime,
+    result: EmailSendResult,
 ) -> EmailSendResult:
     """Record send result."""
+    subject, _text, _html = invite_email_content(
+        candidate_name=candidate_session.candidate_name,
+        invite_url=invite_url,
+        trial=trial,
+        expires_at=getattr(candidate_session, "expires_at", None),
+    )
     candidate_session.invite_email_last_attempt_at = now
     if result.status == "sent":
         candidate_session.invite_email_status = "sent"
@@ -50,5 +65,20 @@ async def record_send_result(
         candidate_session.invite_email_status = result.status
         candidate_session.invite_email_error = sanitize_error(result.error)
 
+    await record_notification_delivery_audit(
+        db,
+        notification_type="trial_invite",
+        candidate_session_id=getattr(candidate_session, "id", None),
+        trial_id=getattr(trial, "id", None),
+        recipient_email=candidate_session.invite_email,
+        recipient_role="candidate",
+        subject=subject,
+        status=result.status,
+        provider_message_id=result.message_id,
+        error=result.error,
+        attempted_at=now,
+        sent_at=now if result.status == "sent" else None,
+        idempotency_key=f"trial_invite:{getattr(candidate_session, 'id', 'unknown')}",
+    )
     await db.commit()
     return result

--- a/app/notifications/services/notifications_services_notifications_invite_rate_limit_service.py
+++ b/app/notifications/services/notifications_services_notifications_invite_rate_limit_service.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from app.notifications.repositories.notifications_repositories_notifications_delivery_audits_repository import (
+    record_notification_delivery_audit,
+)
 from app.notifications.services.notifications_services_notifications_email_sender_service import (
     EmailSendResult,
+)
+from app.notifications.services.notifications_services_notifications_invite_content_service import (
+    invite_email_content,
 )
 from app.notifications.services.notifications_services_notifications_invite_time_service import (
     INVITE_EMAIL_RATE_LIMIT_SECONDS,
@@ -22,10 +28,36 @@ def should_rate_limit(candidate_session, now: datetime) -> bool:
     )
 
 
-async def record_rate_limit(db, candidate_session, now: datetime) -> EmailSendResult:
+async def record_rate_limit(
+    db,
+    *,
+    candidate_session,
+    trial,
+    invite_url: str,
+    now: datetime,
+) -> EmailSendResult:
     """Record rate limit."""
+    subject, _text, _html = invite_email_content(
+        candidate_name=candidate_session.candidate_name,
+        invite_url=invite_url,
+        trial=trial,
+        expires_at=getattr(candidate_session, "expires_at", None),
+    )
     candidate_session.invite_email_status = "rate_limited"
     candidate_session.invite_email_last_attempt_at = now
     candidate_session.invite_email_error = "Rate limited"
+    await record_notification_delivery_audit(
+        db,
+        notification_type="trial_invite",
+        candidate_session_id=getattr(candidate_session, "id", None),
+        trial_id=getattr(trial, "id", None),
+        recipient_email=candidate_session.invite_email,
+        recipient_role="candidate",
+        subject=subject,
+        status="rate_limited",
+        error="Rate limited",
+        attempted_at=now,
+        idempotency_key=f"trial_invite:{getattr(candidate_session, 'id', 'unknown')}",
+    )
     await db.commit()
     return EmailSendResult(status="rate_limited", error="Rate limited")

--- a/app/notifications/services/notifications_services_notifications_invite_send_service.py
+++ b/app/notifications/services/notifications_services_notifications_invite_send_service.py
@@ -39,7 +39,13 @@ async def send_invite_email(
     """Send invite email."""
     resolved_now = utc_now(now)
     if should_rate_limit(candidate_session, resolved_now):
-        return await record_rate_limit(db, candidate_session, resolved_now)
+        return await record_rate_limit(
+            db,
+            candidate_session=candidate_session,
+            trial=trial,
+            invite_url=invite_url,
+            now=resolved_now,
+        )
 
     result = await dispatch_invite_email(
         email_service,
@@ -47,4 +53,11 @@ async def send_invite_email(
         trial=trial,
         invite_url=invite_url,
     )
-    return await record_send_result(db, candidate_session, resolved_now, result)
+    return await record_send_result(
+        db,
+        candidate_session=candidate_session,
+        trial=trial,
+        invite_url=invite_url,
+        now=resolved_now,
+        result=result,
+    )

--- a/app/notifications/services/notifications_services_notifications_schedule_send_service.py
+++ b/app/notifications/services/notifications_services_notifications_schedule_send_service.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
-from datetime import time
+from datetime import UTC, datetime, time
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.notifications.repositories.notifications_repositories_notifications_delivery_audits_repository import (
+    has_successful_notification_delivery,
+    record_notification_delivery_audit,
+)
 from app.notifications.schemas.notifications_schemas_notifications_email_schema import (
     EmailSendResult,
 )
@@ -17,7 +21,7 @@ from app.notifications.services.notifications_services_notifications_schedule_co
     candidate_schedule_confirmation_content,
     talent_partner_schedule_confirmation_content,
 )
-from app.shared.database.shared_database_models_model import User
+from app.shared.database.shared_database_models_model import Trial, User
 
 _DEFAULT_WINDOW_START = time(hour=9, minute=0)
 _DEFAULT_WINDOW_END = time(hour=17, minute=0)
@@ -41,10 +45,13 @@ async def send_schedule_confirmation_emails(
     correlation_id: str | None = None,
 ) -> tuple[EmailSendResult, EmailSendResult | None]:
     """Send schedule confirmation emails."""
-    del (
-        correlation_id
-    )  # Correlation is logged by caller; providers currently do not accept headers.
-
+    if trial is None:
+        result = await db.execute(
+            select(Trial).where(Trial.id == candidate_session.trial_id)
+        )
+        trial = result.scalar_one_or_none()
+    if trial is None:
+        return EmailSendResult(status="failed", error="Trial not found"), None
     scheduled_start_at = getattr(candidate_session, "scheduled_start_at", None)
     candidate_timezone = getattr(candidate_session, "candidate_timezone", None)
     if scheduled_start_at is None or not candidate_timezone:
@@ -60,6 +67,10 @@ async def send_schedule_confirmation_emails(
         or getattr(candidate_session, "invite_email", None)
         or ""
     ).strip()
+    candidate_session_id = getattr(candidate_session, "id", None)
+    candidate_idempotency_seed = (
+        candidate_session_id if candidate_session_id is not None else "unknown"
+    )
     (
         candidate_subject,
         candidate_text,
@@ -73,17 +84,48 @@ async def send_schedule_confirmation_emails(
         day_window_start_local=window_start,
         day_window_end_local=window_end,
     )
-    candidate_result = await email_service.send_email(
-        to=candidate_email,
-        subject=candidate_subject,
-        text=candidate_text,
-        html=candidate_html,
+    candidate_notification_type = "schedule_confirmation_candidate"
+    candidate_idempotency_key = (
+        f"{candidate_notification_type}:{candidate_idempotency_seed}"
     )
+    if await has_successful_notification_delivery(
+        db,
+        candidate_session_id=candidate_session_id,
+        notification_type=candidate_notification_type,
+        recipient_email=candidate_email,
+        recipient_role="candidate",
+    ):
+        candidate_result = EmailSendResult(status="sent", message_id=None)
+    else:
+        attempted_at = datetime.now(UTC)
+        candidate_result = await email_service.send_email(
+            to=candidate_email,
+            subject=candidate_subject,
+            text=candidate_text,
+            html=candidate_html,
+        )
+        await record_notification_delivery_audit(
+            db,
+            notification_type=candidate_notification_type,
+            candidate_session_id=candidate_session_id,
+            trial_id=getattr(trial, "id", None),
+            recipient_email=candidate_email,
+            recipient_role="candidate",
+            subject=candidate_subject,
+            status=candidate_result.status,
+            provider_message_id=candidate_result.message_id,
+            error=candidate_result.error,
+            attempted_at=attempted_at,
+            sent_at=attempted_at if candidate_result.status == "sent" else None,
+            correlation_id=correlation_id,
+            idempotency_key=candidate_idempotency_key,
+        )
 
     talent_partner_email = await _load_talent_partner_email(
         db, talent_partner_id=getattr(trial, "created_by", None)
     )
     if not talent_partner_email:
+        await db.commit()
         return candidate_result, None
 
     (
@@ -100,12 +142,43 @@ async def send_schedule_confirmation_emails(
         day_window_start_local=window_start,
         day_window_end_local=window_end,
     )
-    talent_partner_result = await email_service.send_email(
-        to=talent_partner_email,
-        subject=talent_partner_subject,
-        text=talent_partner_text,
-        html=talent_partner_html,
+    talent_partner_notification_type = "schedule_confirmation_talent_partner"
+    talent_partner_idempotency_key = (
+        f"{talent_partner_notification_type}:{candidate_idempotency_seed}"
     )
+    if await has_successful_notification_delivery(
+        db,
+        candidate_session_id=candidate_session_id,
+        notification_type=talent_partner_notification_type,
+        recipient_email=talent_partner_email,
+        recipient_role="talent_partner",
+    ):
+        talent_partner_result = EmailSendResult(status="sent", message_id=None)
+    else:
+        attempted_at = datetime.now(UTC)
+        talent_partner_result = await email_service.send_email(
+            to=talent_partner_email,
+            subject=talent_partner_subject,
+            text=talent_partner_text,
+            html=talent_partner_html,
+        )
+        await record_notification_delivery_audit(
+            db,
+            notification_type=talent_partner_notification_type,
+            candidate_session_id=candidate_session_id,
+            trial_id=getattr(trial, "id", None),
+            recipient_email=talent_partner_email,
+            recipient_role="talent_partner",
+            subject=talent_partner_subject,
+            status=talent_partner_result.status,
+            provider_message_id=talent_partner_result.message_id,
+            error=talent_partner_result.error,
+            attempted_at=attempted_at,
+            sent_at=attempted_at if talent_partner_result.status == "sent" else None,
+            correlation_id=correlation_id,
+            idempotency_key=talent_partner_idempotency_key,
+        )
+    await db.commit()
     return candidate_result, talent_partner_result
 
 

--- a/app/notifications/services/notifications_services_notifications_talent_partner_updates_service.py
+++ b/app/notifications/services/notifications_services_notifications_talent_partner_updates_service.py
@@ -8,6 +8,10 @@ from typing import Any
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from app.notifications.repositories.notifications_repositories_notifications_delivery_audits_repository import (
+    has_successful_notification_delivery,
+    record_notification_delivery_audit,
+)
 from app.notifications.services.notifications_services_notifications_email_sender_service import (
     EmailService,
 )
@@ -266,6 +270,7 @@ async def _send_talent_partner_update_email(
 
     candidate_name, candidate_email = _candidate_identity(candidate_session)
     if mode == "candidate_completed":
+        notification_type = CANDIDATE_COMPLETED_NOTIFICATION_JOB_TYPE
         subject, text, html = _candidate_completed_email_content(
             candidate_name=candidate_name,
             candidate_email=candidate_email,
@@ -273,6 +278,7 @@ async def _send_talent_partner_update_email(
             completed_at=getattr(candidate_session, "completed_at", None),
         )
     else:
+        notification_type = WINOE_REPORT_READY_NOTIFICATION_JOB_TYPE
         subject, text, html = _winoe_report_ready_email_content(
             candidate_name=candidate_name,
             candidate_email=candidate_email,
@@ -280,12 +286,45 @@ async def _send_talent_partner_update_email(
             generated_at=winoe_report_generated_at,
         )
 
+    if await has_successful_notification_delivery(
+        db,
+        candidate_session_id=candidate_session_id,
+        notification_type=notification_type,
+        recipient_email=talent_partner_email,
+        recipient_role="talent_partner",
+    ):
+        return {
+            "status": "sent",
+            "candidateSessionId": candidate_session_id,
+            "to": talent_partner_email,
+            "messageId": None,
+            "mode": mode,
+            "skipped": True,
+        }
+
+    sent_at = _utcnow()
     result = await email_service.send_email(
         to=talent_partner_email,
         subject=subject,
         text=text,
         html=html,
     )
+    await record_notification_delivery_audit(
+        db,
+        notification_type=notification_type,
+        candidate_session_id=candidate_session_id,
+        trial_id=trial.id,
+        recipient_email=talent_partner_email,
+        recipient_role="talent_partner",
+        subject=subject,
+        status=result.status,
+        provider_message_id=result.message_id,
+        error=result.error,
+        attempted_at=sent_at,
+        sent_at=sent_at if result.status == "sent" else None,
+        idempotency_key=f"{notification_type}:{candidate_session_id}",
+    )
+    await db.commit()
     if result.status != "sent":
         raise RuntimeError(result.error or "talent_partner_notification_send_failed")
     return {

--- a/app/shared/database/shared_database_models_model.py
+++ b/app/shared/database/shared_database_models_model.py
@@ -12,6 +12,9 @@ from app.media.repositories.recordings.media_repositories_recordings_media_recor
 from app.media.repositories.transcripts.media_repositories_transcripts_media_transcripts_core_model import (
     Transcript,
 )
+from app.notifications.repositories.notifications_repositories_notifications_delivery_audits_core_model import (
+    NotificationDeliveryAudit,
+)
 from app.shared.database.shared_database_base_model import Base, TimestampMixin
 from app.shared.jobs.repositories.shared_jobs_repositories_models_repository import Job
 from app.shared.jobs.repositories.shared_jobs_repositories_worker_heartbeats_repository_model import (
@@ -63,6 +66,7 @@ __all__ = [
     "EvaluationDayScore",
     "EvaluationRun",
     "Job",
+    "NotificationDeliveryAudit",
     "WorkerHeartbeat",
     "PrecommitBundle",
     "RecordingAsset",

--- a/pr.md
+++ b/pr.md
@@ -1,68 +1,96 @@
-# Add auth isolation regressions for Talent Partner, candidate session, and invite-token routes
+## 1. Title
 
-## 1. Summary
+Verify invite, scheduling, and Winoe Report notifications
 
-This PR adds auth isolation regressions for Talent Partner, Candidate, and invite-token resources. No production auth logic changes were needed; the existing ownership and auth guards already enforced the required boundaries. Existing CSRF posture and production dev-bypass guards were validated.
+## 2. Summary
 
-## 2. Problem
+This change completes the notification delivery path for the candidate Golden Path in Winoe:
 
-Login worked, but cross-tenant and cross-session isolation needed explicit regression coverage. Issue #292 required proof that:
+- candidate invite delivery is durably audited
+- invite resend is audited and rate-limited
+- schedule confirmation is audited for both the candidate and the Talent Partner
+- Winoe Report-ready notification delivery is audited and skip-safe after success
+- existing candidate-session invite summary fields remain intact
+- schedule idempotency is preserved for repeated identical requests
 
-- Talent Partner A cannot read Talent Partner B's candidates
-- Candidate A cannot read Candidate B's session
-- Invite-token resources are properly scoped
-- CSRF posture is verified
-- Dev bypasses are disabled in production
+The implementation is centered on a new durable `notification_delivery_audits` table plus service-layer checks that avoid duplicate sends when a successful delivery already exists.
 
-## 3. What Changed
+## 3. What changed
 
-### Talent Partner isolation
+- Added durable `notification_delivery_audits` persistence with indexed rows for candidate-session, notification-type, and status lookups.
+- Recorded invite send and resend outcomes as immutable audit rows, while preserving existing `candidate_sessions` invite status fields such as `inviteEmailStatus`, `inviteEmailSentAt`, and `inviteEmailError`.
+- Added schedule confirmation audit persistence for both recipients:
+  - candidate
+  - Talent Partner
+- Added a success-detection guard so schedule confirmations and Winoe Report-ready notifications skip re-sending after a successful prior delivery.
+- Restored the schedule idempotency contract so repeated identical schedule requests do not create new notifications or new audit rows.
+- Kept Winoe Report terminology in the report-ready notification subject and body, and persisted the corresponding delivery audit row.
+- Kept the invite preprovision flow exercised through the repo-supported `StubGithubClient` path during local FastAPI QA.
 
-- Added regression coverage for the Talent Partner candidate-list route to confirm a Talent Partner cannot read another Talent Partner's candidates.
+## 4. Why
 
-### Candidate session isolation
+The issue acceptance criteria required proof that the candidate Golden Path notifications are not just surfaced in response payloads, but actually delivered, retried, audited, and replay-safe.
 
-- Added regression coverage for candidate session read and current-task routes to confirm Candidate A cannot access Candidate B's session data.
+The audit table provides durable evidence across the full lifecycle:
 
-### Invite-token isolation
+- invite send
+- invite resend
+- schedule confirmation
+- Winoe Report-ready notification
 
-- Added regression coverage for invite-token read and claim surfaces to confirm mismatched-email requests are rejected.
+The skip-safe guards prevent duplicate notification sends after a successful delivery has already been recorded, which keeps the notification history consistent with the user-visible state.
 
-### Security posture coverage
+## 5. QA performed
 
-- Added/updated regressions that verify CSRF origin enforcement on logout.
-- Added/updated regressions that confirm production dev-bypass behavior remains disabled.
+### Iteration 3 evidence
 
-## 4. QA
+- `./runBackend.sh migrate`
+- local backend startup
+- live FastAPI route exercise for:
+  - invite
+  - resend
+  - claim
+  - schedule
+  - repeated identical schedule
+  - report generation
+  - report-ready notification processing
+- psql evidence for:
+  - `candidate_sessions`
+  - `notification_delivery_audits`
+  - `winoe_reports`
 
-### Live verification
+### Observed behavior
 
-- `GET /api/trials/19/candidates` as Talent Partner A against Talent Partner B's Trial -> `404 {"detail":"Trial not found"}`
-- `POST /api/auth/logout` with hostile origin + cookie -> `403 {"error":"CSRF_ORIGIN_MISMATCH","message":"Request origin not allowed."}`
-- `GET /api/candidate/session/20/current_task` as candidate A against candidate B session -> `403 CANDIDATE_INVITE_EMAIL_MISMATCH`
-- `GET /api/candidate/session/2lBOgydRX_1WeKPNvFqb9w` as candidate A -> `403 CANDIDATE_INVITE_EMAIL_MISMATCH`
-- `POST /api/candidate/session/2lBOgydRX_1WeKPNvFqb9w/claim` as candidate A -> `403 CANDIDATE_INVITE_EMAIL_MISMATCH`
+- Invite resend is rate-limited immediately by design and succeeded after cooldown.
+- Repeated identical schedule requests did not resend notifications or create new audit rows.
+- Repeated Winoe Report-ready processing was skip-safe after a successful send.
+- Real GitHub org provisioning was not validated live because the PAT only had `metadata:read`.
+- The invite/preprovision route was verified through the repo’s supported `StubGithubClient` via the real FastAPI flow.
 
-### Database evidence
+### QA report references
 
-- Target session row remained unchanged across denied candidate requests:
-  - `candidate_auth0_sub`
-  - `candidate_auth0_email`
-  - `candidate_email`
-  - `claimed_at`
-  - `status`
-- Unrelated session row remained unchanged as well.
+- API verification: [api_endpoints_qa_report.md](qa_verifications/API-Endpoints-QA/api_qa_latest/api_endpoints_qa_report.md)
+- Database verification: [db_protocol_qa_report.md](qa_verifications/Database-Protocol-QA/db_protocol_qa_latest/db_protocol_qa_report.md)
+- Service logic verification: [service_logic_qa_report.md](qa_verifications/Service-Logic-QA/service_logic_qa_latest/service_logic_qa_report.md)
 
-### Focused tests
+### Supporting evidence from the repo
 
-- `8 passed, 16 deselected in 0.61s`
+- `candidate_sessions` still carries the invite summary fields used by the invite response and candidate list response.
+- `notification_delivery_audits` exists as an immutable audit table with `attempted_at`, `sent_at`, `status`, `recipient_role`, and idempotency metadata.
+- `winoe_reports` remains the marker table for report readiness; the ready notification logic checks prior successful delivery before sending again.
 
-### QA notes
+## 6. Known limitations / follow-ups
 
-- Manual QA was completed on a repo-owned local server with local/dev-bypass posture enabled for localhost shorthand auth testing.
-- The issue acceptance criteria were verified live and by focused tests.
+- Live GitHub org provisioning was not validated against the real provider in QA because the available PAT did not include write permissions.
+- The local FastAPI invite/preprovision path was validated with the repository’s `StubGithubClient`, which covers the supported local flow but not external GitHub side effects.
 
-## 5. Risk / notes
+## 7. Checklist
 
-- The local QA database had duplicate candidate-email rows from earlier attempts, so the final evidence pinned specific scenario row IDs.
-- No blocker remains for this issue.
+- [x] Invite email sends and is durably audited
+- [x] Invite resend is rate-limited, resendable after cooldown, and audited
+- [x] Schedule confirmation is audited for both the candidate and the Talent Partner
+- [x] Winoe Report-ready notification uses Winoe terminology and is audited
+- [x] Winoe Report-ready processing skips repeat sends after success
+- [x] Existing candidate-session invite summary fields are preserved
+- [x] Repeated identical schedule requests remain idempotent
+- [x] Audit trail is persisted in `notification_delivery_audits`

--- a/tests/candidates/routes/candidates_session_schedule_api_utils.py
+++ b/tests/candidates/routes/candidates_session_schedule_api_utils.py
@@ -11,7 +11,10 @@ from app.integrations.email.email_provider import MemoryEmailProvider
 from app.notifications.services.notifications_services_notifications_email_sender_service import (
     EmailService,
 )
-from app.shared.database.shared_database_models_model import CandidateSession
+from app.shared.database.shared_database_models_model import (
+    CandidateSession,
+    NotificationDeliveryAudit,
+)
 from app.shared.http.dependencies.shared_http_dependencies_notifications_utils import (
     get_email_service,
 )

--- a/tests/candidates/routes/test_candidates_session_schedule_schedule_endpoint_idempotent_and_conflict_routes.py
+++ b/tests/candidates/routes/test_candidates_session_schedule_schedule_endpoint_idempotent_and_conflict_routes.py
@@ -52,5 +52,18 @@ async def test_schedule_endpoint_idempotent_and_conflict(
     assert first.json() == second.json()
     assert len(provider.sent) == 2
 
+    audits = (
+        (
+            await async_session.execute(
+                select(NotificationDeliveryAudit).where(
+                    NotificationDeliveryAudit.candidate_session_id == cs.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audits) == 2
+
     assert conflict.status_code == 409
     assert conflict.json()["errorCode"] == "SCHEDULE_ALREADY_SET"

--- a/tests/candidates/routes/test_candidates_session_schedule_schedule_endpoint_persists_and_sends_emails_routes.py
+++ b/tests/candidates/routes/test_candidates_session_schedule_schedule_endpoint_persists_and_sends_emails_routes.py
@@ -49,3 +49,20 @@ async def test_schedule_endpoint_persists_and_sends_emails(
     assert cs.invite_email in recipients
     assert talent_partner.email in recipients
     assert any("Schedule confirmed" in message.subject for message in provider.sent)
+
+    audits = (
+        (
+            await async_session.execute(
+                select(NotificationDeliveryAudit).where(
+                    NotificationDeliveryAudit.candidate_session_id == cs.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audits) == 2
+    assert {audit.notification_type for audit in audits} == {
+        "schedule_confirmation_candidate",
+        "schedule_confirmation_talent_partner",
+    }

--- a/tests/notifications/services/test_notifications_core_service.py
+++ b/tests/notifications/services/test_notifications_core_service.py
@@ -1,11 +1,15 @@
 from datetime import UTC, datetime
 
 import pytest
+from sqlalchemy import select
 
 from app.integrations.email.email_provider import MemoryEmailProvider
 from app.notifications.services import service as notification_service
 from app.notifications.services.notifications_services_notifications_email_sender_service import (
     EmailService,
+)
+from app.shared.database.shared_database_models_model import (
+    NotificationDeliveryAudit,
 )
 from app.trials import services as sim_service
 from tests.shared.factories import (
@@ -44,6 +48,24 @@ async def test_send_invite_email_tracks_status_and_rate_limit(async_session):
     assert sent_message.to == cs.invite_email
     assert sim.title in sent_message.subject
 
+    audits = (
+        (
+            await async_session.execute(
+                select(NotificationDeliveryAudit).where(
+                    NotificationDeliveryAudit.candidate_session_id == cs.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audits) == 1
+    assert audits[0].notification_type == "trial_invite"
+    assert audits[0].recipient_role == "candidate"
+    assert audits[0].status == "sent"
+    assert audits[0].provider_message_id == "memory-1"
+    assert audits[0].sent_at is not None
+
     # Second send within rate window should be blocked and not call provider.
     second = await notification_service.send_invite_email(
         async_session,
@@ -59,6 +81,20 @@ async def test_send_invite_email_tracks_status_and_rate_limit(async_session):
     assert cs.invite_email_status == "rate_limited"
     assert cs.invite_email_error == "Rate limited"
     assert len(provider.sent) == 1  # no extra send
+
+    audits = (
+        (
+            await async_session.execute(
+                select(NotificationDeliveryAudit).where(
+                    NotificationDeliveryAudit.candidate_session_id == cs.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audits) == 2
+    assert {audit.status for audit in audits} == {"sent", "rate_limited"}
 
 
 def test_invite_email_content_and_rate_limit_helpers():
@@ -101,3 +137,18 @@ async def test_send_invite_email_failure_path(async_session):
     assert result.status == "failed"
     assert cs.invite_email_status == "failed"
     assert cs.invite_email_error == "boom"
+
+    audits = (
+        (
+            await async_session.execute(
+                select(NotificationDeliveryAudit).where(
+                    NotificationDeliveryAudit.candidate_session_id == cs.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audits) == 1
+    assert audits[0].status == "failed"
+    assert audits[0].error == "boom"

--- a/tests/notifications/services/test_notifications_schedule_send_service.py
+++ b/tests/notifications/services/test_notifications_schedule_send_service.py
@@ -4,8 +4,12 @@ from datetime import UTC, datetime, time
 from types import SimpleNamespace
 
 import pytest
+from sqlalchemy import select
 
 from app.integrations.email.email_provider import MemoryEmailProvider
+from app.notifications.repositories.notifications_repositories_notifications_delivery_audits_core_model import (
+    NotificationDeliveryAudit,
+)
 from app.notifications.services.notifications_services_notifications_email_sender_service import (
     EmailService,
 )
@@ -47,6 +51,9 @@ async def test_send_schedule_confirmation_emails_incomplete_schedule(async_sessi
     assert candidate_result.status == "failed"
     assert talent_partner_result is None
     assert provider.sent == []
+    result = await async_session.execute(select(NotificationDeliveryAudit))
+    audits = result.scalars().all()
+    assert audits == []
 
 
 @pytest.mark.asyncio
@@ -78,6 +85,12 @@ async def test_send_schedule_confirmation_emails_without_talent_partner(async_se
     assert talent_partner_result is None
     assert len(provider.sent) == 1
     assert provider.sent[0].to == "candidate@test.com"
+    result = await async_session.execute(select(NotificationDeliveryAudit))
+    audits = result.scalars().all()
+    assert len(audits) == 1
+    assert audits[0].notification_type == "schedule_confirmation_candidate"
+    assert audits[0].recipient_role == "candidate"
+    assert audits[0].status == "sent"
 
 
 @pytest.mark.asyncio
@@ -115,3 +128,94 @@ async def test_send_schedule_confirmation_emails_candidate_and_talent_partner(
     recipients = {message.to for message in provider.sent}
     assert "candidate-sched@test.com" in recipients
     assert "talent_partner-sched@test.com" in recipients
+
+    result = await async_session.execute(
+        select(NotificationDeliveryAudit).where(
+            NotificationDeliveryAudit.candidate_session_id == candidate_session.id
+        )
+    )
+    audits = result.scalars().all()
+    assert len(audits) == 2
+    assert {audit.status for audit in audits} == {"sent"}
+    assert {audit.notification_type for audit in audits} == {
+        "schedule_confirmation_candidate",
+        "schedule_confirmation_talent_partner",
+    }
+
+
+@pytest.mark.asyncio
+async def test_send_schedule_confirmation_emails_retries_failed_recipient(
+    async_session,
+):
+    talent_partner = await create_talent_partner(
+        async_session, email="talent_partner-retry@test.com"
+    )
+    trial, _tasks = await create_trial(async_session, created_by=talent_partner)
+    candidate_session = await create_candidate_session(
+        async_session,
+        trial=trial,
+        invite_email="candidate-retry@test.com",
+        candidate_email="candidate-retry@test.com",
+    )
+    candidate_session.scheduled_start_at = datetime(2026, 3, 10, 13, 0, tzinfo=UTC)
+    candidate_session.candidate_timezone = "America/New_York"
+    await async_session.commit()
+
+    class FlakyProvider:
+        def __init__(self):
+            self.sent = []
+            self.calls = 0
+
+        async def send(self, message):
+            from app.integrations.email.email_provider import EmailSendError
+
+            self.calls += 1
+            if self.calls == 1:
+                raise EmailSendError("candidate send failed", retryable=False)
+            self.sent.append(message)
+            return f"memory-{self.calls}"
+
+    provider = FlakyProvider()
+    email_service = EmailService(provider, sender="noreply@test.com")
+
+    (
+        first_candidate_result,
+        first_talent_partner_result,
+    ) = await send_schedule_confirmation_emails(
+        async_session,
+        candidate_session=candidate_session,
+        trial=trial,
+        email_service=email_service,
+    )
+    assert first_candidate_result.status == "failed"
+    assert first_talent_partner_result is not None
+    assert first_talent_partner_result.status == "sent"
+
+    (
+        second_candidate_result,
+        second_talent_partner_result,
+    ) = await send_schedule_confirmation_emails(
+        async_session,
+        candidate_session=candidate_session,
+        trial=trial,
+        email_service=email_service,
+    )
+    assert second_candidate_result.status == "sent"
+    assert second_talent_partner_result.status == "sent"
+    assert len(provider.sent) == 2
+
+    audits = (
+        (
+            await async_session.execute(
+                select(NotificationDeliveryAudit).where(
+                    NotificationDeliveryAudit.candidate_session_id
+                    == candidate_session.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audits) == 3
+    assert [audit.status for audit in audits].count("failed") == 1
+    assert [audit.status for audit in audits].count("sent") == 2

--- a/tests/notifications/services/test_notifications_talent_partner_updates_service.py
+++ b/tests/notifications/services/test_notifications_talent_partner_updates_service.py
@@ -4,8 +4,12 @@ from datetime import UTC, datetime
 from uuid import uuid4
 
 import pytest
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
+from app.notifications.repositories.notifications_repositories_notifications_delivery_audits_core_model import (
+    NotificationDeliveryAudit,
+)
 from app.notifications.services.notifications_services_notifications_email_sender_service import (
     EmailSendResult,
 )
@@ -134,3 +138,37 @@ async def test_process_talent_partner_update_jobs_send_expected_email(async_sess
     assert email_service.calls[0]["to"] == talent_partner_email
     assert "completed all five days" in (email_service.calls[0]["text"] or "")
     assert "Winoe Report is ready" in (email_service.calls[1]["text"] or "")
+
+    audits = (
+        (
+            await async_session.execute(
+                select(NotificationDeliveryAudit).where(
+                    NotificationDeliveryAudit.candidate_session_id
+                    == candidate_session.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audits) == 2
+    assert {audit.notification_type for audit in audits} == {
+        "candidate_completed_notification",
+        "winoe_report_ready_notification",
+    }
+    assert all(audit.recipient_role == "talent_partner" for audit in audits)
+    assert all(audit.status == "sent" for audit in audits)
+
+    second_completed = await process_candidate_completed_notification_job(
+        {"candidateSessionId": candidate_session.id},
+        async_session_maker_obj=session_maker,
+        email_service=email_service,
+    )
+    second_fit = await process_winoe_report_ready_notification_job(
+        {"candidateSessionId": candidate_session.id},
+        async_session_maker_obj=session_maker,
+        email_service=email_service,
+    )
+    assert second_completed["skipped"] is True
+    assert second_fit["skipped"] is True
+    assert len(email_service.calls) == 2

--- a/tests/trials/routes/test_trials_api_invite_resend_tracks_audit_routes.py
+++ b/tests/trials/routes/test_trials_api_invite_resend_tracks_audit_routes.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from tests.trials.routes.trials_api_utils import *
+
+
+@pytest.mark.asyncio
+async def test_invite_resend_tracks_audit_rows(
+    async_client, async_session, auth_header_factory, override_dependencies
+):
+    talent_partner = await create_talent_partner(
+        async_session, email="resend-audit@app.com"
+    )
+    sim, _ = await create_trial(async_session, created_by=talent_partner)
+
+    provider = MemoryEmailProvider()
+    email_service = EmailService(provider, sender="noreply@test.com")
+
+    with override_dependencies({get_email_service: lambda: email_service}):
+        create_res = await async_client.post(
+            f"/api/trials/{sim.id}/invite",
+            json={"candidateName": "Jane Doe", "inviteEmail": "jane@example.com"},
+            headers=auth_header_factory(talent_partner),
+        )
+        assert create_res.status_code == 200, create_res.text
+
+        cs_id = create_res.json()["candidateSessionId"]
+        cs = (
+            await async_session.execute(
+                select(CandidateSession).where(CandidateSession.id == cs_id)
+            )
+        ).scalar_one()
+        cs.invite_email_last_attempt_at = datetime.now(UTC) - timedelta(seconds=31)
+        await async_session.commit()
+
+        resend_res = await async_client.post(
+            f"/api/trials/{sim.id}/candidates/{cs_id}/invite/resend",
+            headers=auth_header_factory(talent_partner),
+        )
+
+    assert resend_res.status_code == 200, resend_res.text
+    assert len(provider.sent) == 2
+
+    audits = (
+        (
+            await async_session.execute(
+                select(NotificationDeliveryAudit).where(
+                    NotificationDeliveryAudit.candidate_session_id == cs_id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audits) == 2
+    assert all(audit.notification_type == "trial_invite" for audit in audits)
+    assert all(audit.recipient_role == "candidate" for audit in audits)
+    assert [audit.status for audit in audits] == ["sent", "sent"]

--- a/tests/trials/routes/test_trials_api_invite_sends_email_and_tracks_status_routes.py
+++ b/tests/trials/routes/test_trials_api_invite_sends_email_and_tracks_status_routes.py
@@ -30,6 +30,24 @@ async def test_invite_sends_email_and_tracks_status(
     assert len(provider.sent) == 1
     assert provider.sent[0].to == cs.invite_email
 
+    audits = (
+        (
+            await async_session.execute(
+                select(NotificationDeliveryAudit).where(
+                    NotificationDeliveryAudit.candidate_session_id == cs.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(audits) == 1
+    assert audits[0].notification_type == "trial_invite"
+    assert audits[0].recipient_role == "candidate"
+    assert audits[0].status == "sent"
+    assert audits[0].provider_message_id == "memory-1"
+    assert audits[0].sent_at is not None
+
     list_res = await async_client.get(
         f"/api/trials/{sim.id}/candidates",
         headers=auth_header_factory(talent_partner),

--- a/tests/trials/routes/trials_api_utils.py
+++ b/tests/trials/routes/trials_api_utils.py
@@ -13,6 +13,7 @@ from app.notifications.services.notifications_services_notifications_email_sende
 )
 from app.shared.database.shared_database_models_model import (
     CandidateSession,
+    NotificationDeliveryAudit,
     ScenarioVersion,
     Workspace,
     WorkspaceGroup,


### PR DESCRIPTION
## 2. Summary

This change completes the notification delivery path for the candidate Golden Path in Winoe:

- candidate invite delivery is durably audited
- invite resend is audited and rate-limited
- schedule confirmation is audited for both the candidate and the Talent Partner
- Winoe Report-ready notification delivery is audited and skip-safe after success
- existing candidate-session invite summary fields remain intact
- schedule idempotency is preserved for repeated identical requests

The implementation is centered on a new durable `notification_delivery_audits` table plus service-layer checks that avoid duplicate sends when a successful delivery already exists.

## 3. What changed

- Added durable `notification_delivery_audits` persistence with indexed rows for candidate-session, notification-type, and status lookups.
- Recorded invite send and resend outcomes as immutable audit rows, while preserving existing `candidate_sessions` invite status fields such as `inviteEmailStatus`, `inviteEmailSentAt`, and `inviteEmailError`.
- Added schedule confirmation audit persistence for both recipients:
  - candidate
  - Talent Partner
- Added a success-detection guard so schedule confirmations and Winoe Report-ready notifications skip re-sending after a successful prior delivery.
- Restored the schedule idempotency contract so repeated identical schedule requests do not create new notifications or new audit rows.
- Kept Winoe Report terminology in the report-ready notification subject and body, and persisted the corresponding delivery audit row.
- Kept the invite preprovision flow exercised through the repo-supported `StubGithubClient` path during local FastAPI QA.

## 4. Why

The issue acceptance criteria required proof that the candidate Golden Path notifications are not just surfaced in response payloads, but actually delivered, retried, audited, and replay-safe.

The audit table provides durable evidence across the full lifecycle:

- invite send
- invite resend
- schedule confirmation
- Winoe Report-ready notification

The skip-safe guards prevent duplicate notification sends after a successful delivery has already been recorded, which keeps the notification history consistent with the user-visible state.

## 5. QA performed

### Iteration 3 evidence

- `./runBackend.sh migrate`
- local backend startup
- live FastAPI route exercise for:
  - invite
  - resend
  - claim
  - schedule
  - repeated identical schedule
  - report generation
  - report-ready notification processing
- psql evidence for:
  - `candidate_sessions`
  - `notification_delivery_audits`
  - `winoe_reports`

### Observed behavior

- Invite resend is rate-limited immediately by design and succeeded after cooldown.
- Repeated identical schedule requests did not resend notifications or create new audit rows.
- Repeated Winoe Report-ready processing was skip-safe after a successful send.
- Real GitHub org provisioning was not validated live because the PAT only had `metadata:read`.
- The invite/preprovision route was verified through the repo’s supported `StubGithubClient` via the real FastAPI flow.

### QA report references

- API verification: [api_endpoints_qa_report.md](qa_verifications/API-Endpoints-QA/api_qa_latest/api_endpoints_qa_report.md)
- Database verification: [db_protocol_qa_report.md](qa_verifications/Database-Protocol-QA/db_protocol_qa_latest/db_protocol_qa_report.md)
- Service logic verification: [service_logic_qa_report.md](qa_verifications/Service-Logic-QA/service_logic_qa_latest/service_logic_qa_report.md)

### Supporting evidence from the repo

- `candidate_sessions` still carries the invite summary fields used by the invite response and candidate list response.
- `notification_delivery_audits` exists as an immutable audit table with `attempted_at`, `sent_at`, `status`, `recipient_role`, and idempotency metadata.
- `winoe_reports` remains the marker table for report readiness; the ready notification logic checks prior successful delivery before sending again.

## 6. Known limitations / follow-ups

- Live GitHub org provisioning was not validated against the real provider in QA because the available PAT did not include write permissions.
- The local FastAPI invite/preprovision path was validated with the repository’s `StubGithubClient`, which covers the supported local flow but not external GitHub side effects.

## 7. Checklist

- [x] Invite email sends and is durably audited
- [x] Invite resend is rate-limited, resendable after cooldown, and audited
- [x] Schedule confirmation is audited for both the candidate and the Talent Partner
- [x] Winoe Report-ready notification uses Winoe terminology and is audited
- [x] Winoe Report-ready processing skips repeat sends after success
- [x] Existing candidate-session invite summary fields are preserved
- [x] Repeated identical schedule requests remain idempotent
- [x] Audit trail is persisted in `notification_delivery_audits`

Fixes #293 