### PR TITLE
Remove email-verification gating from candidate runtime flows

### DIFF
--- a/app/candidates/candidate_sessions/services/candidates_candidate_sessions_services_candidates_candidate_sessions_ownership_service.py
+++ b/app/candidates/candidate_sessions/services/candidates_candidate_sessions_services_candidates_candidate_sessions_ownership_service.py
@@ -2,25 +2,19 @@
 
 from __future__ import annotations
 
-import logging
-
 from fastapi import status
 
 from app.candidates.candidate_sessions.services.candidates_candidate_sessions_services_candidates_candidate_sessions_email_service import (
     normalize_email,
 )
-from app.config import settings
 from app.shared.auth.principal import Principal
 from app.shared.database.shared_database_models_model import CandidateSession
 from app.shared.utils.shared_utils_errors_utils import (
     CANDIDATE_AUTH_EMAIL_MISSING,
-    CANDIDATE_EMAIL_NOT_VERIFIED,
     CANDIDATE_INVITE_EMAIL_MISMATCH,
     CANDIDATE_SESSION_ALREADY_CLAIMED,
     ApiError,
 )
-
-logger = logging.getLogger(__name__)
 
 
 def _forbidden(
@@ -35,47 +29,13 @@ def _forbidden(
     )
 
 
-def ensure_email_verified(
-    principal: Principal, *, require_verified_claim_present: bool = False
-) -> None:
-    """Ensure email verified."""
-    email_verified = principal.claims.get("email_verified")
-    logger.info(
-        "candidate_email_verification_check env=%s email=%s sub=%s email_verified=%r require_verified_claim_present=%s",
-        settings.ENV,
-        principal.email,
-        principal.sub,
-        email_verified,
-        require_verified_claim_present,
-    )
-    if email_verified is False or (
-        require_verified_claim_present and email_verified is not True
-    ):
-        _forbidden(
-            "Authenticated email is not verified.",
-            CANDIDATE_EMAIL_NOT_VERIFIED,
-            details={
-                "candidateEmail": principal.email,
-                "candidateSub": principal.sub,
-                "emailVerified": email_verified,
-                "requireVerifiedClaimPresent": require_verified_claim_present,
-                "claimKeys": sorted([str(key) for key in principal.claims][:50]),
-            },
-        )
-
-
 def ensure_candidate_ownership(
     candidate_session: CandidateSession,
     principal: Principal,
     *,
     now,
-    require_verified_claim_present: bool = False,
 ) -> bool:
     """Ensure candidate ownership."""
-    ensure_email_verified(
-        principal,
-        require_verified_claim_present=require_verified_claim_present,
-    )
     email = normalize_email(principal.email)
     if not email:
         _forbidden(

--- a/app/candidates/candidate_sessions/services/candidates_candidate_sessions_services_candidates_candidate_sessions_schedule_helpers_service.py
+++ b/app/candidates/candidate_sessions/services/candidates_candidate_sessions_services_candidates_candidate_sessions_schedule_helpers_service.py
@@ -10,9 +10,6 @@ from fastapi import status
 from app.candidates.candidate_sessions.services.candidates_candidate_sessions_services_candidates_candidate_sessions_email_service import (
     normalize_email,
 )
-from app.candidates.candidate_sessions.services.candidates_candidate_sessions_services_candidates_candidate_sessions_ownership_service import (
-    ensure_email_verified,
-)
 from app.candidates.candidate_sessions.services.scheduling.candidates_candidate_sessions_services_scheduling_candidates_candidate_sessions_scheduling_day_windows_service import (
     coerce_utc_datetime,
 )
@@ -47,7 +44,6 @@ def _forbidden(detail: str, error_code: str) -> None:
 
 
 def _require_claimed_ownership(candidate_session, principal: Principal) -> bool:
-    ensure_email_verified(principal)
     email = normalize_email(principal.email)
     if not email:
         _forbidden(

--- a/app/shared/jobs/repositories/shared_jobs_repositories_repository_lookup_repository.py
+++ b/app/shared/jobs/repositories/shared_jobs_repositories_repository_lookup_repository.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import settings
 from app.shared.auth.principal import Principal
 from app.shared.database.shared_database_models_model import CandidateSession, User
 from app.shared.jobs.repositories.shared_jobs_repositories_models_repository import Job
@@ -57,8 +56,6 @@ async def _candidate_job(
     db: AsyncSession, job_id: str, principal: Principal
 ) -> Job | None:
     if "candidate:access" not in principal.permissions:
-        return None
-    if settings.ENV != "local" and principal.claims.get("email_verified") is False:
         return None
     email = normalize_email(principal.email)
     if not email:

--- a/pr.md
+++ b/pr.md
@@ -5,7 +5,6 @@ Stabilize Winoe Report generation, Evidence Trail integrity, and duplicate job p
 ## 2. Problem
 
 Winoe Report had three reliability issues on the active Winoe-facing path:
-
 - duplicate jobs and duplicate active work
 - hollow scored output, including empty rubric breakdowns and Evidence Trail loss risk
 - Day 4 being scored from failed transcript state
@@ -63,7 +62,6 @@ The read path also needed tightening:
   - provider and recommendation contract updates
 
 ## 5. Scope Note About Persona Governance
-
 - #295 now satisfies the non-determinative recommendation/output requirement and evidence-first report behavior on the active Winoe-facing path.
 - Full `SOUL.md`-based persona governance is not claimed in this PR and remains tracked separately in #298.
 

--- a/tests/candidates/routes/test_candidates_session_api_claim_endpoint_rejects_unverified_email_routes.py
+++ b/tests/candidates/routes/test_candidates_session_api_claim_endpoint_rejects_unverified_email_routes.py
@@ -6,7 +6,7 @@ from tests.candidates.routes.candidates_session_api_utils import *
 
 
 @pytest.mark.asyncio
-async def test_claim_endpoint_rejects_unverified_email(
+async def test_claim_endpoint_allows_unverified_email_claims(
     async_client, async_session, override_dependencies
 ):
     talent_partner = await create_talent_partner(
@@ -23,5 +23,5 @@ async def test_claim_endpoint_rejects_unverified_email(
             f"/api/candidate/session/{cs.token}/claim",
             headers={"Authorization": "Bearer ignored"},
         )
-    assert res.status_code == 403
-    assert res.json()["errorCode"] == "CANDIDATE_EMAIL_NOT_VERIFIED"
+    assert res.status_code == 200, res.text
+    assert res.json()["status"] == "in_progress"

--- a/tests/candidates/routes/test_candidates_session_api_current_task_unclaimed_session_requires_verified_email_and_invite_match_routes.py
+++ b/tests/candidates/routes/test_candidates_session_api_current_task_unclaimed_session_requires_verified_email_and_invite_match_routes.py
@@ -6,7 +6,7 @@ from tests.candidates.routes.candidates_session_api_utils import *
 
 
 @pytest.mark.asyncio
-async def test_current_task_unclaimed_session_requires_verified_email_and_invite_match(
+async def test_current_task_unclaimed_session_requires_invite_match_and_claims_session_without_email_verification_gate(
     async_client, async_session, override_dependencies
 ):
     talent_partner = await create_talent_partner(
@@ -43,8 +43,7 @@ async def test_current_task_unclaimed_session_requires_verified_email_and_invite
 
     with override_dependencies({get_principal: _principal_unverified}):
         unverified = await async_client.get(route, headers=headers)
-    assert unverified.status_code == 403
-    assert unverified.json()["errorCode"] == "CANDIDATE_EMAIL_NOT_VERIFIED"
+    assert unverified.status_code == 200, unverified.text
 
     async def _principal_missing_verified():
         return _principal(

--- a/tests/candidates/services/test_candidates_session_schedule_service_schedule_candidate_session_success_idempotent_and_conflict_service.py
+++ b/tests/candidates/services/test_candidates_session_schedule_service_schedule_candidate_session_success_idempotent_and_conflict_service.py
@@ -73,3 +73,35 @@ async def test_schedule_candidate_session_success_persists_windows_and_jobs(
         assert job.next_run_at is not None
         assert job.idempotency_key.startswith("day_close_enforcement:")
         assert isinstance(job.payload_json["windowEndAt"], str)
+
+
+@pytest.mark.asyncio
+async def test_schedule_candidate_session_allows_unverified_email_on_claimed_session(
+    async_session,
+):
+    (
+        _tasks,
+        candidate_session,
+        _seeded_principal,
+        email_service,
+    ) = await _seed_claimed_schedule_context(async_session)
+    unverified_principal = _principal(
+        candidate_session.invite_email,
+        sub=candidate_session.candidate_auth0_sub,
+        email_verified=False,
+    )
+    now = datetime.now(UTC)
+
+    result = await schedule_service.schedule_candidate_session(
+        async_session,
+        token=candidate_session.token,
+        principal=unverified_principal,
+        scheduled_start_at=now + timedelta(days=1),
+        candidate_timezone="America/New_York",
+        github_username="octocat",
+        email_service=email_service,
+        now=now,
+    )
+    assert result.created is True
+    assert result.candidate_session.schedule_locked_at is not None
+    assert result.candidate_session.candidate_auth0_sub == candidate_session.candidate_auth0_sub

--- a/tests/candidates/services/test_candidates_session_schedule_service_schedule_candidate_session_success_idempotent_and_conflict_service.py
+++ b/tests/candidates/services/test_candidates_session_schedule_service_schedule_candidate_session_success_idempotent_and_conflict_service.py
@@ -104,4 +104,7 @@ async def test_schedule_candidate_session_allows_unverified_email_on_claimed_ses
     )
     assert result.created is True
     assert result.candidate_session.schedule_locked_at is not None
-    assert result.candidate_session.candidate_auth0_sub == candidate_session.candidate_auth0_sub
+    assert (
+        result.candidate_session.candidate_auth0_sub
+        == candidate_session.candidate_auth0_sub
+    )

--- a/tests/candidates/services/test_candidates_session_service_claim_invite_local_bypass_service.py
+++ b/tests/candidates/services/test_candidates_session_service_claim_invite_local_bypass_service.py
@@ -6,7 +6,7 @@ from tests.candidates.services.candidates_session_service_utils import *
 
 
 @pytest.mark.asyncio
-async def test_claim_invite_rejects_unverified_email_even_in_local_env(
+async def test_claim_invite_allows_unverified_email_even_in_local_env(
     async_session, monkeypatch
 ):
     monkeypatch.setattr(settings, "ENV", "local")
@@ -17,8 +17,8 @@ async def test_claim_invite_rejects_unverified_email_even_in_local_env(
     cs = await create_candidate_session(async_session, trial=sim)
     principal = _principal(cs.invite_email, email_verified=False)
 
-    with pytest.raises(HTTPException) as excinfo:
-        await cs_service.claim_invite_with_principal(async_session, cs.token, principal)
-
-    assert excinfo.value.status_code == 403
-    assert getattr(excinfo.value, "error_code", None) == "CANDIDATE_EMAIL_NOT_VERIFIED"
+    claimed = await cs_service.claim_invite_with_principal(
+        async_session, cs.token, principal
+    )
+    assert claimed.status == "in_progress"
+    assert claimed.candidate_auth0_sub == principal.sub

--- a/tests/candidates/services/test_candidates_session_service_claim_invite_requires_verified_email_service.py
+++ b/tests/candidates/services/test_candidates_session_service_claim_invite_requires_verified_email_service.py
@@ -6,7 +6,7 @@ from tests.candidates.services.candidates_session_service_utils import *
 
 
 @pytest.mark.asyncio
-async def test_claim_invite_requires_verified_email(async_session):
+async def test_claim_invite_allows_unverified_email_claims(async_session):
     talent_partner = await create_talent_partner(
         async_session, email="verify-req@sim.com"
     )
@@ -14,7 +14,8 @@ async def test_claim_invite_requires_verified_email(async_session):
     cs = await create_candidate_session(async_session, trial=sim)
     principal = _principal(cs.invite_email, email_verified=False)
 
-    with pytest.raises(HTTPException) as excinfo:
-        await cs_service.claim_invite_with_principal(async_session, cs.token, principal)
-    assert excinfo.value.status_code == 403
-    assert getattr(excinfo.value, "error_code", None) == "CANDIDATE_EMAIL_NOT_VERIFIED"
+    claimed = await cs_service.claim_invite_with_principal(
+        async_session, cs.token, principal
+    )
+    assert claimed.status == "in_progress"
+    assert claimed.candidate_auth0_sub == principal.sub

--- a/tests/candidates/services/test_candidates_session_service_ensure_candidate_ownership_variants_service.py
+++ b/tests/candidates/services/test_candidates_session_service_ensure_candidate_ownership_variants_service.py
@@ -6,7 +6,7 @@ from tests.candidates.services.candidates_session_service_utils import *
 
 
 def test_ensure_candidate_ownership_variants():
-    principal = _principal("owner@example.com")
+    principal = _principal("owner@example.com", email_verified=False)
     cs = type(
         "CS",
         (),
@@ -43,7 +43,7 @@ def test_ensure_candidate_ownership_variants():
     )
 
 
-def test_ensure_candidate_ownership_rejects_unverified_email_even_in_local_env(
+def test_ensure_candidate_ownership_allows_unverified_email_claims_in_local_env(
     monkeypatch,
 ):
     monkeypatch.setattr(settings, "ENV", "local")
@@ -59,6 +59,10 @@ def test_ensure_candidate_ownership_rejects_unverified_email_even_in_local_env(
             "status": "in_progress",
         },
     )()
-    with pytest.raises(HTTPException) as excinfo:
-        cs_service._ensure_candidate_ownership(cs, principal, now=datetime.now(UTC))
-    assert getattr(excinfo.value, "error_code", None) == "CANDIDATE_EMAIL_NOT_VERIFIED"
+    changed = cs_service._ensure_candidate_ownership(
+        cs, principal, now=datetime.now(UTC)
+    )
+    assert changed is True
+    assert cs.candidate_auth0_sub == principal.sub
+    assert cs.candidate_auth0_email == "owner@example.com"
+    assert cs.candidate_email == "owner@example.com"

--- a/tests/shared/jobs/repositories/test_shared_jobs_repository_get_by_id_for_principal_denies_unverified_candidate_repository.py
+++ b/tests/shared/jobs/repositories/test_shared_jobs_repository_get_by_id_for_principal_denies_unverified_candidate_repository.py
@@ -6,7 +6,7 @@ from tests.shared.jobs.repositories.shared_jobs_repository_utils import *
 
 
 @pytest.mark.asyncio
-async def test_get_by_id_for_principal_denies_unverified_candidate(async_session):
+async def test_get_by_id_for_principal_allows_unverified_candidate(async_session):
     talent_partner = await create_talent_partner(
         async_session, email="jobs-owner-unverified@test.com"
     )
@@ -34,4 +34,5 @@ async def test_get_by_id_for_principal_denies_unverified_candidate(async_session
     denied = await jobs_repo.get_by_id_for_principal(
         async_session, job.id, unverified_principal
     )
-    assert denied is None
+    assert denied is not None
+    assert denied.id == job.id


### PR DESCRIPTION
## 2. Problem

Candidate invite and runtime paths were still treating `email_verified` as a product gate in places where the real contract only depends on invite ownership and session state. That conflicted with the product rule that Auth0 owns email verification.

The result was an avoidable mismatch between the backend runtime checks and the candidate experience that the frontend now expects:

- sign-in state
- invite email match
- session ownership
- already-claimed handling
- invalid and expired invite handling

## 3. What Changed

- Removed the candidate ownership-layer email-verification check.
- Removed the extra verification gate from the schedule helper path.
- Removed the `email_verified` candidate-job short-circuit from shared job lookup.
- Updated claim route tests so unverified principals can claim when invite ownership matches.
- Updated current-task route tests so unverified principals can access a claimed session when ownership is correct.
- Updated schedule service tests so claimed sessions can still be scheduled with an unverified principal when the invite/session relationship is valid.
- Updated ownership and claim service tests to reflect that unverified principals are not blocked by runtime email-verification checks.

## 4. Why This Is Correct

Auth0 remains the source of truth for email verification, so the backend should not invent or enforce its own verification workflow.

These changes keep the real access controls intact:

- normalized email matching is still enforced
- invite ownership is still enforced
- claimed-session ownership is still enforced
- invalid and expired invite handling is unchanged

What changed is only the unnecessary runtime dependency on `email_verified`, which was preventing legitimate candidate flows from continuing even when invite ownership was correct.

## 5. Validation / QA

- Route tests now assert that unverified principals are allowed through the candidate claim and current-task paths when ownership matches.
- Service tests now cover unverified principals claiming and scheduling on a claimed session.
- Ownership-variant tests now confirm the claim/ownership path no longer fails just because `email_verified` is false or missing.

## 6. Risks / Follow-Ups

- Any remaining candidate-path code that still depends on `email_verified` should be audited so the old gate does not come back indirectly.
- Local-dev verification bypasses should remain tooling-only for QA support and must not be confused with product behavior.
- Backend issue `#283` only justified local-dev claim QA support, not a product-facing email-verification flow.

## 7. Final Result

Candidate runtime authorization now follows the intended contract without a backend-owned email-verification workflow, while preserving the actual invite ownership checks that protect the session.
