### PR TITLE
Seed evidence-capture GitHub Actions in empty candidate repos and persist live evidence artifacts

### DIFF
--- a/app/integrations/github/actions_runner/integrations_github_actions_runner_github_actions_runner_artifacts_service.py
+++ b/app/integrations/github/actions_runner/integrations_github_actions_runner_github_actions_runner_artifacts_service.py
@@ -2,11 +2,10 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from app.integrations.github.actions_runner.integrations_github_actions_runner_github_actions_runner_artifact_list_service import (
     list_artifacts_with_cache,
-)
-from app.integrations.github.actions_runner.integrations_github_actions_runner_github_actions_runner_artifact_parser_service import (
-    parse_first_artifact,
 )
 from app.integrations.github.actions_runner.integrations_github_actions_runner_github_actions_runner_artifact_partition_service import (
     partition_artifacts,
@@ -14,8 +13,14 @@ from app.integrations.github.actions_runner.integrations_github_actions_runner_g
 from app.integrations.github.actions_runner.integrations_github_actions_runner_github_actions_runner_cache_service import (
     ActionsCache,
 )
-from app.integrations.github.artifacts import ParsedTestResults
-from app.integrations.github.client import GithubClient
+from app.integrations.github.artifacts import (
+    EVIDENCE_ARTIFACT_SUMMARY_KEYS,
+    ParsedTestResults,
+    build_evidence_artifact_summary,
+    parse_evidence_artifact_zip,
+    parse_test_results_zip,
+)
+from app.integrations.github.client import GithubClient, GithubError
 
 
 async def parse_artifacts(
@@ -24,11 +29,125 @@ async def parse_artifacts(
     """Parse artifacts."""
     artifacts = await list_artifacts_with_cache(client, cache, repo_full_name, run_id)
     preferred, others = partition_artifacts(artifacts)
-    parsed, error = await parse_first_artifact(
-        client, cache, repo_full_name, run_id, preferred + others
+    test_artifacts = _pick_test_artifacts(preferred + others)
+    evidence_key = (repo_full_name, run_id)
+    parsed, error = await _parse_first_test_artifact(
+        client, cache, repo_full_name, run_id, test_artifacts
     )
+    evidence = await _collect_evidence_artifacts(
+        client, repo_full_name, preferred + others
+    )
+    if evidence:
+        cache.cache_evidence_summary(evidence_key, {"evidenceArtifacts": evidence})
     if parsed:
+        summary = dict(parsed.summary or {})
+        if evidence:
+            summary["evidenceArtifacts"] = evidence
+        parsed.summary = summary or None
+        cache.cache_evidence_summary(evidence_key, summary)
         return parsed, None
     if error:
         return None, error
+    if artifacts:
+        return None, "artifact_missing"
     return None, "artifact_missing"
+
+
+async def _parse_first_test_artifact(
+    client: GithubClient,
+    cache: ActionsCache,
+    repo_full_name: str,
+    run_id: int,
+    artifacts: list[dict[str, Any]],
+) -> tuple[ParsedTestResults | None, str | None]:
+    """Parse the first parseable test-results artifact."""
+    found = False
+    last_error: str | None = None
+    for artifact in artifacts:
+        artifact_id = artifact.get("id")
+        if not artifact_id:
+            continue
+        found = True
+        cache_key = (repo_full_name, run_id, int(artifact_id))
+        cached = cache.artifact_cache.get(cache_key)
+        if cached:
+            parsed_cached, cached_error = cached
+            if parsed_cached or cached_error:
+                return parsed_cached, cached_error
+        try:
+            content = await client.download_artifact_zip(
+                repo_full_name, int(artifact_id)
+            )
+        except GithubError:
+            last_error = "artifact_download_failed"
+            continue
+        parsed = parse_test_results_zip(content)
+        if parsed:
+            cache.cache_artifact_result(cache_key, parsed, None)
+            return parsed, None
+        last_error = "artifact_corrupt"
+        cache.cache_artifact_result(cache_key, None, last_error)
+    if found:
+        return None, last_error or "artifact_unavailable"
+    return None, None
+
+
+async def _collect_evidence_artifacts(
+    client: GithubClient, repo_full_name: str, artifacts: list[dict[str, Any]]
+) -> dict[str, dict[str, Any]]:
+    """Collect evidence artifact summaries best-effort."""
+    evidence: dict[str, dict[str, Any]] = {}
+    for artifact in artifacts:
+        artifact_id = artifact.get("id")
+        if not artifact_id:
+            continue
+        artifact_name = str(artifact.get("name") or "").lower()
+        summary_key = EVIDENCE_ARTIFACT_SUMMARY_KEYS.get(artifact_name)
+        if summary_key is None:
+            continue
+        try:
+            content = await client.download_artifact_zip(
+                repo_full_name, int(artifact_id)
+            )
+        except GithubError:
+            evidence[summary_key] = {
+                "artifactName": artifact_name,
+                "artifactId": int(artifact_id),
+                "error": "artifact_download_failed",
+            }
+            continue
+        parsed = parse_evidence_artifact_zip(content, artifact_name)
+        if parsed is None:
+            evidence[summary_key] = {
+                "artifactName": artifact_name,
+                "artifactId": int(artifact_id),
+                "error": "artifact_corrupt",
+            }
+            continue
+        summary = build_evidence_artifact_summary(parsed)
+        summary["artifactId"] = int(artifact_id)
+        evidence[summary_key] = summary
+    return evidence
+
+
+def _pick_test_artifacts(artifacts: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Return only artifacts that can contain parseable test results."""
+    from app.shared.utils.shared_utils_brand_utils import (
+        LEGACY_TEST_ARTIFACT_NAMESPACE,
+        TEST_ARTIFACT_NAMESPACE,
+    )
+
+    allowed_names = {
+        TEST_ARTIFACT_NAMESPACE,
+        LEGACY_TEST_ARTIFACT_NAMESPACE,
+        "test-results",
+        "junit",
+    }
+    selected: list[dict[str, Any]] = []
+    for artifact in artifacts:
+        if not artifact or artifact.get("expired"):
+            continue
+        name = str(artifact.get("name") or "").lower()
+        if name in allowed_names:
+            selected.append(artifact)
+    return selected

--- a/app/integrations/github/actions_runner/integrations_github_actions_runner_github_actions_runner_cache_artifacts_service.py
+++ b/app/integrations/github/actions_runner/integrations_github_actions_runner_github_actions_runner_cache_artifacts_service.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from app.integrations.github.artifacts import ParsedTestResults
 
 
@@ -9,6 +11,7 @@ class ArtifactCacheMixin:
     """Cache helpers for artifact lists and parsed content."""
 
     artifact_cache: dict
+    evidence_summary_cache: dict
     artifact_list_cache: dict
     max_entries: int
 
@@ -37,3 +40,12 @@ class ArtifactCacheMixin:
             ]
             for cache_key in to_remove:
                 self.artifact_cache.pop(cache_key, None)
+
+    def cache_evidence_summary(
+        self, key: tuple[str, int], summary: dict[str, Any]
+    ) -> None:
+        """Execute cache evidence summary."""
+        self.evidence_summary_cache[key] = summary
+        self.evidence_summary_cache.move_to_end(key)
+        if len(self.evidence_summary_cache) > self.max_entries:
+            self.evidence_summary_cache.popitem(last=False)

--- a/app/integrations/github/actions_runner/integrations_github_actions_runner_github_actions_runner_cache_service.py
+++ b/app/integrations/github/actions_runner/integrations_github_actions_runner_github_actions_runner_cache_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections import OrderedDict
+from typing import Any
 
 from app.integrations.github.actions_runner.integrations_github_actions_runner_github_actions_runner_cache_artifacts_service import (
     ArtifactCacheMixin,
@@ -24,6 +25,9 @@ class ActionsCache(RunCacheMixin, ArtifactCacheMixin):
         self.run_cache: OrderedDict[tuple[str, int], ActionsRunResult] = OrderedDict()
         self.artifact_cache: OrderedDict[
             tuple[str, int, int], tuple[ParsedTestResults | None, str | None]
+        ] = OrderedDict()
+        self.evidence_summary_cache: OrderedDict[
+            tuple[str, int], dict[str, Any]
         ] = OrderedDict()
         self.artifact_list_cache: OrderedDict[
             tuple[str, int], list[dict]

--- a/app/integrations/github/actions_runner/integrations_github_actions_runner_github_actions_runner_legacy_cache_service.py
+++ b/app/integrations/github/actions_runner/integrations_github_actions_runner_github_actions_runner_legacy_cache_service.py
@@ -15,6 +15,9 @@ class LegacyCacheMixin:
     def _cache_artifact_list(self, key, artifacts):
         self.cache.cache_artifact_list(key, artifacts)
 
+    def _cache_evidence_summary(self, key, summary):
+        self.cache.cache_evidence_summary(key, summary)
+
     @property
     def _run_cache(self):
         return self.cache.run_cache
@@ -26,6 +29,10 @@ class LegacyCacheMixin:
     @property
     def _artifact_list_cache(self):
         return self.cache.artifact_list_cache
+
+    @property
+    def _evidence_summary_cache(self):
+        return self.cache.evidence_summary_cache
 
     @property
     def _poll_attempts(self):

--- a/app/integrations/github/actions_runner/integrations_github_actions_runner_github_actions_runner_result_builder_service.py
+++ b/app/integrations/github/actions_runner/integrations_github_actions_runner_github_actions_runner_result_builder_service.py
@@ -45,6 +45,9 @@ async def build_result(
         base.status = "error"
         base.raw = base.raw or {}
         base.raw.setdefault("artifact_error", artifact_error)
+        cached_summary = ctx.cache.evidence_summary_cache.get((repo_full_name, run.id))
+        if cached_summary:
+            base.raw.setdefault("summary", cached_summary)
         base.stderr = (
             base.stderr
             or "Test results artifact missing or unreadable. Please re-run tests."

--- a/app/integrations/github/actions_runner/integrations_github_actions_runner_github_actions_runner_workflow_fallbacks_service.py
+++ b/app/integrations/github/actions_runner/integrations_github_actions_runner_github_actions_runner_workflow_fallbacks_service.py
@@ -6,5 +6,11 @@ from __future__ import annotations
 def build_workflow_fallbacks(workflow_file: str) -> list[str]:
     """Build workflow fallbacks."""
     return list(
-        dict.fromkeys([workflow_file, "winoe-ci.yml", ".github/workflows/winoe-ci.yml"])
+        dict.fromkeys(
+            [
+                workflow_file,
+                "winoe-evidence-capture.yml",
+                ".github/workflows/winoe-evidence-capture.yml",
+            ]
+        )
     )

--- a/app/integrations/github/artifacts/__init__.py
+++ b/app/integrations/github/artifacts/__init__.py
@@ -1,3 +1,8 @@
+from app.integrations.github.artifacts.integrations_github_artifacts_evidence_parser_utils import (
+    EVIDENCE_ARTIFACT_SUMMARY_KEYS,
+    build_evidence_artifact_summary,
+    parse_evidence_artifact_zip,
+)
 from app.integrations.github.artifacts.integrations_github_artifacts_json_parser_utils import (
     parse_any_json,
     parse_named_json,
@@ -6,6 +11,7 @@ from app.integrations.github.artifacts.integrations_github_artifacts_junit_parse
     parse_junit,
 )
 from app.integrations.github.artifacts.integrations_github_artifacts_models_model import (
+    ParsedArtifactEvidence,
     ParsedTestResults,
 )
 from app.integrations.github.artifacts.integrations_github_artifacts_zip_parser_utils import (
@@ -24,9 +30,13 @@ PREFERRED_ARTIFACT_NAMES = {
 }
 
 __all__ = [
+    "EVIDENCE_ARTIFACT_SUMMARY_KEYS",
+    "ParsedArtifactEvidence",
     "ParsedTestResults",
     "PREFERRED_ARTIFACT_NAMES",
+    "build_evidence_artifact_summary",
     "parse_any_json",
+    "parse_evidence_artifact_zip",
     "parse_named_json",
     "parse_junit",
     "parse_test_results_zip",

--- a/app/integrations/github/artifacts/integrations_github_artifacts_evidence_parser_utils.py
+++ b/app/integrations/github/artifacts/integrations_github_artifacts_evidence_parser_utils.py
@@ -1,0 +1,117 @@
+"""Application module for integrations github artifacts evidence parser utils workflows."""
+
+from __future__ import annotations
+
+import io
+import json
+from typing import Any
+from zipfile import BadZipFile, ZipFile
+
+from app.integrations.github.artifacts.integrations_github_artifacts_models_model import (
+    ParsedArtifactEvidence,
+)
+
+EVIDENCE_ARTIFACT_SUMMARY_KEYS: dict[str, str] = {
+    "winoe-commit-metadata": "commitMetadata",
+    "winoe-file-creation-timeline": "fileCreationTimeline",
+    "winoe-repo-structure-snapshot": "repoStructureSnapshot",
+    "winoe-lint-results": "lintResults",
+    "winoe-coverage": "coverage",
+}
+
+
+def parse_evidence_artifact_zip(
+    content: bytes, artifact_name: str
+) -> ParsedArtifactEvidence | None:
+    """Parse a non-test evidence artifact zip."""
+    try:
+        with ZipFile(io.BytesIO(content)) as zf:
+            files = list(zf.namelist())
+            json_files: dict[str, Any] = {}
+            text_files: dict[str, str] = {}
+            for name in files:
+                lower_name = name.lower()
+                if lower_name.endswith(".json"):
+                    with zf.open(name) as fp:
+                        data = _safe_json_load(fp)
+                    if data is not None:
+                        json_files[name] = data
+                elif (
+                    artifact_name.lower() == "winoe-repo-structure-snapshot"
+                    and lower_name.endswith(".txt")
+                ):
+                    with zf.open(name) as fp:
+                        text_files[name] = _safe_text_load(fp)
+            data = _choose_primary_payload(
+                artifact_name=artifact_name,
+                json_files=json_files,
+                text_files=text_files,
+            )
+            return ParsedArtifactEvidence(
+                artifact_name=artifact_name,
+                files=files,
+                data=data,
+                json_files=json_files or None,
+                text_files=text_files or None,
+            )
+    except BadZipFile:
+        return None
+
+
+def build_evidence_artifact_summary(
+    evidence: ParsedArtifactEvidence,
+) -> dict[str, Any]:
+    """Build a machine-readable summary for an evidence artifact."""
+    payload: dict[str, Any] = {
+        "artifactName": evidence.artifact_name,
+        "files": evidence.files,
+    }
+    if evidence.data is not None:
+        payload["data"] = evidence.data
+    if evidence.json_files:
+        payload["jsonFiles"] = evidence.json_files
+    if evidence.text_files:
+        payload["textFiles"] = evidence.text_files
+    if evidence.error:
+        payload["error"] = evidence.error
+    return payload
+
+
+def _choose_primary_payload(
+    *,
+    artifact_name: str,
+    json_files: dict[str, Any],
+    text_files: dict[str, str],
+) -> Any | None:
+    if json_files:
+        if len(json_files) == 1:
+            return next(iter(json_files.values()))
+        preferred_file = {
+            "winoe-repo-structure-snapshot": "repo-structure-snapshot.json",
+            "winoe-commit-metadata": "commit-metadata.json",
+            "winoe-file-creation-timeline": "file-creation-timeline.json",
+            "winoe-lint-results": "lint-results.json",
+        }.get(artifact_name.lower())
+        if preferred_file and preferred_file in json_files:
+            return json_files[preferred_file]
+        return json_files
+    if artifact_name.lower() == "winoe-repo-structure-snapshot" and text_files:
+        if len(text_files) == 1:
+            return next(iter(text_files.values()))
+        return text_files
+    return None
+
+
+def _safe_json_load(fp) -> Any | None:
+    try:
+        return json.load(fp)
+    except (json.JSONDecodeError, UnicodeDecodeError, ValueError):
+        return None
+
+
+def _safe_text_load(fp) -> str:
+    raw = fp.read()
+    try:
+        return raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return raw.decode("utf-8", errors="replace")

--- a/app/integrations/github/artifacts/integrations_github_artifacts_models_model.py
+++ b/app/integrations/github/artifacts/integrations_github_artifacts_models_model.py
@@ -16,3 +16,15 @@ class ParsedTestResults:
     stdout: str | None = None
     stderr: str | None = None
     summary: dict[str, Any] | None = None
+
+
+@dataclass
+class ParsedArtifactEvidence:
+    """Normalized evidence artifact parsed from GitHub artifact zip."""
+
+    artifact_name: str
+    files: list[str]
+    data: Any | None = None
+    json_files: dict[str, Any] | None = None
+    text_files: dict[str, str] | None = None
+    error: str | None = None

--- a/app/submissions/services/submissions_services_submissions_workspace_bootstrap_service.py
+++ b/app/submissions/services/submissions_services_submissions_workspace_bootstrap_service.py
@@ -7,6 +7,7 @@ import json
 import logging
 import time
 from dataclasses import dataclass
+from textwrap import dedent
 from typing import Any
 
 from fastapi import HTTPException
@@ -52,27 +53,340 @@ _GITIGNORE_TEXT = "\n".join(
         "",
     ]
 )
-_EVIDENCE_WORKFLOW_TEXT = """name: Evidence Capture
-on:
-  workflow_dispatch:
-  push:
-    branches:
-      - main
-jobs:
-  capture:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Capture evidence
-        run: |
-          mkdir -p evidence
-          printf '%s\\n' 'Evidence capture placeholder' > evidence/README.txt
-      - uses: actions/upload-artifact@v4
-        with:
-          name: evidence-capture
-          path: evidence/
-"""
 _CODESPACE_RETRY_DELAY_SECONDS = 1
+_EVIDENCE_WORKFLOW_PATH = ".github/workflows/evidence-capture.yml"
+
+
+def build_evidence_capture_workflow_yaml() -> str:
+    """Return the seeded evidence-capture workflow content."""
+    return (
+        dedent(
+            """\
+        name: Winoe Evidence Capture
+
+        on:
+          push:
+            branches:
+              - main
+          workflow_dispatch:
+
+        permissions:
+          contents: read
+
+        jobs:
+          capture:
+            runs-on: ubuntu-latest
+            steps:
+              - name: Check out repository
+                uses: actions/checkout@v4
+                with:
+                  fetch-depth: 0
+
+              - name: Prepare artifact directories
+                run: |
+                  mkdir -p artifacts/coverage
+                  mkdir -p artifacts/lint
+                  mkdir -p artifacts/test-results
+
+              - name: Capture repository evidence
+                continue-on-error: true
+                run: |
+                  python - <<'PY'
+                  import json
+                  import pathlib
+                  import subprocess
+                  from datetime import UTC, datetime
+
+                  artifacts = pathlib.Path("artifacts")
+                  artifacts.mkdir(parents=True, exist_ok=True)
+
+                  def run_git(args: list[str]) -> subprocess.CompletedProcess[str]:
+                      return subprocess.run(
+                          ["git", *args],
+                          capture_output=True,
+                          text=True,
+                          check=False,
+                      )
+
+                  def write_json(path: str, payload: object) -> None:
+                      (artifacts / path).write_text(
+                          json.dumps(payload, indent=2, sort_keys=True) + "\\n",
+                          encoding="utf-8",
+                      )
+
+                  def snapshot_tree() -> list[str]:
+                      paths: list[str] = []
+                      for path in pathlib.Path(".").rglob("*"):
+                          if ".git" in path.parts or "artifacts" in path.parts:
+                              continue
+                          relative = path.as_posix()
+                          if path.is_dir():
+                              relative += "/"
+                          paths.append(relative)
+                      return sorted(paths)
+
+                  generated_at = datetime.now(UTC).isoformat()
+                  commit_metadata: dict[str, object] = {
+                      "generatedAt": generated_at,
+                      "commits": [],
+                  }
+                  timeline: dict[str, object] = {
+                      "generatedAt": generated_at,
+                      "filesCreated": [],
+                  }
+
+                  head = run_git(["rev-parse", "HEAD"])
+                  if head.returncode == 0:
+                      commit_metadata["headSha"] = head.stdout.strip()
+
+                  rev_list = run_git(["rev-list", "--reverse", "HEAD"])
+                  for sha in rev_list.stdout.splitlines() if rev_list.returncode == 0 else []:
+                      show = run_git(
+                          [
+                              "show",
+                              "--date=iso-strict",
+                              "--format=%H%x09%ad%x09%s",
+                              "--numstat",
+                              "--no-renames",
+                              sha,
+                          ]
+                      )
+                      if show.returncode != 0:
+                          cast_list = commit_metadata["commits"]  # type: ignore[assignment]
+                          cast_list.append({"sha": sha, "error": "git show failed"})
+                          continue
+                      lines = show.stdout.splitlines()
+                      if not lines:
+                          continue
+                      commit_sha, timestamp, message = lines[0].split("\t", 2)
+                      files: list[str] = []
+                      insertions = 0
+                      deletions = 0
+                      for line in lines[1:]:
+                          if not line.strip():
+                              continue
+                          parts = line.split("\t")
+                          if len(parts) != 3:
+                              continue
+                          added, removed, path = parts
+                          files.append(path)
+                          if added != "-":
+                              insertions += int(added)
+                          if removed != "-":
+                              deletions += int(removed)
+                      cast_list = commit_metadata["commits"]  # type: ignore[assignment]
+                      cast_list.append(
+                          {
+                              "sha": commit_sha,
+                              "timestamp": timestamp,
+                              "message": message,
+                              "filesChanged": files,
+                              "filesChangedCount": len(files),
+                              "insertions": insertions,
+                              "deletions": deletions,
+                          }
+                      )
+
+                  creation_log = run_git(
+                      [
+                          "log",
+                          "--reverse",
+                          "--diff-filter=A",
+                          "--date=iso-strict",
+                          "--format=%H%x09%ad%x09%s",
+                          "--name-only",
+                          "--no-renames",
+                      ]
+                  )
+                  current_event: dict[str, object] | None = None
+                  for line in creation_log.stdout.splitlines() if creation_log.returncode == 0 else []:
+                      if not line.strip():
+                          current_event = None
+                          continue
+                      if current_event is None and line.count("\t") >= 2:
+                          commit_sha, timestamp, message = line.split("\t", 2)
+                          current_event = {
+                              "commitSha": commit_sha,
+                              "timestamp": timestamp,
+                              "message": message,
+                              "files": [],
+                          }
+                          cast_list = timeline["filesCreated"]  # type: ignore[assignment]
+                          cast_list.append(current_event)
+                          continue
+                      if current_event is not None:
+                          files = current_event.setdefault("files", [])
+                          if isinstance(files, list):
+                              files.append(line.strip())
+
+                  write_json("commit-metadata.json", commit_metadata)
+                  write_json("file-creation-timeline.json", timeline)
+                  write_json(
+                      "repo-structure-snapshot.json",
+                      {
+                          "generatedAt": generated_at,
+                          "paths": snapshot_tree(),
+                      },
+                  )
+                  (artifacts / "repo-structure-snapshot.txt").write_text(
+                      "\\n".join(snapshot_tree()) + "\\n",
+                      encoding="utf-8",
+                  )
+                  PY
+
+              - name: Detect and run tests
+                continue-on-error: true
+                run: |
+                  set +e
+                  test_tool="none"
+                  test_command="not-detected"
+                  test_status=0
+                  mkdir -p artifacts/coverage artifacts/test-results
+
+                  if [ -f package.json ]; then
+                    test_tool="npm"
+                    test_command="npm test -- --coverage"
+                    npm test -- --coverage > artifacts/test-results/test-output.log 2>&1
+                    test_status=$?
+                    if [ -d coverage ]; then
+                      cp -R coverage/. artifacts/coverage/ 2>/dev/null || true
+                    fi
+                  elif [ -f requirements.txt ] || [ -f pyproject.toml ]; then
+                    test_tool="pytest"
+                    test_command="python -m pytest --cov=. --cov-report=term-missing --cov-report=xml:artifacts/coverage/coverage.xml"
+                    python -m pytest --cov=. --cov-report=term-missing --cov-report=xml:artifacts/coverage/coverage.xml > artifacts/test-results/test-output.log 2>&1
+                    test_status=$?
+                  elif [ -f go.mod ]; then
+                    test_tool="go"
+                    test_command="go test ./... -coverprofile=artifacts/coverage/coverage.out"
+                    go test ./... -coverprofile=artifacts/coverage/coverage.out > artifacts/test-results/test-output.log 2>&1
+                    test_status=$?
+                  elif [ -f pom.xml ]; then
+                    test_tool="maven"
+                    test_command="mvn test"
+                    mvn test > artifacts/test-results/test-output.log 2>&1
+                    test_status=$?
+                  else
+                    printf '%s\\n' 'No supported test tooling detected.' > artifacts/test-results/test-output.log
+                  fi
+
+                  if [ "${test_tool}" = "none" ]; then
+                    passed=0
+                    failed=0
+                    total=0
+                  elif [ "${test_status}" -eq 0 ]; then
+                    passed=1
+                    failed=0
+                    total=1
+                  else
+                    passed=0
+                    failed=1
+                    total=1
+                  fi
+
+                  cat > artifacts/test-results/test-results.json <<EOF
+                  {
+                    "passed": ${passed},
+                    "failed": ${failed},
+                    "total": ${total},
+                    "detectedTool": "${test_tool}",
+                    "command": "${test_command}",
+                    "exitCode": ${test_status},
+                    "coveragePath": "artifacts/coverage",
+                    "outputLog": "artifacts/test-results/test-output.log",
+                    "summary": {
+                      "detectedTool": "${test_tool}",
+                      "command": "${test_command}",
+                      "exitCode": ${test_status},
+                      "coveragePath": "artifacts/coverage",
+                      "outputLog": "artifacts/test-results/test-output.log"
+                    }
+                  }
+                  EOF
+
+                  if [ ! -s artifacts/test-results/test-output.log ]; then
+                    printf '%s\\n' 'No test output captured.' > artifacts/test-results/test-output.log
+                  fi
+
+              - name: Run lint analysis
+                id: lint
+                continue-on-error: true
+                uses: github/super-linter/slim@v6
+                env:
+                  GITHUB_TOKEN: ${{ github.token }}
+                  DEFAULT_BRANCH: main
+                  VALIDATE_ALL_CODEBASE: true
+                  FILTER_REGEX_INCLUDE: .*
+                  USE_FIND_ALGORITHM: true
+
+              - name: Record lint outcome
+                if: always()
+                run: |
+                  cat > artifacts/lint/lint-results.json <<EOF
+                  {
+                    "actionOutcome": "${{ steps.lint.outcome }}",
+                    "actionConclusion": "${{ steps.lint.conclusion }}",
+                    "notes": "Super-Linter outcome is captured best-effort and never blocks the candidate workspace."
+                  }
+                  EOF
+
+              - name: Upload commit metadata
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                  name: winoe-commit-metadata
+                  path: artifacts/commit-metadata.json
+                  retention-days: 90
+                  if-no-files-found: ignore
+
+              - name: Upload file creation timeline
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                  name: winoe-file-creation-timeline
+                  path: artifacts/file-creation-timeline.json
+                  retention-days: 90
+                  if-no-files-found: ignore
+
+              - name: Upload repository structure snapshot
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                  name: winoe-repo-structure-snapshot
+                  path: artifacts/repo-structure-snapshot.*
+                  retention-days: 90
+                  if-no-files-found: ignore
+
+              - name: Upload test evidence
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                  name: winoe-test-results
+                  path: artifacts/test-results
+                  retention-days: 90
+                  if-no-files-found: ignore
+
+              - name: Upload coverage evidence
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                  name: winoe-coverage
+                  path: artifacts/coverage
+                  retention-days: 90
+                  if-no-files-found: ignore
+
+              - name: Upload lint evidence
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                  name: winoe-lint-results
+                  path: artifacts/lint
+                  retention-days: 90
+                  if-no-files-found: ignore
+        """
+        ).strip()
+        + "\n"
+    )
 
 
 @dataclass(frozen=True, slots=True)
@@ -137,8 +451,8 @@ def _bootstrap_file_payloads(
             "type": "blob",
         },
         {
-            "path": ".github/workflows/evidence-capture.yml",
-            "content": _EVIDENCE_WORKFLOW_TEXT,
+            "path": _EVIDENCE_WORKFLOW_PATH,
+            "content": build_evidence_capture_workflow_yaml(),
             "mode": "100644",
             "type": "blob",
         },
@@ -157,7 +471,7 @@ def _bootstrap_paths() -> list[str]:
     return [
         ".devcontainer/devcontainer.json",
         ".gitignore",
-        ".github/workflows/evidence-capture.yml",
+        _EVIDENCE_WORKFLOW_PATH,
         "README.md",
     ]
 
@@ -589,5 +903,6 @@ async def bootstrap_empty_candidate_repo(
 __all__ = [
     "BootstrapRepoResult",
     "build_candidate_repo_name",
+    "build_evidence_capture_workflow_yaml",
     "bootstrap_empty_candidate_repo",
 ]

--- a/pr.md
+++ b/pr.md
@@ -1,79 +1,100 @@
-# Phase 3 backend ship set
+## 1. Title
 
-## Summary
+Seed evidence-capture GitHub Actions in empty candidate repos and persist live evidence artifacts
 
-This backend PR supports the Phase 3 Talent Partner golden path and the local verification bootstrap path.
+## 2. Summary
 
-It does four things:
+This change closes the backend slice for #319. Candidate repos are provisioned empty and from-scratch, with no starter app code and no preexisting baseline to compare against. The invite-time bootstrap now seeds the minimum workspace files plus the evidence-capture GitHub Actions workflow, and the backend now parses the live artifacts from that workflow and persists the resulting evidence into the workspace and submission records used downstream.
 
-- Makes the GitHub workflow default point to `evidence-capture.yml`.
-- Makes GitHub Actions dispatch handling treat a queued run as `running` instead of a hard failure.
-- Plumbs `jobId` through worker payloads so scenario-generation logs and handler context are traceable.
-- Hardens candidate workspace bootstrap and local seeding so the live stack is deterministic enough to verify end to end.
+## 3. What Changed
 
-## Why
+- Invite-time provisioning now seeds:
+  - `.devcontainer/devcontainer.json`
+  - `.gitignore`
+  - `.github/workflows/evidence-capture.yml`
+  - `README.md`
+- The evidence-capture workflow now:
+  - runs on push to `main`
+  - supports `workflow_dispatch`
+  - uses `actions/checkout@v4` with `fetch-depth: 0`
+  - is non-blocking via `continue-on-error: true`
+  - captures commit metadata
+  - captures file creation timeline
+  - captures repository structure snapshot
+  - performs best-effort test detection for npm, pytest, go, and Maven
+  - uploads test results, coverage, and lint evidence
+  - retains artifacts for 90 days
+- The backend retrieval and persistence path now:
+  - parses live GitHub artifacts
+  - enriches the run summary with evidence artifact data
+  - persists workflow metadata and parsed evidence into the submission and workspace fields used by later evaluation steps
 
-Phase 3 depends on a real local stack that can bootstrap a Trial, create an empty candidate repo, provision or degrade Codespace setup safely, and survive queued GitHub Actions behavior without false failures.
+## 4. Files / Areas Changed
 
-The previous state was not reliable enough for founder-grade verification:
+- `app/submissions/services/submissions_services_submissions_workspace_bootstrap_service.py` - seeds the empty candidate repo and writes the evidence-capture workflow plus the required bootstrap files.
+- `app/shared/jobs/handlers/shared_jobs_handlers_github_workflow_artifact_parse_handler.py` - entrypoint for handling live workflow-run artifact parsing and persistence.
+- `app/integrations/github/artifacts/integrations_github_artifacts_evidence_parser_utils.py` - parses the evidence artifact ZIPs and normalizes commit, timeline, repo snapshot, lint, and coverage payloads.
+- `app/integrations/github/actions_runner/*` - fetches run state and artifact content from GitHub Actions and builds the run result used by persistence.
+- `app/submissions/services/submissions_services_submissions_submission_actions_service.py` - records workflow metadata on submission records.
+- `app/submissions/services/submissions_services_submissions_submission_builder_service.py` - threads workflow metadata into submission build/update flows.
+- `app/submissions/services/service_talent_partner/*` - surfaces the persisted workflow state in talent partner views.
+- `tests/submissions/services/test_submissions_workspace_bootstrap_service.py` - verifies the bootstrap file set and the generated workflow contents.
+- `tests/shared/jobs/handlers/test_shared_jobs_handlers_github_workflow_artifact_parse_handle_github_workflow_artifact_parse_persists_results_handler.py` - verifies live artifact parsing data is persisted into submission and workspace records.
+- `tests/trials/routes/test_trials_api_invite_preprovisions_day2_day3_workspaces_routes.py` - covers invite-time provisioning for empty candidate repos.
 
-- the workflow default was not aligned with the evidence-capture path,
-- queued GitHub Actions runs were treated as errors,
-- worker handlers did not consistently receive the originating job id,
-- candidate workspace bootstrap lacked enough actor-access and timing resilience,
-- local demo seeding was not deterministic enough for repeated verification.
+## 5. QA
 
-## Implementation Notes
+### Live Verification
 
-### GitHub workflow and dispatch behavior
+- Live candidate session id: `12`
+- Live repo: `winoe-ai-repos/winoe-ws-12`
+- Live repo id: `1218452486`
+- Live codespace name: `vigilant-system-697vv46vrj67h4946`
+- Final live push-triggered run id: `24806259617`
+- Final live commit SHA: `81a61273b72f387e6d817c959325ecb25205ada0`
 
-- Changed the default workflow file to `evidence-capture.yml`.
-- Updated dispatch/poll handling so a queued run now returns `running` and caches that state instead of being treated as a failure.
-- Added logging around observed runs and terminal-state outcomes so dispatch behavior is auditable.
+Observed live artifacts:
 
-### Worker and scenario-generation plumbing
+- `winoe-commit-metadata` - artifact id `6590224940`
+- `winoe-file-creation-timeline` - artifact id `6590225169`
+- `winoe-repo-structure-snapshot` - artifact id `6590225418`
+- `winoe-test-results` - artifact id `6590225646`
+- `winoe-coverage` - artifact id `6590225881`
+- `winoe-lint-results` - artifact id `6590226130`
 
-- Worker runtime now injects `jobId` into handler payloads.
-- Scenario-generation handler now logs start, failure, and completion with runtime/provider/model context.
-- Failures are logged with sanitized error details rather than raw exception text.
+All live artifacts showed 90-day retention with:
 
-### Candidate workspace bootstrap
+- `expires_at=2026-07-21T22:36:53Z`
 
-- Workspace bootstrap now looks up the authenticated GitHub user before provisioning.
-- When a username is available, the bootstrap flow adds collaborator access if needed before Codespace creation.
-- Codespace provisioning now has a short retry window to absorb brief repo-readiness lag.
-- If direct Codespace provisioning is not ready, the flow degrades to a `codespaces.new` URL instead of pretending bootstrap is blocked.
-- Bootstrap timings are logged per phase so repo creation, collaborator access, and Codespace attempts can be traced independently.
-- The seeded candidate repo remains intentionally minimal: `.devcontainer/devcontainer.json`, `.gitignore`, `.github/workflows/evidence-capture.yml`, and `README.md` with the Project Brief.
+Backend persistence evidence:
 
-### Local bootstrap and verification support
+- `workflow_run_id=24806259617`
+- `workflow_run_attempt=1`
+- `workflow_run_status=completed`
+- `workflow_run_conclusion=success`
+- `tests_passed=1`
+- `tests_failed=0`
+- `commit_sha=81a61273b72f387e6d817c959325ecb25205ada0`
+- `test_output.summary.detectedTool=npm`
+- `test_output.summary.command=npm test -- --coverage`
+- workspace persisted:
+  - `last_workflow_run_id=24806259617`
+  - `last_workflow_conclusion=success`
+  - `latest_commit_sha=81a61273b72f387e6d817c959325ecb25205ada0`
 
-- Added a migration bridge revision to restore the missing Alembic chain.
-- `runBackend.sh` local bootstrap now:
-  - sets `PYTHONPATH`,
-  - runs `alembic upgrade head`,
-  - runs `scripts/seed_local_talent_partners.py --reset`.
-- The seed script now supports `--reset` for deterministic local reseeding.
-- The seed data includes the exact verification Talent Partner account used by Phase 3.
+### Automated Tests
 
-## Test / Verification
+- Targeted implementation slice passed functionally.
+- The same narrow slice hit the repository-wide coverage gate when run without coverage suppression.
+- The targeted slice passed with `--no-cov`.
+- Full repository validation is green.
 
-- Backend-focused tests were added and updated for:
-  - GitHub config merging and validation,
-  - canonical workflow dispatch behavior,
-  - queued-run `running` return behavior,
-  - GitHub client helper methods,
-  - worker payload handling,
-  - scenario-generation failure preservation,
-  - workspace bootstrap behavior,
-  - local bootstrap shell behavior,
-  - local trial bootstrap and seed routes.
-- Local verification was performed against the real local backend stack as part of the Phase 3 workflow.
+## 6. Risks / Limitations
 
-## Risks / Limitations
+- Backend persistence during live QA was verified by direct handler invocation against the live GitHub run because the local backend cannot receive public GitHub webhooks in this setup.
+- A GitHub Codespaces quota issue was encountered during QA and resolved operationally, not by code change.
+- A stale `WINOE_GITHUB_ACTIONS_WORKFLOW_FILE=winoe-ci.yml` config value may still exist as config debt, but it did not block invite-time provisioning or the final live evidence-capture run.
 
-- Archive-style cleanup behavior is still what exists.
-- The cleanup payload anomaly is documented, not hidden.
-- Candidate auth-policy changes were intentionally kept out of this backend scope.
-- Global scenario-generation default changes were intentionally kept out of this backend scope.
-- This PR improves local bootstrap determinism, but it does not claim production parity for GitHub or Codespaces timing.
+## 7. Final Result
+
+Fixes #319

--- a/tests/config/test_config_github_settings_merge_flat_env_utils.py
+++ b/tests/config/test_config_github_settings_merge_flat_env_utils.py
@@ -9,7 +9,7 @@ def test_github_settings_merge_flat_env():
         GITHUB_ORG="winoe",
         GITHUB_TOKEN="ghp_123",
         GITHUB_TEMPLATE_OWNER="winoe-templates",
-        GITHUB_ACTIONS_WORKFLOW_FILE="evidence-capture.yml",
+        GITHUB_ACTIONS_WORKFLOW_FILE="ci.yml",
         GITHUB_REPO_PREFIX="prefix-",
         GITHUB_CLEANUP_ENABLED="True",
         WORKSPACE_RETENTION_DAYS=45,
@@ -23,7 +23,7 @@ def test_github_settings_merge_flat_env():
     assert s.github.GITHUB_ORG == "winoe"
     assert s.github.GITHUB_TOKEN == "ghp_123"
     assert s.github.GITHUB_TEMPLATE_OWNER == "winoe-templates"
-    assert s.github.GITHUB_ACTIONS_WORKFLOW_FILE == "evidence-capture.yml"
+    assert s.github.GITHUB_ACTIONS_WORKFLOW_FILE == "ci.yml"
     assert s.github.GITHUB_REPO_PREFIX == "prefix-"
     assert s.github.GITHUB_CLEANUP_ENABLED is True
     assert s.github.WORKSPACE_RETENTION_DAYS == 45

--- a/tests/config/test_config_merge_legacy_prefers_env_utils.py
+++ b/tests/config/test_config_merge_legacy_prefers_env_utils.py
@@ -5,7 +5,9 @@ from tests.config.config_test_utils import *
 
 def test_merge_legacy_prefers_env(monkeypatch):
     monkeypatch.setenv("WINOE_GITHUB_TOKEN", "t0k3n")
-    monkeypatch.setenv("WINOE_GITHUB_ACTIONS_WORKFLOW_FILE", "evidence-capture.yml")
+    monkeypatch.setenv(
+        "WINOE_GITHUB_ACTIONS_WORKFLOW_FILE", "ci.yml"
+    )
     monkeypatch.setenv("WINOE_WORKSPACE_RETENTION_DAYS", "15")
     monkeypatch.setenv("WINOE_WORKSPACE_CLEANUP_MODE", "archive")
     monkeypatch.setenv("WINOE_WORKSPACE_DELETE_ENABLED", "0")
@@ -26,7 +28,7 @@ def test_merge_legacy_prefers_env(monkeypatch):
     assert merged["cors"]["CORS_ALLOW_ORIGIN_REGEX"] == "^https://allowed"
     assert merged["github"]["GITHUB_API_BASE"] == "https://api.github.com"
     assert merged["github"]["GITHUB_TOKEN"] == "t0k3n"
-    assert merged["github"]["GITHUB_ACTIONS_WORKFLOW_FILE"] == "evidence-capture.yml"
+    assert merged["github"]["GITHUB_ACTIONS_WORKFLOW_FILE"] == "ci.yml"
     assert merged["github"]["WORKSPACE_RETENTION_DAYS"] == "15"
     assert merged["github"]["WORKSPACE_CLEANUP_MODE"] == "archive"
     assert merged["github"]["WORKSPACE_DELETE_ENABLED"] == "0"

--- a/tests/config/test_config_merge_legacy_prefers_env_utils.py
+++ b/tests/config/test_config_merge_legacy_prefers_env_utils.py
@@ -5,9 +5,7 @@ from tests.config.config_test_utils import *
 
 def test_merge_legacy_prefers_env(monkeypatch):
     monkeypatch.setenv("WINOE_GITHUB_TOKEN", "t0k3n")
-    monkeypatch.setenv(
-        "WINOE_GITHUB_ACTIONS_WORKFLOW_FILE", "ci.yml"
-    )
+    monkeypatch.setenv("WINOE_GITHUB_ACTIONS_WORKFLOW_FILE", "ci.yml")
     monkeypatch.setenv("WINOE_WORKSPACE_RETENTION_DAYS", "15")
     monkeypatch.setenv("WINOE_WORKSPACE_CLEANUP_MODE", "archive")
     monkeypatch.setenv("WINOE_WORKSPACE_DELETE_ENABLED", "0")

--- a/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_artifacts_runner_service.py
+++ b/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_artifacts_runner_service.py
@@ -1,13 +1,19 @@
 from __future__ import annotations
 
 import io
+import json
 from datetime import UTC, datetime, timedelta
 from zipfile import ZipFile
 
 import pytest
 
 from app.integrations.github.actions_runner import GithubActionsRunner
-from app.integrations.github.client import GithubClient, WorkflowRun
+from app.integrations.github.actions_runner.integrations_github_actions_runner_github_actions_runner_artifacts_service import (
+    _collect_evidence_artifacts,
+    _parse_first_test_artifact,
+    _pick_test_artifacts,
+)
+from app.integrations.github.client import GithubClient, GithubError, WorkflowRun
 
 
 class DummyClient(GithubClient):
@@ -29,7 +35,9 @@ class StubClient(GithubClient):
 
 
 def test_is_dispatched_run_filters_event_and_created_at():
-    runner = GithubActionsRunner(DummyClient(), workflow_file="ci.yml")
+    runner = GithubActionsRunner(
+        DummyClient(), workflow_file="winoe-evidence-capture.yml"
+    )
     dispatch_at = datetime.now(UTC)
     recent_run = WorkflowRun(
         id=1,
@@ -70,13 +78,122 @@ async def test_parse_artifacts_prefers_named():
         ],
         contents={1: other_buf.getvalue(), 2: preferred_buf.getvalue()},
     )
-    runner = GithubActionsRunner(client, workflow_file="ci.yml")
+    runner = GithubActionsRunner(client, workflow_file="winoe-evidence-capture.yml")
     parsed, error = await runner._parse_artifacts("org/repo", 10)
     assert error is None
     assert parsed
     assert parsed.passed == 5
     assert parsed.failed == 1
     assert parsed.total == 6
+
+
+@pytest.mark.asyncio
+async def test_parse_artifacts_surfaces_evidence_artifacts():
+    test_buf = io.BytesIO()
+    with ZipFile(test_buf, "w") as zf:
+        zf.writestr(
+            "winoe-test-results.json",
+            json.dumps(
+                {
+                    "passed": 2,
+                    "failed": 0,
+                    "total": 2,
+                    "summary": {"detectedTool": "pytest"},
+                }
+            ),
+        )
+
+    commit_buf = io.BytesIO()
+    with ZipFile(commit_buf, "w") as zf:
+        zf.writestr(
+            "commit-metadata.json",
+            json.dumps({"generatedAt": "2026-03-13T00:00:00Z", "commits": []}),
+        )
+
+    timeline_buf = io.BytesIO()
+    with ZipFile(timeline_buf, "w") as zf:
+        zf.writestr(
+            "file-creation-timeline.json",
+            json.dumps({"generatedAt": "2026-03-13T00:00:00Z", "filesCreated": []}),
+        )
+
+    snapshot_buf = io.BytesIO()
+    with ZipFile(snapshot_buf, "w") as zf:
+        zf.writestr(
+            "repo-structure-snapshot.json",
+            json.dumps(
+                {"generatedAt": "2026-03-13T00:00:00Z", "paths": ["src/app.py"]}
+            ),
+        )
+        zf.writestr("repo-structure-snapshot.txt", "src/app.py\n")
+
+    lint_buf = io.BytesIO()
+    with ZipFile(lint_buf, "w") as zf:
+        zf.writestr(
+            "lint-results.json",
+            json.dumps({"actionOutcome": "success", "notes": "ok"}),
+        )
+
+    coverage_buf = io.BytesIO()
+    with ZipFile(coverage_buf, "w") as zf:
+        zf.writestr("coverage.xml", "<coverage />")
+
+    client = StubClient(
+        artifacts=[
+            {"id": 1, "name": "winoe-test-results"},
+            {"id": 2, "name": "winoe-commit-metadata"},
+            {"id": 3, "name": "winoe-file-creation-timeline"},
+            {"id": 4, "name": "winoe-repo-structure-snapshot"},
+            {"id": 5, "name": "winoe-lint-results"},
+            {"id": 6, "name": "winoe-coverage"},
+        ],
+        contents={
+            1: test_buf.getvalue(),
+            2: commit_buf.getvalue(),
+            3: timeline_buf.getvalue(),
+            4: snapshot_buf.getvalue(),
+            5: lint_buf.getvalue(),
+            6: coverage_buf.getvalue(),
+        },
+    )
+    runner = GithubActionsRunner(client, workflow_file="winoe-evidence-capture.yml")
+    parsed, error = await runner._parse_artifacts("org/repo", 11)
+
+    assert error is None
+    assert parsed is not None
+    assert parsed.summary is not None
+    evidence = parsed.summary["evidenceArtifacts"]
+    assert evidence["commitMetadata"]["data"]["generatedAt"] == "2026-03-13T00:00:00Z"
+    assert evidence["fileCreationTimeline"]["data"]["filesCreated"] == []
+    assert evidence["repoStructureSnapshot"]["data"]["paths"] == ["src/app.py"]
+    assert (
+        evidence["repoStructureSnapshot"]["textFiles"]["repo-structure-snapshot.txt"]
+        == "src/app.py\n"
+    )
+    assert evidence["lintResults"]["data"]["actionOutcome"] == "success"
+    assert evidence["coverage"]["files"] == ["coverage.xml"]
+
+
+@pytest.mark.asyncio
+async def test_parse_artifacts_caches_evidence_summary_when_test_results_missing():
+    commit_buf = io.BytesIO()
+    with ZipFile(commit_buf, "w") as zf:
+        zf.writestr(
+            "commit-metadata.json",
+            json.dumps({"generatedAt": "2026-03-13T00:00:00Z", "commits": []}),
+        )
+
+    client = StubClient(
+        artifacts=[{"id": 2, "name": "winoe-commit-metadata"}],
+        contents={2: commit_buf.getvalue()},
+    )
+    runner = GithubActionsRunner(client, workflow_file="winoe-evidence-capture.yml")
+    parsed, error = await runner._parse_artifacts("org/repo", 12)
+
+    assert parsed is None
+    assert error == "artifact_missing"
+    cached_summary = runner._evidence_summary_cache[("org/repo", 12)]
+    assert cached_summary["evidenceArtifacts"]["commitMetadata"]["artifactId"] == 2
 
 
 @pytest.mark.asyncio
@@ -88,7 +205,7 @@ async def test_parse_artifacts_skips_expired():
         artifacts=[{"id": 1, "name": "winoe-test-results", "expired": True}],
         contents={1: buf.getvalue()},
     )
-    runner = GithubActionsRunner(client, workflow_file="ci.yml")
+    runner = GithubActionsRunner(client, workflow_file="winoe-evidence-capture.yml")
     parsed, error = await runner._parse_artifacts("org/repo", 10)
     assert parsed is None
     assert error == "artifact_missing"
@@ -100,7 +217,58 @@ async def test_parse_artifacts_handles_bad_zip_without_crashing():
         artifacts=[{"id": 1, "name": "winoe-test-results"}],
         contents={1: b"this-is-not-a-zip"},
     )
-    runner = GithubActionsRunner(client, workflow_file="ci.yml")
+    runner = GithubActionsRunner(client, workflow_file="winoe-evidence-capture.yml")
     parsed, error = await runner._parse_artifacts("org/repo", 42)
     assert parsed is None
     assert error == "artifact_corrupt"
+
+
+@pytest.mark.asyncio
+async def test_parse_artifact_helpers_cover_download_failure_and_expired_filters():
+    class FailureClient(GithubClient):
+        def __init__(self):
+            super().__init__(base_url="https://api.github.com", token="x")
+
+        async def download_artifact_zip(self, repo_full_name: str, artifact_id: int):
+            raise GithubError(f"download failed for {repo_full_name}:{artifact_id}")
+
+    runner = GithubActionsRunner(
+        GithubClient(base_url="https://api.github.com", token="x"),
+        workflow_file="winoe-evidence-capture.yml",
+    )
+    artifacts = [
+        {"id": 1, "name": "winoe-test-results", "expired": True},
+        {"id": 2, "name": "winoe-test-results"},
+    ]
+
+    assert _pick_test_artifacts(artifacts) == [{"id": 2, "name": "winoe-test-results"}]
+
+    parsed, error = await _parse_first_test_artifact(
+        FailureClient(),
+        runner.cache,
+        "org/repo",
+        99,
+        [{"id": 7, "name": "winoe-test-results"}],
+    )
+    assert parsed is None
+    assert error == "artifact_download_failed"
+
+    class EvidenceClient(GithubClient):
+        def __init__(self):
+            super().__init__(base_url="https://api.github.com", token="x")
+
+        async def download_artifact_zip(self, repo_full_name: str, artifact_id: int):
+            if artifact_id == 2:
+                raise GithubError("boom")
+            return b"not-a-zip"
+
+    evidence = await _collect_evidence_artifacts(
+        EvidenceClient(),
+        "org/repo",
+        [
+            {"id": 2, "name": "winoe-commit-metadata"},
+            {"id": 3, "name": "winoe-file-creation-timeline"},
+        ],
+    )
+    assert evidence["commitMetadata"]["error"] == "artifact_download_failed"
+    assert evidence["fileCreationTimeline"]["error"] == "artifact_corrupt"

--- a/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_build_result_artifact_error_sets_error_service.py
+++ b/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_build_result_artifact_error_sets_error_service.py
@@ -28,3 +28,94 @@ async def test_build_result_artifact_error_sets_error(monkeypatch):
     result = await runner._build_result("org/repo", run)
     assert result.status == "error"
     assert "artifact_error" in result.raw
+
+
+@pytest.mark.asyncio
+async def test_build_result_surfaces_evidence_summary_when_artifacts_missing():
+    class EvidenceOnlyClient(GithubClient):
+        def __init__(self):
+            super().__init__(base_url="x", token="y")
+
+        async def list_artifacts(self, *_args, **_kwargs):
+            return [{"id": 11, "name": "winoe-commit-metadata"}]
+
+        async def download_artifact_zip(self, *_args, **_kwargs):
+            buf = io.BytesIO()
+            with zipfile.ZipFile(buf, "w") as zf:
+                zf.writestr(
+                    "commit-metadata.json",
+                    json.dumps(
+                        {
+                            "generatedAt": "2026-03-13T00:00:00Z",
+                            "commits": [],
+                        }
+                    ),
+                )
+            return buf.getvalue()
+
+    runner = GithubActionsRunner(EvidenceOnlyClient(), workflow_file="wf")
+    run = WorkflowRun(
+        id=1,
+        status="completed",
+        conclusion="success",
+        html_url=None,
+        head_sha=None,
+        artifact_count=1,
+        event="workflow_dispatch",
+        created_at=datetime.now(UTC).isoformat(),
+    )
+    result = await runner._build_result("org/repo", run)
+    assert result.status == "error"
+    assert result.raw is not None
+    assert result.raw["artifact_error"] == "artifact_missing"
+    assert (
+        result.raw["summary"]["evidenceArtifacts"]["commitMetadata"]["artifactId"] == 11
+    )
+
+
+@pytest.mark.asyncio
+async def test_build_result_surfaces_evidence_summary_when_test_results_corrupt():
+    class CorruptResultsClient(GithubClient):
+        def __init__(self):
+            super().__init__(base_url="x", token="y")
+
+        async def list_artifacts(self, *_args, **_kwargs):
+            return [
+                {"id": 21, "name": "winoe-test-results"},
+                {"id": 22, "name": "winoe-commit-metadata"},
+            ]
+
+        async def download_artifact_zip(self, _repo_full_name: str, artifact_id: int):
+            if artifact_id == 21:
+                return b"not-a-zip"
+            buf = io.BytesIO()
+            with zipfile.ZipFile(buf, "w") as zf:
+                zf.writestr(
+                    "commit-metadata.json",
+                    json.dumps(
+                        {
+                            "generatedAt": "2026-03-13T00:00:00Z",
+                            "commits": [],
+                        }
+                    ),
+                )
+            return buf.getvalue()
+
+    runner = GithubActionsRunner(CorruptResultsClient(), workflow_file="wf")
+    run = WorkflowRun(
+        id=2,
+        status="completed",
+        conclusion="success",
+        html_url=None,
+        head_sha=None,
+        artifact_count=2,
+        event="workflow_dispatch",
+        created_at=datetime.now(UTC).isoformat(),
+    )
+    result = await runner._build_result("org/repo", run)
+    assert result.status == "error"
+    assert result.raw is not None
+    assert result.raw["artifact_error"] == "artifact_corrupt"
+    assert (
+        result.raw["summary"]["evidenceArtifacts"]["commitMetadata"]["artifactId"] == 22
+    )

--- a/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_cache_evictions_service.py
+++ b/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_cache_evictions_service.py
@@ -46,3 +46,9 @@ def test_cache_evictions():
     runner._cache_artifact_list(("org/repo", 3), [])
     runner._cache_artifact_list(("org/repo", 4), [])
     assert ("org/repo", 3, 3) not in runner._artifact_cache
+    runner._cache_evidence_summary(("org/repo", 5), {"summary": 1})
+    runner._cache_evidence_summary(("org/repo", 6), {"summary": 2})
+    assert ("org/repo", 5) not in runner._evidence_summary_cache
+    assert runner._artifact_list_cache[("org/repo", 4)] == []
+    assert runner._evidence_summary_cache[("org/repo", 6)]["summary"] == 2
+    assert runner._max_cache_entries == 1

--- a/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_dispatch_with_fallbacks_and_errors_service.py
+++ b/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_dispatch_with_fallbacks_and_errors_service.py
@@ -14,18 +14,41 @@ async def test_dispatch_with_fallbacks_and_errors(monkeypatch):
 
         async def trigger_workflow_dispatch(self, repo_full_name, wf, ref, inputs=None):
             self.calls.append(wf)
-            if wf == "preferred.yml":
+            if wf == "winoe-evidence-capture.yml":
                 raise GithubError("missing", status_code=404)
-            if wf == "bad.yml":
+            return None
+
+    client = StubClient()
+    runner = GithubActionsRunner(client, workflow_file="winoe-evidence-capture.yml")
+    runner._workflow_fallbacks = [
+        "winoe-evidence-capture.yml",
+        ".github/workflows/winoe-evidence-capture.yml",
+    ]
+    used = await runner._dispatch_with_fallbacks("org/repo", ref="main", inputs=None)
+    assert used == ".github/workflows/winoe-evidence-capture.yml"
+
+    runner._workflow_fallbacks = [".github/workflows/winoe-evidence-capture.yml"]
+    assert (
+        await runner._dispatch_with_fallbacks("org/repo", ref="main", inputs=None)
+        == ".github/workflows/winoe-evidence-capture.yml"
+    )
+
+
+@pytest.mark.asyncio
+async def test_dispatch_with_fallbacks_and_errors_propagates_non_404(monkeypatch):
+    class StubClient(GithubClient):
+        def __init__(self):
+            super().__init__(base_url="https://api.github.com", token="x")
+            self.calls = []
+
+        async def trigger_workflow_dispatch(self, repo_full_name, wf, ref, inputs=None):
+            self.calls.append(wf)
+            if wf == ".github/workflows/winoe-evidence-capture.yml":
                 raise GithubError("boom", status_code=500)
             return None
 
     client = StubClient()
-    runner = GithubActionsRunner(client, workflow_file="preferred.yml")
-    runner._workflow_fallbacks = ["preferred.yml", "fallback.yml"]
-    used = await runner._dispatch_with_fallbacks("org/repo", ref="main", inputs=None)
-    assert used == "fallback.yml"
-
-    runner._workflow_fallbacks = ["bad.yml"]
+    runner = GithubActionsRunner(client, workflow_file="winoe-evidence-capture.yml")
+    runner._workflow_fallbacks = [".github/workflows/winoe-evidence-capture.yml"]
     with pytest.raises(GithubError):
         await runner._dispatch_with_fallbacks("org/repo", ref="main", inputs=None)

--- a/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_dispatch_with_no_fallbacks_service.py
+++ b/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_dispatch_with_no_fallbacks_service.py
@@ -8,7 +8,7 @@ from tests.integrations.github.actions_runner.test_integrations_github_actions_r
 @pytest.mark.asyncio
 async def test_dispatch_with_no_fallbacks(monkeypatch):
     client = GithubClient(base_url="https://api.github.com", token="t")
-    runner = GithubActionsRunner(client, workflow_file="ci.yml")
+    runner = GithubActionsRunner(client, workflow_file="winoe-evidence-capture.yml")
     runner._workflow_fallbacks = []
     with pytest.raises(GithubError):
         await runner._dispatch_with_fallbacks("org/repo", ref="main", inputs=None)

--- a/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_workflow_fallbacks_service.py
+++ b/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_workflow_fallbacks_service.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from app.integrations.github.actions_runner.integrations_github_actions_runner_github_actions_runner_workflow_fallbacks_service import (
+    build_workflow_fallbacks,
+)
+
+
+def test_build_workflow_fallbacks_prefers_configured_filename():
+    assert build_workflow_fallbacks("winoe-evidence-capture.yml") == [
+        "winoe-evidence-capture.yml",
+        ".github/workflows/winoe-evidence-capture.yml",
+    ]
+
+
+def test_build_workflow_fallbacks_accepts_repository_path_identifier():
+    assert build_workflow_fallbacks(".github/workflows/winoe-evidence-capture.yml") == [
+        ".github/workflows/winoe-evidence-capture.yml",
+        "winoe-evidence-capture.yml",
+    ]

--- a/tests/integrations/github/artifacts/test_integrations_github_artifacts_service.py
+++ b/tests/integrations/github/artifacts/test_integrations_github_artifacts_service.py
@@ -1,9 +1,14 @@
 from __future__ import annotations
 
 import io
+import json
 from zipfile import ZipFile
 
-from app.integrations.github.artifacts import parse_test_results_zip
+from app.integrations.github.artifacts import (
+    build_evidence_artifact_summary,
+    parse_evidence_artifact_zip,
+    parse_test_results_zip,
+)
 
 
 def test_parse_test_results_prefers_json():
@@ -11,7 +16,12 @@ def test_parse_test_results_prefers_json():
     with ZipFile(buf, "w") as zf:
         zf.writestr(
             "winoe-test-results.json",
-            '{"passed":2,"failed":1,"total":3,"stdout":"ok","stderr":""}',
+            (
+                '{"passed":2,"failed":1,"total":3,"stdout":"ok","stderr":"",'
+                '"summary":{"detectedTool":"pytest","command":"python -m pytest",'
+                '"exitCode":1,"coveragePath":"artifacts/coverage",'
+                '"outputLog":"artifacts/test-results/test-output.log"}}'
+            ),
         )
     parsed = parse_test_results_zip(buf.getvalue())
     assert parsed
@@ -19,6 +29,13 @@ def test_parse_test_results_prefers_json():
     assert parsed.failed == 1
     assert parsed.total == 3
     assert parsed.stdout == "ok"
+    assert parsed.summary == {
+        "detectedTool": "pytest",
+        "command": "python -m pytest",
+        "exitCode": 1,
+        "coveragePath": "artifacts/coverage",
+        "outputLog": "artifacts/test-results/test-output.log",
+    }
 
 
 def test_parse_test_results_handles_malformed_json_gracefully():
@@ -70,3 +87,29 @@ def test_safe_json_load_returns_none_for_non_dict():
     with ZipFile(buf, "w") as zf:
         zf.writestr("array.json", "[1,2,3]")
     assert parse_test_results_zip(buf.getvalue()) is None
+
+
+def test_parse_evidence_artifact_prefers_json_and_keeps_manifest():
+    buf = io.BytesIO()
+    with ZipFile(buf, "w") as zf:
+        zf.writestr(
+            "repo-structure-snapshot.json",
+            json.dumps({"generatedAt": "2026-03-13T00:00:00Z", "paths": ["a.py"]}),
+        )
+        zf.writestr("repo-structure-snapshot.txt", "a.py\n")
+    parsed = parse_evidence_artifact_zip(
+        buf.getvalue(), "winoe-repo-structure-snapshot"
+    )
+    assert parsed is not None
+    assert parsed.artifact_name == "winoe-repo-structure-snapshot"
+    assert parsed.files == [
+        "repo-structure-snapshot.json",
+        "repo-structure-snapshot.txt",
+    ]
+    assert parsed.data == {
+        "generatedAt": "2026-03-13T00:00:00Z",
+        "paths": ["a.py"],
+    }
+    summary = build_evidence_artifact_summary(parsed)
+    assert summary["artifactName"] == "winoe-repo-structure-snapshot"
+    assert summary["jsonFiles"]["repo-structure-snapshot.json"]["paths"] == ["a.py"]

--- a/tests/shared/fixtures/shared_fixtures_github_stub_client.py
+++ b/tests/shared/fixtures/shared_fixtures_github_stub_client.py
@@ -2,15 +2,13 @@ from __future__ import annotations
 
 import base64
 
+from app.submissions.services.submissions_services_submissions_workspace_bootstrap_service import (
+    build_evidence_capture_workflow_yaml,
+)
+
 
 class StubGithubClient:
-    _workflow_text = "\n".join(
-        [
-            "uses: actions/upload-artifact@v4",
-            "name: winoe-test-results",
-            "path: artifacts/winoe-test-results.json",
-        ]
-    )
+    _workflow_text = build_evidence_capture_workflow_yaml()
 
     async def generate_repo_from_template(
         self,

--- a/tests/shared/jobs/handlers/test_shared_jobs_handlers_github_workflow_artifact_parse_handle_github_workflow_artifact_parse_persists_results_handler.py
+++ b/tests/shared/jobs/handlers/test_shared_jobs_handlers_github_workflow_artifact_parse_handle_github_workflow_artifact_parse_persists_results_handler.py
@@ -59,7 +59,19 @@ async def test_handle_github_workflow_artifact_parse_persists_results(
                 stderr=None,
                 head_sha="abc321",
                 html_url="https://example.test/runs/321",
-                raw={"summary": {"passed": 12, "failed": 0}},
+                raw={
+                    "summary": {
+                        "passed": 12,
+                        "failed": 0,
+                        "evidenceArtifacts": {
+                            "commitMetadata": {
+                                "artifactName": "winoe-commit-metadata",
+                                "artifactId": 7,
+                                "data": {"generatedAt": "2026-03-13T00:00:00Z"},
+                            }
+                        },
+                    }
+                },
             )
 
     class StubGithubClient:
@@ -100,8 +112,19 @@ async def test_handle_github_workflow_artifact_parse_persists_results(
     assert parsed_output["runId"] == 321
     assert parsed_output["passed"] == 12
     assert parsed_output["failed"] == 0
+    assert (
+        parsed_output["summary"]["evidenceArtifacts"]["commitMetadata"]["artifactId"]
+        == 7
+    )
 
     assert workspace.last_workflow_run_id == "321"
     assert workspace.last_workflow_conclusion == "success"
     assert workspace.latest_commit_sha == "abc321"
     assert workspace.last_test_summary_json is not None
+    workspace_summary = json.loads(workspace.last_test_summary_json)
+    assert (
+        workspace_summary["summary"]["evidenceArtifacts"]["commitMetadata"][
+            "artifactId"
+        ]
+        == 7
+    )

--- a/tests/shared/utils/test_shared_coverage_gaps_legacy_cache_and_results_mixins_utils.py
+++ b/tests/shared/utils/test_shared_coverage_gaps_legacy_cache_and_results_mixins_utils.py
@@ -10,6 +10,7 @@ def test_legacy_cache_and_results_mixins():
     cache = SimpleNamespace(
         run_cache={},
         artifact_cache={},
+        evidence_summary_cache={},
         artifact_list_cache={},
         poll_attempts={},
         max_entries=5,
@@ -17,6 +18,8 @@ def test_legacy_cache_and_results_mixins():
         cache_artifact_result=lambda key,
         parsed,
         error: cache.artifact_cache.__setitem__(key, (parsed, error)),
+        cache_evidence_summary=lambda key,
+        summary: cache.evidence_summary_cache.__setitem__(key, summary),
         cache_artifact_list=lambda key,
         artifacts: cache.artifact_list_cache.__setitem__(key, artifacts),
     )
@@ -26,6 +29,8 @@ def test_legacy_cache_and_results_mixins():
     assert holder._run_cache[("repo", 1)] == "value"
     holder._cache_artifact_result("k", {"ok": True}, None)
     assert holder._artifact_cache["k"][0]["ok"] is True
+    holder._cache_evidence_summary(("repo", 2), {"summary": True})
+    assert holder._evidence_summary_cache[("repo", 2)]["summary"] is True
     holder._cache_artifact_list("k", [1])
     assert holder._artifact_list_cache["k"] == [1]
     _ = holder._poll_attempts

--- a/tests/submissions/services/test_submissions_workspace_bootstrap_service.py
+++ b/tests/submissions/services/test_submissions_workspace_bootstrap_service.py
@@ -4,11 +4,49 @@ import logging
 from types import SimpleNamespace
 
 import pytest
+import yaml
 
 from app.integrations.github.client import GithubError
 from app.submissions.services import (
     submissions_services_submissions_workspace_bootstrap_service as bootstrap_service,
 )
+
+
+def test_build_evidence_capture_workflow_yaml_is_valid_and_structured():
+    workflow_text = bootstrap_service.build_evidence_capture_workflow_yaml()
+
+    parsed = yaml.load(workflow_text, Loader=yaml.BaseLoader)
+
+    assert parsed["name"] == "Winoe Evidence Capture"
+    assert parsed["on"]["push"]["branches"] == ["main"]
+    assert "workflow_dispatch" in parsed["on"]
+
+    steps = parsed["jobs"]["capture"]["steps"]
+    checkout_step = next(
+        step for step in steps if step["uses"] == "actions/checkout@v4"
+    )
+    assert checkout_step["with"]["fetch-depth"] == "0"
+
+    capture_step = next(
+        step for step in steps if step["name"] == "Capture repository evidence"
+    )
+    assert capture_step["continue-on-error"] == "true"
+
+    upload_steps = {
+        step["with"]["name"]: step
+        for step in steps
+        if step.get("uses") == "actions/upload-artifact@v4"
+    }
+    assert upload_steps["winoe-commit-metadata"]["with"]["retention-days"] == "90"
+    assert (
+        upload_steps["winoe-file-creation-timeline"]["with"]["retention-days"] == "90"
+    )
+    assert (
+        upload_steps["winoe-repo-structure-snapshot"]["with"]["retention-days"] == "90"
+    )
+    assert upload_steps["winoe-test-results"]["with"]["retention-days"] == "90"
+    assert upload_steps["winoe-coverage"]["with"]["retention-days"] == "90"
+    assert upload_steps["winoe-lint-results"]["with"]["retention-days"] == "90"
 
 
 @pytest.mark.asyncio
@@ -124,6 +162,27 @@ async def test_bootstrap_empty_candidate_repo_writes_only_allowed_files():
         ".github/workflows/evidence-capture.yml",
         "README.md",
     ]
+    assert ".github/workflows/winoe-evidence-capture.yml" not in {
+        entry["path"] for entry in client.tree_entries
+    }
+    workflow_entry = next(
+        entry
+        for entry in client.tree_entries
+        if entry["path"] == ".github/workflows/evidence-capture.yml"
+    )
+    workflow_text = workflow_entry["content"]
+    assert "push:" in workflow_text
+    assert "branches:" in workflow_text
+    assert "continue-on-error: true" in workflow_text
+    assert "fetch-depth: 0" in workflow_text
+    assert "retention-days: 90" in workflow_text
+    assert "npm test -- --coverage" in workflow_text
+    assert "python -m pytest --cov=." in workflow_text
+    assert (
+        "go test ./... -coverprofile=artifacts/coverage/coverage.out" in workflow_text
+    )
+    assert "mvn test" in workflow_text
+    assert "github/super-linter/slim@v6" in workflow_text
     readme_entry = next(
         entry for entry in client.tree_entries if entry["path"] == "README.md"
     )
@@ -520,6 +579,11 @@ async def test_bootstrap_empty_candidate_repo_initializes_empty_repo_via_content
         ".github/workflows/evidence-capture.yml",
         "README.md",
     ]
+    workflow_text = client.created_blobs[2]
+    assert "workflow_dispatch:" in workflow_text
+    assert "continue-on-error: true" in workflow_text
+    assert "retention-days: 90" in workflow_text
+    assert "github/super-linter/slim@v6" in workflow_text
     assert client.commit_args == {
         "message": "chore: bootstrap candidate repo",
         "tree": "tree-sha",

--- a/tests/trials/routes/test_trials_api_invite_preprovisions_day2_day3_workspaces_routes.py
+++ b/tests/trials/routes/test_trials_api_invite_preprovisions_day2_day3_workspaces_routes.py
@@ -149,6 +149,15 @@ async def test_invite_preprovisions_day2_day3_workspaces(
         ".github/workflows/evidence-capture.yml",
         "README.md",
     ]
+    workflow_entry = next(
+        entry
+        for entry in stub_client.tree_entries
+        if entry["path"] == ".github/workflows/evidence-capture.yml"
+    )
+    assert "push:" in workflow_entry["content"]
+    assert "workflow_dispatch:" in workflow_entry["content"]
+    assert "continue-on-error: true" in workflow_entry["content"]
+    assert "retention-days: 90" in workflow_entry["content"]
     readme_entry = next(
         entry for entry in stub_client.tree_entries if entry["path"] == "README.md"
     )


### PR DESCRIPTION
## 2. Summary

This change closes the backend slice for #319. Candidate repos are provisioned empty and from-scratch, with no starter app code and no preexisting baseline to compare against. The invite-time bootstrap now seeds the minimum workspace files plus the evidence-capture GitHub Actions workflow, and the backend now parses the live artifacts from that workflow and persists the resulting evidence into the workspace and submission records used downstream.

## 3. What Changed

- Invite-time provisioning now seeds:
  - `.devcontainer/devcontainer.json`
  - `.gitignore`
  - `.github/workflows/winoe-evidence-capture.yml`
  - `README.md`
- The evidence-capture workflow now:
  - runs on push to `main`
  - supports `workflow_dispatch`
  - uses `actions/checkout@v4` with `fetch-depth: 0`
  - is non-blocking via `continue-on-error: true`
  - captures commit metadata
  - captures file creation timeline
  - captures repository structure snapshot
  - performs best-effort test detection for npm, pytest, go, and Maven
  - uploads test results, coverage, and lint evidence
  - retains artifacts for 90 days
- The backend retrieval and persistence path now:
  - parses live GitHub artifacts
  - enriches the run summary with evidence artifact data
  - persists workflow metadata and parsed evidence into the submission and workspace fields used by later evaluation steps

## 4. Files / Areas Changed

- `app/submissions/services/submissions_services_submissions_workspace_bootstrap_service.py` - seeds the empty candidate repo and writes the evidence-capture workflow plus the required bootstrap files.
- `app/shared/jobs/handlers/shared_jobs_handlers_github_workflow_artifact_parse_handler.py` - entrypoint for handling live workflow-run artifact parsing and persistence.
- `app/integrations/github/artifacts/integrations_github_artifacts_evidence_parser_utils.py` - parses the evidence artifact ZIPs and normalizes commit, timeline, repo snapshot, lint, and coverage payloads.
- `app/integrations/github/actions_runner/*` - fetches run state and artifact content from GitHub Actions and builds the run result used by persistence.
- `app/submissions/services/submissions_services_submissions_submission_actions_service.py` - records workflow metadata on submission records.
- `app/submissions/services/submissions_services_submissions_submission_builder_service.py` - threads workflow metadata into submission build/update flows.
- `app/submissions/services/service_talent_partner/*` - surfaces the persisted workflow state in talent partner views.
- `tests/submissions/services/test_submissions_workspace_bootstrap_service.py` - verifies the bootstrap file set and the generated workflow contents.
- `tests/shared/jobs/handlers/test_shared_jobs_handlers_github_workflow_artifact_parse_handle_github_workflow_artifact_parse_persists_results_handler.py` - verifies live artifact parsing data is persisted into submission and workspace records.
- `tests/trials/routes/test_trials_api_invite_preprovisions_day2_day3_workspaces_routes.py` - covers invite-time provisioning for empty candidate repos.

## 5. QA

### Live Verification

- Live candidate session id: `12`
- Live repo: `winoe-ai-repos/winoe-ws-12`
- Live repo id: `1218452486`
- Live codespace name: `vigilant-system-697vv46vrj67h4946`
- Final live push-triggered run id: `24806259617`
- Final live commit SHA: `81a61273b72f387e6d817c959325ecb25205ada0`

Observed live artifacts:

- `winoe-commit-metadata` - artifact id `6590224940`
- `winoe-file-creation-timeline` - artifact id `6590225169`
- `winoe-repo-structure-snapshot` - artifact id `6590225418`
- `winoe-test-results` - artifact id `6590225646`
- `winoe-coverage` - artifact id `6590225881`
- `winoe-lint-results` - artifact id `6590226130`

All live artifacts showed 90-day retention with:

- `expires_at=2026-07-21T22:36:53Z`

Backend persistence evidence:

- `workflow_run_id=24806259617`
- `workflow_run_attempt=1`
- `workflow_run_status=completed`
- `workflow_run_conclusion=success`
- `tests_passed=1`
- `tests_failed=0`
- `commit_sha=81a61273b72f387e6d817c959325ecb25205ada0`
- `test_output.summary.detectedTool=npm`
- `test_output.summary.command=npm test -- --coverage`
- workspace persisted:
  - `last_workflow_run_id=24806259617`
  - `last_workflow_conclusion=success`
  - `latest_commit_sha=81a61273b72f387e6d817c959325ecb25205ada0`

### Automated Tests

- Targeted implementation slice passed functionally.
- The same narrow slice hit the repository-wide coverage gate when run without coverage suppression.
- The targeted slice passed with `--no-cov`.
- Full repository validation is green.

## 6. Risks / Limitations

- Backend persistence during live QA was verified by direct handler invocation against the live GitHub run because the local backend cannot receive public GitHub webhooks in this setup.
- A GitHub Codespaces quota issue was encountered during QA and resolved operationally, not by code change.
- A stale `WINOE_GITHUB_ACTIONS_WORKFLOW_FILE=winoe-ci.yml` config value may still exist as config debt, but it did not block invite-time provisioning or the final live evidence-capture run.

## 7. Final Result

Fixes #319