### PR TITLE
Fix Benchmarks data isolation so comparisons only include same-Trial candidates

### DIFF
--- a/app/trials/routes/trials_routes/trials_routes_trials_routes_trials_routes_candidates_compare_routes.py
+++ b/app/trials/routes/trials_routes/trials_routes_trials_routes_trials_routes_candidates_compare_routes.py
@@ -28,8 +28,9 @@ logger = logging.getLogger(__name__)
     status_code=status.HTTP_200_OK,
     summary="List Trial Candidates Compare",
     description=(
-        "Return side-by-side candidate progress and scoring signals for a"
-        " Talent Partner-owned trial."
+        "Return side-by-side candidate progress and public evidence-backed"
+        " signals for a Talent Partner-owned trial. Winoe does not decide who"
+        " to hire."
     ),
     responses={
         status.HTTP_403_FORBIDDEN: {"description": "Talent Partner access required."},
@@ -57,7 +58,7 @@ async def list_trial_candidates_compare(
         len(payload["candidates"]),
         latency_ms,
     )
-    return TrialCandidatesCompareResponse(**payload)
+    return TrialCandidatesCompareResponse.model_validate(payload)
 
 
 __all__ = ["router", "list_trial_candidates_compare"]

--- a/app/trials/schemas/trials_schemas_trials_compare_schema.py
+++ b/app/trials/schemas/trials_schemas_trials_compare_schema.py
@@ -16,6 +16,12 @@ CandidateCompareStatus = Literal[
     "evaluated",
 ]
 WinoeReportCompareStatus = Literal["none", "generating", "ready", "failed"]
+PublicCompareRecommendation = Literal[
+    "strong_signal",
+    "positive_signal",
+    "mixed_signal",
+    "limited_signal",
+]
 
 
 class TrialCandidateCompareItem(APIModel):
@@ -27,7 +33,7 @@ class TrialCandidateCompareItem(APIModel):
     status: CandidateCompareStatus
     winoeReportStatus: WinoeReportCompareStatus
     overallWinoeScore: float | None = None
-    recommendation: str | None = None
+    recommendation: PublicCompareRecommendation | None = None
     dayCompletion: dict[str, bool] = Field(default_factory=dict)
     updatedAt: datetime
 
@@ -36,11 +42,15 @@ class TrialCandidatesCompareResponse(APIModel):
     """Represent trial candidates compare response data and behavior."""
 
     trialId: int
+    cohortSize: int = 0
+    state: Literal["empty", "partial", "ready"] = "empty"
+    message: str | None = None
     candidates: list[TrialCandidateCompareItem] = Field(default_factory=list)
 
 
 __all__ = [
     "CandidateCompareStatus",
+    "PublicCompareRecommendation",
     "WinoeReportCompareStatus",
     "TrialCandidateCompareItem",
     "TrialCandidatesCompareResponse",

--- a/app/trials/services/trials_services_trials_candidates_compare_formatting_service.py
+++ b/app/trials/services/trials_services_trials_candidates_compare_formatting_service.py
@@ -5,8 +5,29 @@ from __future__ import annotations
 from typing import Any
 
 from app.evaluations.repositories.evaluations_repositories_evaluations_core_model import (
+    EVALUATION_RECOMMENDATION_HIRE,
+    EVALUATION_RECOMMENDATION_LEAN_HIRE,
+    EVALUATION_RECOMMENDATION_NO_HIRE,
+    EVALUATION_RECOMMENDATION_STRONG_HIRE,
     EVALUATION_RECOMMENDATIONS,
 )
+from app.trials.schemas.trials_schemas_trials_compare_schema import (
+    PublicCompareRecommendation,
+)
+
+_PUBLIC_RECOMMENDATIONS: set[PublicCompareRecommendation] = {
+    "strong_signal",
+    "positive_signal",
+    "mixed_signal",
+    "limited_signal",
+}
+
+_STORED_TO_PUBLIC_RECOMMENDATION = {
+    EVALUATION_RECOMMENDATION_STRONG_HIRE: "strong_signal",
+    EVALUATION_RECOMMENDATION_HIRE: "positive_signal",
+    EVALUATION_RECOMMENDATION_LEAN_HIRE: "mixed_signal",
+    EVALUATION_RECOMMENDATION_NO_HIRE: "limited_signal",
+}
 
 
 def anonymized_candidate_label(position: int) -> str:
@@ -42,14 +63,20 @@ def normalize_score(value: Any) -> float | None:
     return normalized if 0 <= normalized <= 1 else None
 
 
-def normalize_recommendation(value: Any) -> str | None:
+def normalize_recommendation(value: Any) -> PublicCompareRecommendation | None:
     """Normalize recommendation."""
     if not isinstance(value, str):
         return None
     normalized = value.strip().lower()
-    if not normalized or normalized not in EVALUATION_RECOMMENDATIONS:
+    if not normalized:
         return None
-    return normalized
+    if normalized in _PUBLIC_RECOMMENDATIONS:
+        return normalized
+    if normalized in _STORED_TO_PUBLIC_RECOMMENDATION:
+        return _STORED_TO_PUBLIC_RECOMMENDATION[normalized]
+    if normalized not in EVALUATION_RECOMMENDATIONS:
+        return None
+    return None
 
 
 __all__ = [

--- a/app/trials/services/trials_services_trials_candidates_compare_queries_service.py
+++ b/app/trials/services/trials_services_trials_candidates_compare_queries_service.py
@@ -83,7 +83,7 @@ def candidate_compare_rows_stmt(*, trial_id: int) -> Any:
             latest_run_success.c.candidate_session_id == CandidateSession.id,
         )
         .outerjoin(active_job, active_job.c.candidate_session_id == CandidateSession.id)
-        .where(Trial.id == trial_id)
+        .where(CandidateSession.trial_id == trial_id)
         .order_by(CandidateSession.id.asc())
     )
 

--- a/app/trials/services/trials_services_trials_candidates_compare_summary_service.py
+++ b/app/trials/services/trials_services_trials_candidates_compare_summary_service.py
@@ -85,6 +85,18 @@ def _build_candidate_summary(
     }
 
 
+def _build_cohort_state(cohort_size: int) -> tuple[str, str | None]:
+    if cohort_size == 0:
+        return "empty", "No completed Winoe Reports are available for this Trial yet."
+    if cohort_size < 3:
+        noun = "candidate" if cohort_size == 1 else "candidates"
+        return (
+            "partial",
+            f"Limited comparison — only {cohort_size} {noun} completed this Trial.",
+        )
+    return "ready", None
+
+
 async def list_candidates_compare_summary(
     db: AsyncSession,
     *,
@@ -96,7 +108,20 @@ async def list_candidates_compare_summary(
     """Return candidates compare summary."""
     access = await require_access(db, trial_id=trial_id, user=user)
     rows = await fetch_candidate_compare_rows(db, trial_id=trial_id)
-    session_ids = [int(row.candidate_session_id) for row in rows]
+    ready_rows = [
+        row
+        for row in rows
+        if derive_winoe_report_status(
+            has_ready_profile=(
+                getattr(row, "latest_success_candidate_session_id", None) is not None
+                or getattr(row, "winoe_report_generated_at", None) is not None
+            ),
+            latest_run_status=getattr(row, "latest_run_status", None),
+            has_active_job=getattr(row, "active_job_updated_at", None) is not None,
+        )
+        == "ready"
+    ]
+    session_ids = [int(row.candidate_session_id) for row in ready_rows]
     (
         day_completion_by_session,
         latest_submission_by_session,
@@ -116,9 +141,16 @@ async def list_candidates_compare_summary(
                 int(row.candidate_session_id)
             ),
         )
-        for index, row in enumerate(rows)
+        for index, row in enumerate(ready_rows)
     ]
-    return {"trialId": access.trial_id, "candidates": candidates}
+    state, message = _build_cohort_state(len(candidates))
+    return {
+        "trialId": access.trial_id,
+        "cohortSize": len(candidates),
+        "state": state,
+        "message": message,
+        "candidates": candidates,
+    }
 
 
 __all__ = ["list_candidates_compare_summary"]

--- a/pr.md
+++ b/pr.md
@@ -1,122 +1,126 @@
-## Title
+# Summary
 
-Materialize per-Trial Winoe and company rubric snapshots for all five days
+Benchmarks now compare candidates only within the same Trial, preserving Winoe AI's fairness and evidence-trust guarantees.
 
-## Summary
+The public response now includes `cohortSize`, `state`, `message`, and public-only signal values in `recommendation`.
 
-This PR materializes immutable rubric snapshots per `ScenarioVersion` so every candidate in the same Trial is evaluated against the same Winoe baseline and any optional company-specific rubric content.
+# Changes
 
-Once snapshots exist, the pipeline consumes persisted snapshot content instead of mutable static rubric files. That freezes the evaluation inputs used by the Winoe Report and keeps Trial-level evaluation consistent over time.
+- Trial-scoped compare query/response path now filters Benchmarks to the requested Trial only.
+- Cohort metadata and empty/partial/ready states are returned in the live API contract.
+- Limited-comparison caveat is shown when cohort size is below 3.
+- Stored-to-public signal mapping is enforced:
+  - `strong_hire` -> `strong_signal`
+  - `hire` -> `positive_signal`
+  - `lean_hire` -> `mixed_signal`
+  - `no_hire` -> `limited_signal`
+- Public schema validation rejects internal hiring enums at the API boundary.
+- Singular/plural caveat copy is corrected so the message reads naturally for 1, 2, or 3+ candidates.
+- Route/API tests cover the contract behavior for 0, 1, 2, and 3+ candidate states.
+- Refresh-after-Winoe-Report-generation regression coverage confirms Benchmarks updates after new completed evaluations land.
+- Live-style smoke helper was added to exercise the contract against a running API instance.
 
-## What changed
+# QA / Verification
 
-- Added the `winoe_rubric_snapshots` persistence model and migration.
-- Added the `ScenarioVersion` relationship to rubric snapshots.
-- Added Trial-level `company_rubric_json` attachment support.
-- Added a Winoe rubric registry with explicit versions.
-- Added a snapshot materialization service with idempotency.
-- Materialized snapshots at the successful `ScenarioVersion` lifecycle boundary.
-- Added a lock-time deterministic backstop for legacy or incomplete rows.
-- Updated pipeline loading to use persisted rubric snapshot content.
-- Updated Winoe Report metadata to include rubric snapshot IDs, versions, hashes, and source paths.
-- Added tests covering persistence, idempotency, company rubric immutability, pipeline loading, report metadata, same-Trial reuse, fingerprint stability, and the scenario-generation failure regression.
+- Focused compare tests:
+  - `poetry run pytest --no-cov ...`
+  - Result: pass, `17 passed`
+- Full test suite:
+  - `poetry run pytest`
+  - Result: pass, `1846 passed`
+- Pre-commit:
+  - `poetry run pre-commit run --all-files` could not run because `pre-commit` was unavailable in the workspace.
+  - `poetry run python -m pre_commit run --all-files` could not run because the module was unavailable.
+  - The reported validation output showed coverage passing at `96.01%` with `1846 passed`.
 
-## Acceptance Criteria Coverage
+# Live HTTP Verification
 
-1. **Winoe rubrics versioned and referenced by `ScenarioVersion`**
+0 candidates:
 
-   The new `winoe_rubric_snapshots` table stores versioned baseline rubric material and is linked to `ScenarioVersion`. The registry carries explicit rubric versions, and snapshot materialization occurs at the successful `ScenarioVersion` lifecycle boundary so the frozen snapshot set is tied to that version, not to mutable source files.
+```json
+{"trialId":1,"cohortSize":0,"state":"empty","message":"No completed Winoe Reports are available for this Trial yet.","candidates":[]}
+```
 
-2. **Company-specific rubrics attachable per Trial**
+1 candidate:
 
-   `Trial.company_rubric_json` now carries optional company-specific rubric content. Company snapshots are materialized in the Trial scope, validated, and treated as immutable after materialization so the same Trial cannot drift between candidates.
+```json
+{"trialId":2,"cohortSize":1,"state":"partial","message":"Limited comparison — only 1 candidate completed this Trial.","candidates":[{"candidateSessionId":1,"recommendation":"positive_signal"}]}
+```
 
-3. **Version IDs in Winoe Report metadata**
+2 candidates:
 
-   `report.version.rubricSnapshots` now includes the full snapshot metadata needed for auditability:
+```json
+{"trialId":3,"cohortSize":2,"state":"partial","message":"Limited comparison — only 2 candidates completed this Trial.","candidates":[{"candidateSessionId":2,"recommendation":"mixed_signal"},{"candidateSessionId":3,"recommendation":"positive_signal"}]}
+```
 
-   - `snapshotId`
-   - `scenarioVersionId`
-   - `rubricScope`
-   - `rubricKind`
-   - `rubricKey`
-   - `rubricVersion`
-   - `contentHash`
-   - `sourcePath`
+3 candidates:
 
-4. **Pipeline loads correct versions**
+```json
+{"trialId":4,"cohortSize":3,"state":"ready","message":null,"candidates":[{"candidateSessionId":4,"recommendation":"strong_signal"},{"candidateSessionId":5,"recommendation":"positive_signal"},{"candidateSessionId":6,"recommendation":"mixed_signal"}]}
+```
 
-   The effective AI policy snapshot now persists `resolvedRubricMd`, and the evaluator bundle consumes that persisted snapshot content. This ensures the pipeline uses the exact rubric versions that were materialized for the Trial instead of rereading static files.
+Same-company/different-Trial isolation:
 
-## QA Evidence
+- Trial 2 returned candidate IDs `[1]`.
+- Trial 5 returned candidate ID `[7]`.
+- No cross-contamination between those Trials.
 
-Manual QA from Iteration 6:
+Different-company isolation:
 
-- `./runBackend.sh migrate` passed.
-- Schema verified:
-  - `winoe_rubric_snapshots`
-  - FK to `scenario_versions`
-  - uniqueness constraint on `(scenario_version_id, scope, rubric_kind, rubric_key, rubric_version)`
-  - `trials.company_rubric_json`
-- ScenarioVersion snapshot evidence:
-  - live `scenario_version_id = 7`
-  - 5 baseline snapshots
-  - snapshot IDs `[1, 2, 3, 4, 5]`
-- Idempotency:
-  - before first materialization: `0`
-  - after first: `5`
-  - after second: `5`
-  - IDs stable: `[1, 2, 3, 4, 5]`
-- Company rubric immutability:
-  - company `scenario_version_id = 8`
-  - company snapshot `id = 7`
-  - original hash: `a9fe9259f952749e8bf470065aa56e6174eb6ec3673f7bc276b798554f5bf80b`
-  - edited hash: `e0684b38150aca57fa0a46e1cf47d19234b05d3e9777171c116f49febf2885c8`
-  - persisted snapshot hash stayed unchanged: `a9fe9259f952749e8bf470065aa56e6174eb6ec3673f7bc276b798554f5bf80b`
-- Pipeline loading:
-  - `_read_text_file` patched to raise if static rubrics were reread
-  - report pipeline still completed for candidate sessions `7` and `8`
-  - effective bundle contained persisted `resolvedRubricMd`
-  - bundle snapshot IDs `[1, 2, 3, 4, 5]`
-- Winoe Report metadata:
-  - `fetch_winoe_report` returned `status: ready`
-  - metadata included `scenarioVersionId: 7`
-  - `rubricSnapshots` had 5 entries with required snapshot/version/hash/source fields
-- Same-Trial reuse:
-  - candidate sessions `7` and `8`
-  - shared `scenario_version_id = 7`
-  - both used snapshot IDs `[1, 2, 3, 4, 5]`
-- Scenario generation failure regression:
-  - focused tests passed functionally
-  - job failure/dead-letter behavior intact
-  - Trial remains `generating`
-  - retry still works
+```json
+{"status":403,"payload":{"detail":"Trial access forbidden"}}
+```
 
-## Automated Checks
+Authorization:
 
-- `./precommit.sh` passed
-- `1843 passed`
-- coverage: `96.04%`
-- `./runBackend.sh migrate` passed
-- forbidden terminology scan:
-  - newly introduced forbidden terms: `0`
-  - existing unrelated legacy matches remain outside the scope
+- Different-company access guard returned `403`.
+- Candidate-email dev request returned `401` in the local seeded DB because that dev user was not present.
 
-## Risks / Notes
+Refresh after Winoe Report generation:
 
-- Local QA rows for Trial and candidate test data remained in the local database because cleanup hit FK/check-constraint edges. This is local-only residue, not a code or migration issue.
-- Pipeline QA used a fake evaluator at the final scoring step to avoid external AI/provider dependence, while still exercising persisted snapshot loading and report metadata paths.
-- Existing unrelated legacy terminology remains in older repo areas and was not broadened by this PR.
+- Before report generation, Trial 7 returned `empty`.
+- After inserting the completed evaluation run, Trial 7 returned:
 
-## Final Checklist
+```json
+{"trialId":7,"cohortSize":1,"state":"partial","message":"Limited comparison — only 1 candidate completed this Trial.","candidates":[{"candidateSessionId":9,"recommendation":"strong_signal"}]}
+```
 
-- [x] Winoe baseline rubrics snapshotted per `ScenarioVersion`
-- [x] Company rubric attachment supported
-- [x] Snapshot materialization is idempotent
-- [x] Same Trial candidates reuse same rubric snapshots
-- [x] Evaluation pipeline consumes persisted snapshot content
-- [x] Winoe Report metadata includes snapshot/version/hash identifiers
-- [x] Scenario generation failure behavior preserved
-- [x] `./precommit.sh` passes
+# Risk / Notes
 
-Fixes #299
+- Live HTTP verification was performed against a local `uvicorn` instance with seeded sqlite data and dev-bypass auth.
+- The prior QA failure was caused by runtime drift and live verification mismatch; the route now explicitly validates the response model at the API boundary.
+- A live-style smoke helper was added to reduce the chance of this contract drifting again.
+
+# Acceptance Criteria Mapping
+
+- Compare only returns same-Trial candidates: covered by same-company/different-Trial and different-company checks.
+- No-data state for new Trials: covered by the 0-candidate payload.
+- Refreshes after report generation: covered by the Trial 7 before/after payload.
+- Framing does not imply Winoe decides: public signal values only; internal hiring enums are rejected.
+- 2+ same-Trial candidates: covered by the 2-candidate and 3-candidate payloads.
+- Cohort size: `cohortSize` is present in all payloads.
+- Limited caveat for cohort < 3: present for 1 and 2 candidates.
+- 0 -> 1 -> 2+ transitions: covered by the live HTTP payloads and tests.
+
+# Follow-ups
+
+- Consider wiring `scripts/compare_contract_smoke_test.py` into CI or the backend smoke pipeline.
+
+## Worker Report
+
+- Summary
+  - Benchmarks are now isolated to the requested Trial, with public contract fields and state handling that make the response predictable across 0, 1, 2, and 3+ candidate cohorts.
+- Files changed
+  - `pr.md`
+- Commands run
+  - `sed -n '1,240p' pr.md` - pass
+  - `sed -n '1,240p' issue.md` - pass
+  - `poetry run pytest --no-cov ...` - pass, `17 passed`
+  - `poetry run pytest` - pass, `1846 passed`
+  - `poetry run pre-commit run --all-files` - fail, `pre-commit` unavailable in the workspace
+  - `poetry run python -m pre_commit run --all-files` - fail, module unavailable
+- Risks / assumptions
+  - The live HTTP verification reflects a local `uvicorn` instance with seeded sqlite data and dev-bypass auth.
+  - The reported validation output is treated as the source of truth for the pre-commit/coverage status because the direct pre-commit commands could not execute.
+- Open questions / blockers
+  - None

--- a/scripts/compare_contract_smoke_test.py
+++ b/scripts/compare_contract_smoke_test.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""Smoke test the public compare contract against a running backend.
+
+Usage:
+  python scripts/compare_contract_smoke_test.py \
+    --base-url http://127.0.0.1:8000 \
+    --trial-id 123 \
+    --auth-token talent_partner:alice@example.com
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from urllib.error import HTTPError, URLError
+from urllib.request import Request, urlopen
+
+_INTERNAL_RECOMMENDATIONS = {
+    "hire",
+    "lean_hire",
+    "strong_hire",
+    "no_hire",
+    "reject",
+    "pass",
+    "fail",
+    "Winoe recommends",
+}
+
+_PUBLIC_RECOMMENDATIONS = {
+    "strong_signal",
+    "positive_signal",
+    "mixed_signal",
+    "limited_signal",
+}
+
+
+def _fail(message: str) -> None:
+    raise RuntimeError(message)
+
+
+def _assert_public_payload(payload: dict, *, expected_trial_id: int) -> None:
+    required_keys = {"trialId", "cohortSize", "state", "message", "candidates"}
+    if set(payload) != required_keys:
+        _fail(f"unexpected top-level keys: {sorted(payload)}")
+    if payload["trialId"] != expected_trial_id:
+        _fail(f"trialId mismatch: {payload['trialId']} != {expected_trial_id}")
+    if not isinstance(payload["candidates"], list):
+        _fail("candidates must be a list")
+    for row in payload["candidates"]:
+        if set(row) != {
+            "candidateSessionId",
+            "candidateName",
+            "candidateDisplayName",
+            "status",
+            "winoeReportStatus",
+            "overallWinoeScore",
+            "recommendation",
+            "dayCompletion",
+            "updatedAt",
+        }:
+            _fail(f"unexpected candidate keys: {sorted(row)}")
+        recommendation = row["recommendation"]
+        if recommendation is not None and recommendation not in _PUBLIC_RECOMMENDATIONS:
+            _fail(f"unexpected public recommendation: {recommendation}")
+        if recommendation in _INTERNAL_RECOMMENDATIONS:
+            _fail(f"internal recommendation leaked: {recommendation}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", required=True)
+    parser.add_argument("--trial-id", required=True, type=int)
+    parser.add_argument("--auth-token", required=True)
+    args = parser.parse_args()
+
+    url = f"{args.base_url.rstrip('/')}/api/trials/{args.trial_id}/candidates/compare"
+    request = Request(url, headers={"Authorization": f"Bearer {args.auth_token}"})
+    try:
+        with urlopen(request, timeout=30) as response:
+            body = response.read().decode("utf-8")
+            payload = json.loads(body)
+    except HTTPError as exc:
+        print(f"HTTP error: {exc.code} {exc.reason}", file=sys.stderr)
+        print(exc.read().decode("utf-8", errors="replace"), file=sys.stderr)
+        return 1
+    except URLError as exc:
+        print(f"Request failed: {exc}", file=sys.stderr)
+        return 1
+
+    _assert_public_payload(payload, expected_trial_id=args.trial_id)
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/shared/fixtures/shared_fixtures_client_utils.py
+++ b/tests/shared/fixtures/shared_fixtures_client_utils.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 
-import pytest_asyncio
+import pytest
 from fastapi import HTTPException, Request, status
 from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
@@ -20,8 +20,8 @@ from app.shared.http.dependencies.shared_http_dependencies_github_native_utils i
 from tests.shared.fixtures.shared_fixtures_github_stub_client import StubGithubClient
 
 
-@pytest_asyncio.fixture
-async def async_client(db_session: AsyncSession):
+@pytest.fixture
+def async_client(db_session: AsyncSession):
     async def override_get_session():
         yield db_session
 
@@ -82,10 +82,12 @@ async def async_client(db_session: AsyncSession):
     app.dependency_overrides[get_principal] = override_get_principal
     app.dependency_overrides[get_github_client] = lambda: StubGithubClient()
     transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+    client = AsyncClient(transport=transport, base_url="http://testserver")
+    try:
         yield client
-    await asyncio.sleep(0)
-    app.dependency_overrides.pop(get_session, None)
-    app.dependency_overrides.pop(get_current_user, None)
-    app.dependency_overrides.pop(get_principal, None)
-    app.dependency_overrides.pop(get_github_client, None)
+    finally:
+        asyncio.run(client.aclose())
+        app.dependency_overrides.pop(get_session, None)
+        app.dependency_overrides.pop(get_current_user, None)
+        app.dependency_overrides.pop(get_principal, None)
+        app.dependency_overrides.pop(get_github_client, None)

--- a/tests/shared/fixtures/shared_fixtures_core_utils.py
+++ b/tests/shared/fixtures/shared_fixtures_core_utils.py
@@ -4,7 +4,6 @@ import asyncio
 import os
 
 import pytest
-import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 from sqlalchemy.pool import NullPool, StaticPool
 
@@ -20,8 +19,8 @@ def anyio_backend() -> str:
     return "asyncio"
 
 
-@pytest_asyncio.fixture(scope="session")
-async def db_engine():
+@pytest.fixture(scope="session")
+def db_engine():
     test_url = os.getenv("TEST_DATABASE_URL") or "sqlite+aiosqlite:///:memory:"
     engine_kwargs = {
         "echo": False,
@@ -33,30 +32,41 @@ async def db_engine():
     else:
         engine_kwargs["poolclass"] = NullPool
     engine = create_async_engine(test_url, **engine_kwargs)
-    async with engine.begin() as conn:
-        await conn.run_sync(Base.metadata.create_all)
+
+    async def _create_schema() -> None:
+        async with engine.begin() as conn:
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(_create_schema())
     yield engine
-    await engine.dispose()
-    await asyncio.sleep(0)
+
+    asyncio.run(engine.dispose())
 
 
-@pytest_asyncio.fixture
-async def db_session(db_engine):
-    async with db_engine.begin() as conn:
-        await conn.run_sync(Base.metadata.drop_all)
-        await conn.run_sync(Base.metadata.create_all)
+@pytest.fixture
+def db_session(db_engine):
+    async def _reset_schema() -> None:
+        async with db_engine.begin() as conn:
+            await conn.run_sync(Base.metadata.drop_all)
+            await conn.run_sync(Base.metadata.create_all)
+
+    asyncio.run(_reset_schema())
     session_maker = async_sessionmaker(
         bind=db_engine,
         expire_on_commit=False,
         autoflush=False,
         class_=AsyncSession,
     )
-    async with session_maker() as session:
-        yield session
+    session = session_maker()
+    yield session
+
+    async def _close_session() -> None:
         await session.rollback()
-        await asyncio.sleep(0)
+        await session.close()
+
+    asyncio.run(_close_session())
 
 
-@pytest_asyncio.fixture(name="async_session")
-async def _async_session_alias(db_session: AsyncSession) -> AsyncSession:
+@pytest.fixture(name="async_session")
+def _async_session_alias(db_session: AsyncSession) -> AsyncSession:
     return db_session

--- a/tests/trials/routes/test_trials_candidates_compare_api_compare_orders_candidates_and_assigns_deterministic_display_names_routes.py
+++ b/tests/trials/routes/test_trials_candidates_compare_api_compare_orders_candidates_and_assigns_deterministic_display_names_routes.py
@@ -36,6 +36,24 @@ async def test_compare_orders_candidates_and_assigns_deterministic_display_names
         invite_email="order-third@example.com",
         status="not_started",
     )
+    await _create_ready_compare_run(
+        async_session,
+        candidate_session=first,
+        overall_winoe_score=0.51,
+        recommendation="mixed_signal",
+    )
+    await _create_ready_compare_run(
+        async_session,
+        candidate_session=second,
+        overall_winoe_score=0.63,
+        recommendation="mixed_signal",
+    )
+    await _create_ready_compare_run(
+        async_session,
+        candidate_session=third,
+        overall_winoe_score=0.74,
+        recommendation="strong_signal",
+    )
     await async_session.commit()
 
     response = await async_client.get(
@@ -45,6 +63,9 @@ async def test_compare_orders_candidates_and_assigns_deterministic_display_names
     assert response.status_code == 200, response.text
     payload = response.json()
 
+    assert payload["cohortSize"] == 3
+    assert payload["state"] == "ready"
+    assert payload["message"] is None
     assert [row["candidateSessionId"] for row in payload["candidates"]] == [
         first.id,
         second.id,
@@ -60,3 +81,19 @@ async def test_compare_orders_candidates_and_assigns_deterministic_display_names
         "Katherine Johnson",
         "Candidate C",
     ]
+    assert {row["recommendation"] for row in payload["candidates"]} <= {
+        "strong_signal",
+        "positive_signal",
+        "mixed_signal",
+        "limited_signal",
+    }
+    assert not {
+        "hire",
+        "lean_hire",
+        "strong_hire",
+        "no_hire",
+        "reject",
+        "pass",
+        "fail",
+        "Winoe recommends",
+    }.intersection({row["recommendation"] for row in payload["candidates"]})

--- a/tests/trials/routes/test_trials_candidates_compare_api_compare_refreshes_after_report_generation_routes.py
+++ b/tests/trials/routes/test_trials_candidates_compare_api_compare_refreshes_after_report_generation_routes.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.trials.routes.trials_candidates_compare_api_utils import *
+
+
+@pytest.mark.asyncio
+async def test_compare_refreshes_after_report_generation(
+    async_client, async_session, auth_header_factory
+):
+    talent_partner = await create_talent_partner(
+        async_session,
+        email="compare-refresh@test.com",
+    )
+    trial, _tasks = await create_trial(async_session, created_by=talent_partner)
+    candidate = await create_candidate_session(
+        async_session,
+        trial=trial,
+        candidate_name="Refresh Candidate",
+        invite_email="compare-refresh@example.com",
+        status="completed",
+    )
+    await async_session.commit()
+
+    first_response = await async_client.get(
+        f"/api/trials/{trial.id}/candidates/compare",
+        headers=auth_header_factory(talent_partner),
+    )
+    assert first_response.status_code == 200, first_response.text
+    first_payload = first_response.json()
+    assert first_payload["cohortSize"] == 0
+    assert first_payload["state"] == "empty"
+    assert first_payload["candidates"] == []
+
+    await _create_ready_compare_run(
+        async_session,
+        candidate_session=candidate,
+        overall_winoe_score=0.88,
+        recommendation="strong_signal",
+    )
+    await async_session.commit()
+
+    second_response = await async_client.get(
+        f"/api/trials/{trial.id}/candidates/compare",
+        headers=auth_header_factory(talent_partner),
+    )
+    assert second_response.status_code == 200, second_response.text
+    second_payload = second_response.json()
+    assert second_payload["cohortSize"] == 1
+    assert second_payload["state"] == "partial"
+    assert second_payload["message"] == (
+        "Limited comparison — only 1 candidate completed this Trial."
+    )
+    assert [row["candidateSessionId"] for row in second_payload["candidates"]] == [
+        candidate.id
+    ]
+    row = second_payload["candidates"][0]
+    assert row["overallWinoeScore"] == 0.88
+    assert row["recommendation"] == "strong_signal"
+    assert row["recommendation"] not in {
+        "hire",
+        "lean_hire",
+        "strong_hire",
+        "no_hire",
+        "reject",
+        "pass",
+        "fail",
+        "Winoe recommends",
+    }

--- a/tests/trials/routes/test_trials_candidates_compare_api_compare_returns_empty_candidates_for_trial_without_sessions_routes.py
+++ b/tests/trials/routes/test_trials_candidates_compare_api_compare_returns_empty_candidates_for_trial_without_sessions_routes.py
@@ -21,4 +21,11 @@ async def test_compare_returns_empty_candidates_for_trial_without_sessions(
         headers=auth_header_factory(talent_partner),
     )
     assert response.status_code == 200, response.text
-    assert response.json() == {"trialId": trial.id, "candidates": []}
+    payload = response.json()
+    assert payload == {
+        "trialId": trial.id,
+        "cohortSize": 0,
+        "state": "empty",
+        "message": "No completed Winoe Reports are available for this Trial yet.",
+        "candidates": [],
+    }

--- a/tests/trials/routes/test_trials_candidates_compare_api_compare_returns_summaries_with_winoe_report_statuses_and_nullable_fields_routes.py
+++ b/tests/trials/routes/test_trials_candidates_compare_api_compare_returns_summaries_with_winoe_report_statuses_and_nullable_fields_routes.py
@@ -17,6 +17,12 @@ async def test_compare_returns_summaries_with_winoe_report_statuses_and_nullable
         candidate_b,
         candidate_c,
     ) = await _seed_compare_candidates_scenario(async_session)
+    await _create_ready_compare_run(
+        async_session,
+        candidate_session=candidate_b,
+        overall_winoe_score=0.64,
+        recommendation="mixed_signal",
+    )
     trial_b, tasks_b = await create_trial(
         async_session,
         created_by=talent_partner,
@@ -56,7 +62,7 @@ async def test_compare_returns_summaries_with_winoe_report_statuses_and_nullable
         completed_at=datetime.now(UTC).replace(microsecond=0) - timedelta(minutes=8),
         generated_at=datetime.now(UTC).replace(microsecond=0) - timedelta(minutes=7),
         overall_winoe_score=0.95,
-        recommendation="hire",
+        recommendation="positive_signal",
         commit=False,
     )
     company = await async_session.get(Company, talent_partner.company_id)
@@ -69,6 +75,62 @@ async def test_compare_returns_summaries_with_winoe_report_statuses_and_nullable
         status="queued",
         idempotency_key="compare-job-candidate-d",
     )
+    other_company = await create_company(async_session, name="Other Compare Co")
+    other_partner = await create_talent_partner(
+        async_session,
+        company=other_company,
+        email="compare-other-company@test.com",
+    )
+    other_trial, other_tasks = await create_trial(
+        async_session,
+        created_by=other_partner,
+        title="Other Company Trial",
+    )
+    other_candidate = await create_candidate_session(
+        async_session,
+        trial=other_trial,
+        candidate_name="Other Company Ready",
+        invite_email="compare-other-company@example.com",
+        status="completed",
+        completed_at=datetime.now(UTC).replace(microsecond=0),
+    )
+    for index, task in enumerate(other_tasks):
+        await create_submission(
+            async_session,
+            candidate_session=other_candidate,
+            task=task,
+            submitted_at=datetime.now(UTC).replace(microsecond=0)
+            - timedelta(minutes=index + 10),
+            content_text=f"other-company day{task.day_index}",
+        )
+    await evaluation_repo.create_run(
+        async_session,
+        candidate_session_id=other_candidate.id,
+        scenario_version_id=other_candidate.scenario_version_id,
+        status=EVALUATION_RUN_STATUS_COMPLETED,
+        model_name="gpt-5-evaluator",
+        model_version="2026-03-12",
+        prompt_version="prompt.v1",
+        rubric_version="rubric.v1",
+        day2_checkpoint_sha="day2-sha-other",
+        day3_final_sha="day3-sha-other",
+        cutoff_commit_sha="cutoff-sha-other",
+        transcript_reference="transcript-ref-other",
+        started_at=datetime.now(UTC).replace(microsecond=0) - timedelta(minutes=12),
+        completed_at=datetime.now(UTC).replace(microsecond=0) - timedelta(minutes=11),
+        generated_at=datetime.now(UTC).replace(microsecond=0) - timedelta(minutes=10),
+        overall_winoe_score=0.67,
+        recommendation="mixed_signal",
+        commit=False,
+    )
+    await create_job(
+        async_session,
+        company=other_company,
+        candidate_session=other_candidate,
+        job_type=EVALUATION_RUN_JOB_TYPE,
+        status="queued",
+        idempotency_key="compare-job-other-candidate",
+    )
     await async_session.commit()
 
     response = await async_client.get(
@@ -79,14 +141,22 @@ async def test_compare_returns_summaries_with_winoe_report_statuses_and_nullable
     payload = response.json()
 
     assert payload["trialId"] == trial.id
+    assert payload["cohortSize"] == 2
+    assert payload["state"] == "partial"
+    assert payload["message"] == (
+        "Limited comparison — only 2 candidates completed this Trial."
+    )
     assert [row["candidateSessionId"] for row in payload["candidates"]] == [
-        candidate_a.id,
         candidate_b.id,
         candidate_c.id,
     ]
     assert all(
-        row["candidateSessionId"] != candidate_d.id for row in payload["candidates"]
+        row["candidateSessionId"] not in {candidate_a.id, candidate_d.id}
+        for row in payload["candidates"]
     )
+    assert other_candidate.id not in {
+        row["candidateSessionId"] for row in payload["candidates"]
+    }
 
     first = payload["candidates"][0]
     assert set(first.keys()) == {
@@ -100,14 +170,24 @@ async def test_compare_returns_summaries_with_winoe_report_statuses_and_nullable
         "dayCompletion",
         "updatedAt",
     }
-    assert first["candidateName"] == "Candidate A"
-    assert first["candidateDisplayName"] == "Candidate A"
-    assert first["status"] == "scheduled"
-    assert first["winoeReportStatus"] == "none"
-    assert first["overallWinoeScore"] is None
-    assert first["recommendation"] is None
+    assert first["candidateName"] == "Ada Lovelace"
+    assert first["candidateDisplayName"] == "Ada Lovelace"
+    assert first["status"] == "evaluated"
+    assert first["winoeReportStatus"] == "ready"
+    assert first["overallWinoeScore"] == 0.64
+    assert first["recommendation"] == "mixed_signal"
+    assert first["recommendation"] not in {
+        "hire",
+        "lean_hire",
+        "strong_hire",
+        "no_hire",
+        "reject",
+        "pass",
+        "fail",
+        "Winoe recommends",
+    }
     assert first["dayCompletion"] == {
-        "1": False,
+        "1": True,
         "2": False,
         "3": False,
         "4": False,
@@ -116,27 +196,49 @@ async def test_compare_returns_summaries_with_winoe_report_statuses_and_nullable
     assert isinstance(first["updatedAt"], str)
 
     second = payload["candidates"][1]
-    assert second["candidateName"] == "Ada Lovelace"
-    assert second["candidateDisplayName"] == "Ada Lovelace"
-    assert second["status"] == "in_progress"
-    assert second["winoeReportStatus"] == "generating"
-    assert second["overallWinoeScore"] is None
-    assert second["recommendation"] is None
-    assert second["dayCompletion"] == {
-        "1": True,
-        "2": False,
-        "3": False,
-        "4": False,
-        "5": False,
+    assert second["candidateName"] == "Grace Hopper"
+    assert second["candidateDisplayName"] == "Grace Hopper"
+    assert second["status"] == "evaluated"
+    assert second["winoeReportStatus"] == "ready"
+    assert second["overallWinoeScore"] == 0.78
+    assert second["recommendation"] == "positive_signal"
+    assert second["recommendation"] not in {
+        "hire",
+        "lean_hire",
+        "strong_hire",
+        "no_hire",
+        "reject",
+        "pass",
+        "fail",
+        "Winoe recommends",
     }
+    assert _all_days_true(second["dayCompletion"]) is True
     assert isinstance(second["updatedAt"], str)
 
-    third = payload["candidates"][2]
-    assert third["candidateName"] == "Grace Hopper"
-    assert third["candidateDisplayName"] == "Grace Hopper"
-    assert third["status"] == "evaluated"
-    assert third["winoeReportStatus"] == "ready"
-    assert third["overallWinoeScore"] == 0.78
-    assert third["recommendation"] == "hire"
-    assert _all_days_true(third["dayCompletion"]) is True
-    assert isinstance(third["updatedAt"], str)
+    trial_b_response = await async_client.get(
+        f"/api/trials/{trial_b.id}/candidates/compare",
+        headers=auth_header_factory(talent_partner),
+    )
+    assert trial_b_response.status_code == 200, trial_b_response.text
+    trial_b_payload = trial_b_response.json()
+    assert trial_b_payload["trialId"] == trial_b.id
+    assert trial_b_payload["cohortSize"] == 1
+    assert trial_b_payload["state"] == "partial"
+    assert trial_b_payload["message"] == (
+        "Limited comparison — only 1 candidate completed this Trial."
+    )
+    assert [row["candidateSessionId"] for row in trial_b_payload["candidates"]] == [
+        candidate_d.id,
+    ]
+    assert all(
+        row["candidateSessionId"]
+        not in {candidate_a.id, candidate_b.id, candidate_c.id}
+        for row in trial_b_payload["candidates"]
+    )
+    assert trial_b_payload["candidates"][0]["recommendation"] == "positive_signal"
+    assert trial_b_payload["candidates"][0]["recommendation"] not in {
+        "hire",
+        "reject",
+        "pass",
+        "fail",
+    }

--- a/tests/trials/routes/test_trials_candidates_compare_api_compare_state_and_isolation_routes.py
+++ b/tests/trials/routes/test_trials_candidates_compare_api_compare_state_and_isolation_routes.py
@@ -6,25 +6,25 @@ from tests.trials.routes.trials_candidates_compare_api_utils import *
 
 
 @pytest.mark.asyncio
-async def test_talent_partner_trials_compare_returns_public_signal_framing(
+async def test_compare_returns_partial_state_for_single_ready_candidate(
     async_client, async_session, auth_header_factory
 ):
     talent_partner = await create_talent_partner(
         async_session,
-        email="talent-partner-compare@test.com",
+        email="compare-single-ready@test.com",
     )
     trial, _tasks = await create_trial(async_session, created_by=talent_partner)
     candidate = await create_candidate_session(
         async_session,
         trial=trial,
-        candidate_name="Talent Partner Candidate",
-        invite_email="talent-partner-candidate@example.com",
+        candidate_name="Single Ready",
+        invite_email="compare-single-ready@example.com",
         status="completed",
     )
     await _create_ready_compare_run(
         async_session,
         candidate_session=candidate,
-        overall_winoe_score=0.74,
+        overall_winoe_score=0.81,
         recommendation="positive_signal",
     )
     await async_session.commit()
@@ -41,8 +41,15 @@ async def test_talent_partner_trials_compare_returns_public_signal_framing(
     assert payload["message"] == (
         "Limited comparison — only 1 candidate completed this Trial."
     )
-    assert payload["candidates"][0]["recommendation"] == "positive_signal"
-    assert payload["candidates"][0]["recommendation"] not in {
+    assert [row["candidateSessionId"] for row in payload["candidates"]] == [
+        candidate.id
+    ]
+    row = payload["candidates"][0]
+    assert row["candidateName"] == "Single Ready"
+    assert row["winoeReportStatus"] == "ready"
+    assert row["overallWinoeScore"] == 0.81
+    assert row["recommendation"] == "positive_signal"
+    assert row["recommendation"] not in {
         "hire",
         "lean_hire",
         "strong_hire",

--- a/tests/trials/routes/test_trials_candidates_compare_api_compare_updated_at_uses_fit_then_session_activity_precedence_routes.py
+++ b/tests/trials/routes/test_trials_candidates_compare_api_compare_updated_at_uses_fit_then_session_activity_precedence_routes.py
@@ -56,7 +56,28 @@ async def test_compare_updated_at_uses_fit_then_session_activity_precedence(
         completed_at=base - timedelta(minutes=12),
         generated_at=fit_generated_at,
         overall_winoe_score=0.71,
-        recommendation="lean_hire",
+        recommendation="mixed_signal",
+        commit=False,
+    )
+    session_generated_at = base - timedelta(minutes=8)
+    await evaluation_repo.create_run(
+        async_session,
+        candidate_session_id=session_candidate.id,
+        scenario_version_id=session_candidate.scenario_version_id,
+        status=EVALUATION_RUN_STATUS_COMPLETED,
+        model_name="gpt-5-evaluator",
+        model_version="2026-03-12",
+        prompt_version="prompt.v1",
+        rubric_version="rubric.v1",
+        day2_checkpoint_sha="day2-sha-2",
+        day3_final_sha="day3-sha-2",
+        cutoff_commit_sha="cutoff-sha-2",
+        transcript_reference="transcript-ref-2",
+        started_at=base - timedelta(minutes=11),
+        completed_at=base - timedelta(minutes=9),
+        generated_at=session_generated_at,
+        overall_winoe_score=0.62,
+        recommendation="mixed_signal",
         commit=False,
     )
     await async_session.commit()
@@ -72,5 +93,10 @@ async def test_compare_updated_at_uses_fit_then_session_activity_precedence(
     fit_row = rows_by_id[fit_candidate.id]
     session_row = rows_by_id[session_candidate.id]
 
+    assert payload["cohortSize"] == 2
+    assert payload["state"] == "partial"
+    assert payload["message"] == (
+        "Limited comparison — only 2 candidates completed this Trial."
+    )
     assert _parse_iso_utc(fit_row["updatedAt"]) == fit_generated_at
-    assert _parse_iso_utc(session_row["updatedAt"]) == base - timedelta(minutes=40)
+    assert _parse_iso_utc(session_row["updatedAt"]) == session_generated_at

--- a/tests/trials/routes/trials_candidates_compare_api_utils.py
+++ b/tests/trials/routes/trials_candidates_compare_api_utils.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime, timedelta
 
 from app.evaluations.repositories import repository as evaluation_repo
 from app.evaluations.repositories.evaluations_repositories_evaluations_core_model import (
+    EVALUATION_RECOMMENDATIONS,
     EVALUATION_RUN_STATUS_COMPLETED,
 )
 from app.evaluations.services.evaluations_services_evaluations_winoe_report_jobs_service import (
@@ -25,6 +26,23 @@ def _all_days_true(day_completion: dict[str, bool]) -> bool:
 
 def _parse_iso_utc(value: str) -> datetime:
     return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(UTC)
+
+
+_COMPARE_SIGNAL_TO_STORED_RECOMMENDATION = {
+    "strong_signal": "strong_hire",
+    "positive_signal": "hire",
+    "mixed_signal": "lean_hire",
+    "limited_signal": "no_hire",
+}
+
+
+def _stored_compare_recommendation(value: str) -> str:
+    normalized = value.strip().lower()
+    if normalized in _COMPARE_SIGNAL_TO_STORED_RECOMMENDATION:
+        return _COMPARE_SIGNAL_TO_STORED_RECOMMENDATION[normalized]
+    if normalized in EVALUATION_RECOMMENDATIONS:
+        return normalized
+    raise AssertionError(f"Unsupported compare recommendation: {value}")
 
 
 async def _seed_compare_candidates_scenario(async_session):
@@ -92,7 +110,7 @@ async def _seed_compare_candidates_scenario(async_session):
         completed_at=now - timedelta(minutes=16),
         generated_at=now - timedelta(minutes=15),
         overall_winoe_score=0.78,
-        recommendation="hire",
+        recommendation=_stored_compare_recommendation("positive_signal"),
         commit=False,
     )
     await create_job(
@@ -105,6 +123,47 @@ async def _seed_compare_candidates_scenario(async_session):
     )
     await async_session.commit()
     return talent_partner, trial, candidate_a, candidate_b, candidate_c
+
+
+async def _create_ready_compare_run(
+    async_session,
+    *,
+    candidate_session,
+    overall_winoe_score: float,
+    recommendation: str = "mixed_signal",
+    generated_at: datetime | None = None,
+    started_at: datetime | None = None,
+    completed_at: datetime | None = None,
+    model_name: str = "gpt-5-evaluator",
+    model_version: str = "2026-03-12",
+    prompt_version: str = "prompt.v1",
+    rubric_version: str = "rubric.v1",
+    day2_checkpoint_sha: str = "day2-sha",
+    day3_final_sha: str = "day3-sha",
+    cutoff_commit_sha: str = "cutoff-sha",
+    transcript_reference: str = "transcript-ref",
+):
+    now = datetime.now(UTC).replace(microsecond=0)
+    await evaluation_repo.create_run(
+        async_session,
+        candidate_session_id=candidate_session.id,
+        scenario_version_id=candidate_session.scenario_version_id,
+        status=EVALUATION_RUN_STATUS_COMPLETED,
+        model_name=model_name,
+        model_version=model_version,
+        prompt_version=prompt_version,
+        rubric_version=rubric_version,
+        day2_checkpoint_sha=day2_checkpoint_sha,
+        day3_final_sha=day3_final_sha,
+        cutoff_commit_sha=cutoff_commit_sha,
+        transcript_reference=transcript_reference,
+        started_at=started_at or now - timedelta(minutes=18),
+        completed_at=completed_at or now - timedelta(minutes=16),
+        generated_at=generated_at or now - timedelta(minutes=15),
+        overall_winoe_score=overall_winoe_score,
+        recommendation=_stored_compare_recommendation(recommendation),
+        commit=False,
+    )
 
 
 __all__ = [name for name in globals() if not name.startswith("__")]

--- a/tests/trials/schemas/test_trials_schemas_schema.py
+++ b/tests/trials/schemas/test_trials_schemas_schema.py
@@ -6,6 +6,9 @@ from app.trials.constants.trials_constants_trials_ai_config_constants import (
     AI_NOTICE_DEFAULT_TEXT,
     AI_NOTICE_DEFAULT_VERSION,
 )
+from app.trials.schemas.trials_schemas_trials_compare_schema import (
+    TrialCandidateCompareItem,
+)
 from app.trials.schemas.trials_schemas_trials_core_schema import (
     TrialDayWindowOverride,
     TrialDetailTask,
@@ -115,3 +118,31 @@ def test_build_trial_ai_config_falls_back_on_validation_error(monkeypatch):
         "4": True,
         "5": True,
     }
+
+
+def test_trial_candidates_compare_item_recommendation_uses_public_signals_only():
+    item = TrialCandidateCompareItem(
+        candidateSessionId=1,
+        candidateName="Candidate A",
+        candidateDisplayName="Candidate A",
+        status="evaluated",
+        winoeReportStatus="ready",
+        overallWinoeScore=0.91,
+        recommendation="positive_signal",
+        dayCompletion={"1": True, "2": True, "3": True, "4": True, "5": True},
+        updatedAt="2026-03-16T10:00:00Z",
+    )
+    assert item.recommendation == "positive_signal"
+
+    with pytest.raises(ValidationError):
+        TrialCandidateCompareItem(
+            candidateSessionId=1,
+            candidateName="Candidate A",
+            candidateDisplayName="Candidate A",
+            status="evaluated",
+            winoeReportStatus="ready",
+            overallWinoeScore=0.91,
+            recommendation="hire",
+            dayCompletion={"1": True, "2": True, "3": True, "4": True, "5": True},
+            updatedAt="2026-03-16T10:00:00Z",
+        )

--- a/tests/trials/services/test_trials_candidates_compare_service_compare_helpers_cover_edge_branches_service.py
+++ b/tests/trials/services/test_trials_candidates_compare_service_compare_helpers_cover_edge_branches_service.py
@@ -13,6 +13,11 @@ def test_compare_helpers_cover_edge_branches():
     assert compare_service._normalize_score(True) is None
     assert compare_service._normalize_score(1.2) is None
     assert compare_service._normalize_recommendation(" maybe ") is None
+    assert compare_service._normalize_recommendation("hire") == "positive_signal"
+    assert compare_service._normalize_recommendation("strong_hire") == "strong_signal"
+    assert compare_service._normalize_recommendation("lean_hire") == "mixed_signal"
+    assert compare_service._normalize_recommendation("no_hire") == "limited_signal"
+    assert compare_service._normalize_recommendation("mixed_signal") == "mixed_signal"
     assert (
         compare_service._candidate_session_created_at(
             SimpleNamespace(candidate_session_created_at="not-a-datetime")

--- a/tests/trials/services/test_trials_candidates_compare_service_list_candidates_compare_summary_applies_order_display_and_updated_at_precedence_service.py
+++ b/tests/trials/services/test_trials_candidates_compare_service_list_candidates_compare_summary_applies_order_display_and_updated_at_precedence_service.py
@@ -1,107 +1,97 @@
 from __future__ import annotations
 
-import pytest
+import asyncio
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
 
+from app.trials.services import (
+    trials_services_trials_candidates_compare_summary_service as compare_summary_service,
+)
 from tests.trials.services.trials_candidates_compare_service_utils import *
 
 
-@pytest.mark.asyncio
-async def test_list_candidates_compare_summary_applies_order_display_and_updated_at_precedence(
+def test_list_candidates_compare_summary_applies_order_display_and_updated_at_precedence(
     monkeypatch,
 ):
-    fit_timestamp = datetime(2026, 3, 16, 10, 15, tzinfo=UTC)
-    session_timestamp = datetime(2026, 3, 16, 9, 45, tzinfo=UTC)
-    created_timestamp = datetime(2026, 3, 16, 8, 30, tzinfo=UTC)
-
+    access = SimpleNamespace(trial_id=42)
+    report_time = datetime(2026, 3, 16, 10, 30, tzinfo=UTC)
+    session_time = datetime(2026, 3, 16, 9, 15, tzinfo=UTC)
     rows = [
         _candidate_row(
-            candidate_session_id=101,
+            candidate_session_id=11,
             candidate_name="   ",
             candidate_session_status="completed",
-            candidate_session_updated_at=fit_timestamp + timedelta(hours=1),
+            candidate_session_updated_at=session_time,
+            winoe_report_generated_at=report_time,
+            latest_success_candidate_session_id=11,
+            latest_success_generated_at=report_time,
             latest_run_status="completed",
-            latest_success_candidate_session_id=101,
-            overall_winoe_score=0.82,
-            recommendation="hire",
-            latest_success_completed_at=fit_timestamp,
+            overall_winoe_score=0.83,
+            recommendation="mixed_signal",
         ),
         _candidate_row(
-            candidate_session_id=102,
-            candidate_name="Ada Lovelace",
-            latest_run_status="running",
-        ),
-        _candidate_row(
-            candidate_session_id=103,
-            candidate_name="",
-            candidate_session_created_at=created_timestamp,
-        ),
-        _candidate_row(
-            candidate_session_id=104,
-            candidate_name="   ",
+            candidate_session_id=7,
+            candidate_name="Zed",
+            candidate_session_status="completed",
+            candidate_session_updated_at=session_time - timedelta(minutes=5),
+            latest_success_candidate_session_id=7,
+            latest_run_status="completed",
+            overall_winoe_score=0.67,
+            recommendation="positive_signal",
         ),
     ]
-    fake_db = _FakeDB([_RowsResult(rows)])
-    user = SimpleNamespace(id=700, company_id=55)
-    before_call = datetime.now(UTC).replace(microsecond=0)
-
-    monkeypatch.setattr(
-        compare_service,
-        "require_trial_compare_access",
-        AsyncMock(return_value=compare_service.TrialCompareAccessContext(trial_id=77)),
-    )
-    monkeypatch.setattr(
-        compare_service,
-        "_load_day_completion",
-        AsyncMock(
-            return_value=(
-                {
-                    101: _day_completion(completed_days={1, 2, 3, 4, 5}),
-                    102: _day_completion(completed_days={1}),
-                    103: _day_completion(),
-                    104: _day_completion(),
+    load_day_completion = AsyncMock(
+        return_value=(
+            {
+                11: {
+                    "1": True,
+                    "2": False,
+                    "3": False,
+                    "4": False,
+                    "5": False,
                 },
-                {
-                    101: None,
-                    102: session_timestamp,
-                    103: None,
-                    104: None,
+                7: {
+                    "1": True,
+                    "2": True,
+                    "3": True,
+                    "4": True,
+                    "5": True,
                 },
-            )
-        ),
+            },
+            {11: None, 7: session_time - timedelta(minutes=5)},
+        )
     )
 
-    payload = await list_candidates_compare_summary(
-        fake_db,
-        trial_id=77,
-        user=user,
+    fetch_rows = AsyncMock(return_value=rows)
+    monkeypatch.setattr(
+        compare_summary_service, "fetch_candidate_compare_rows", fetch_rows
     )
-    after_call = datetime.now(UTC).replace(microsecond=0)
 
-    assert "ORDER BY candidate_sessions.id ASC" in str(fake_db.executed_statements[0])
-    assert payload["trialId"] == 77
-    assert [c["candidateSessionId"] for c in payload["candidates"]] == [
-        101,
-        102,
-        103,
-        104,
-    ]
-    expected = [
-        ("Candidate A", "evaluated", "ready", fit_timestamp),
-        ("Ada Lovelace", "in_progress", "generating", session_timestamp),
-        ("Candidate C", "scheduled", "none", created_timestamp),
-    ]
-    for candidate, (name, status_value, winoe_report_status, updated_at) in zip(
-        payload["candidates"][:3],
-        expected,
-        strict=True,
-    ):
-        assert candidate["candidateName"] == name
-        assert candidate["candidateDisplayName"] == name
-        assert candidate["status"] == status_value
-        assert candidate["winoeReportStatus"] == winoe_report_status
-        assert candidate["updatedAt"] == updated_at
+    payload = asyncio.run(
+        compare_summary_service.list_candidates_compare_summary(
+            SimpleNamespace(),
+            trial_id=42,
+            user=SimpleNamespace(id=100, company_id=5),
+            require_access=AsyncMock(return_value=access),
+            load_day_completion_for_sessions=load_day_completion,
+        )
+    )
 
-    fourth = payload["candidates"][3]
-    assert fourth["candidateName"] == "Candidate D"
-    assert fourth["candidateDisplayName"] == "Candidate D"
-    assert before_call <= fourth["updatedAt"] <= after_call
+    assert payload["trialId"] == 42
+    assert payload["cohortSize"] == 2
+    assert payload["state"] == "partial"
+    assert payload["message"] == (
+        "Limited comparison — only 2 candidates completed this Trial."
+    )
+    assert [row["candidateSessionId"] for row in payload["candidates"]] == [11, 7]
+    assert payload["candidates"][0]["candidateName"] == "Candidate A"
+    assert payload["candidates"][0]["candidateDisplayName"] == "Candidate A"
+    assert payload["candidates"][0]["updatedAt"] == report_time
+    assert payload["candidates"][0]["recommendation"] == "mixed_signal"
+    assert payload["candidates"][1]["candidateName"] == "Zed"
+    assert payload["candidates"][1]["candidateDisplayName"] == "Zed"
+    assert payload["candidates"][1]["updatedAt"] == session_time - timedelta(minutes=5)
+    assert payload["candidates"][1]["recommendation"] == "positive_signal"
+    fetch_rows.assert_awaited_once()
+    assert load_day_completion.await_count == 1

--- a/tests/trials/services/test_trials_candidates_compare_service_scopes_to_selected_trial_service.py
+++ b/tests/trials/services/test_trials_candidates_compare_service_scopes_to_selected_trial_service.py
@@ -2,38 +2,35 @@ from __future__ import annotations
 
 import pytest
 
-from tests.shared.factories import create_candidate_session
-from tests.trials.services.trials_candidates_compare_service_utils import *
-from tests.trials.services.trials_core_service_utils import *
+from app.trials.services import (
+    trials_services_trials_candidates_compare_queries_service as compare_queries_service,
+)
+
+
+class _RowsResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def all(self):
+        return list(self._rows)
+
+
+class _FakeDB:
+    def __init__(self):
+        self.executed_stmt = None
+
+    async def execute(self, stmt):
+        self.executed_stmt = stmt
+        return _RowsResult([])
 
 
 @pytest.mark.asyncio
-async def test_list_candidates_compare_summary_scopes_to_selected_trial(async_session):
-    talent_partner = await create_talent_partner(async_session, email="bench@test.com")
-    first_trial, _ = await create_trial(async_session, created_by=talent_partner)
-    second_trial, _ = await create_trial(async_session, created_by=talent_partner)
+async def test_fetch_candidate_compare_rows_scopes_to_selected_trial():
+    db = _FakeDB()
 
-    first_session = await create_candidate_session(
-        async_session,
-        trial=first_trial,
-        invite_email="candidate-a@example.com",
-        candidate_name="Candidate A",
-    )
-    await create_candidate_session(
-        async_session,
-        trial=second_trial,
-        invite_email="candidate-b@example.com",
-        candidate_name="Candidate B",
-    )
-    await async_session.commit()
+    rows = await compare_queries_service.fetch_candidate_compare_rows(db, trial_id=42)
 
-    payload = await list_candidates_compare_summary(
-        async_session,
-        trial_id=first_trial.id,
-        user=talent_partner,
-    )
-
-    assert payload["trialId"] == first_trial.id
-    assert [row["candidateSessionId"] for row in payload["candidates"]] == [
-        first_session.id
-    ]
+    assert rows == []
+    sql = str(db.executed_stmt).lower().replace('"', "")
+    assert "join trials on trials.id = candidate_sessions.trial_id" in sql
+    assert "where candidate_sessions.trial_id =" in sql


### PR DESCRIPTION
# Summary

Benchmarks now compare candidates only within the same Trial, preserving Winoe AI's fairness and evidence-trust guarantees.

The public response now includes `cohortSize`, `state`, `message`, and public-only signal values in `recommendation`.

# Changes

- Trial-scoped compare query/response path now filters Benchmarks to the requested Trial only.
- Cohort metadata and empty/partial/ready states are returned in the live API contract.
- Limited-comparison caveat is shown when cohort size is below 3.
- Stored-to-public signal mapping is enforced:
  - `strong_hire` -> `strong_signal`
  - `hire` -> `positive_signal`
  - `lean_hire` -> `mixed_signal`
  - `no_hire` -> `limited_signal`
- Public schema validation rejects internal hiring enums at the API boundary.
- Singular/plural caveat copy is corrected so the message reads naturally for 1, 2, or 3+ candidates.
- Route/API tests cover the contract behavior for 0, 1, 2, and 3+ candidate states.
- Refresh-after-Winoe-Report-generation regression coverage confirms Benchmarks updates after new completed evaluations land.
- Live-style smoke helper was added to exercise the contract against a running API instance.

# QA / Verification

- Focused compare tests:
  - `poetry run pytest --no-cov ...`
  - Result: pass, `17 passed`
- Full test suite:
  - `poetry run pytest`
  - Result: pass, `1846 passed`
- Pre-commit:
  - `poetry run pre-commit run --all-files` could not run because `pre-commit` was unavailable in the workspace.
  - `poetry run python -m pre_commit run --all-files` could not run because the module was unavailable.
  - The reported validation output showed coverage passing at `96.01%` with `1846 passed`.

# Live HTTP Verification

0 candidates:

```json
{"trialId":1,"cohortSize":0,"state":"empty","message":"No completed Winoe Reports are available for this Trial yet.","candidates":[]}
```

1 candidate:

```json
{"trialId":2,"cohortSize":1,"state":"partial","message":"Limited comparison — only 1 candidate completed this Trial.","candidates":[{"candidateSessionId":1,"recommendation":"positive_signal"}]}
```

2 candidates:

```json
{"trialId":3,"cohortSize":2,"state":"partial","message":"Limited comparison — only 2 candidates completed this Trial.","candidates":[{"candidateSessionId":2,"recommendation":"mixed_signal"},{"candidateSessionId":3,"recommendation":"positive_signal"}]}
```

3 candidates:

```json
{"trialId":4,"cohortSize":3,"state":"ready","message":null,"candidates":[{"candidateSessionId":4,"recommendation":"strong_signal"},{"candidateSessionId":5,"recommendation":"positive_signal"},{"candidateSessionId":6,"recommendation":"mixed_signal"}]}
```

Same-company/different-Trial isolation:

- Trial 2 returned candidate IDs `[1]`.
- Trial 5 returned candidate ID `[7]`.
- No cross-contamination between those Trials.

Different-company isolation:

```json
{"status":403,"payload":{"detail":"Trial access forbidden"}}
```

Authorization:

- Different-company access guard returned `403`.
- Candidate-email dev request returned `401` in the local seeded DB because that dev user was not present.

Refresh after Winoe Report generation:

- Before report generation, Trial 7 returned `empty`.
- After inserting the completed evaluation run, Trial 7 returned:

```json
{"trialId":7,"cohortSize":1,"state":"partial","message":"Limited comparison — only 1 candidate completed this Trial.","candidates":[{"candidateSessionId":9,"recommendation":"strong_signal"}]}
```

# Risk / Notes

- Live HTTP verification was performed against a local `uvicorn` instance with seeded sqlite data and dev-bypass auth.
- The prior QA failure was caused by runtime drift and live verification mismatch; the route now explicitly validates the response model at the API boundary.
- A live-style smoke helper was added to reduce the chance of this contract drifting again.

# Acceptance Criteria Mapping

- Compare only returns same-Trial candidates: covered by same-company/different-Trial and different-company checks.
- No-data state for new Trials: covered by the 0-candidate payload.
- Refreshes after report generation: covered by the Trial 7 before/after payload.
- Framing does not imply Winoe decides: public signal values only; internal hiring enums are rejected.
- 2+ same-Trial candidates: covered by the 2-candidate and 3-candidate payloads.
- Cohort size: `cohortSize` is present in all payloads.
- Limited caveat for cohort < 3: present for 1 and 2 candidates.
- 0 -> 1 -> 2+ transitions: covered by the live HTTP payloads and tests.

# Follow-ups

- Consider wiring `scripts/compare_contract_smoke_test.py` into CI or the backend smoke pipeline.

## Worker Report

- Summary
  - Benchmarks are now isolated to the requested Trial, with public contract fields and state handling that make the response predictable across 0, 1, 2, and 3+ candidate cohorts.
- Files changed
  - `pr.md`
- Commands run
  - `sed -n '1,240p' pr.md` - pass
  - `sed -n '1,240p' issue.md` - pass
  - `poetry run pytest --no-cov ...` - pass, `17 passed`
  - `poetry run pytest` - pass, `1846 passed`
  - `poetry run pre-commit run --all-files` - fail, `pre-commit` unavailable in the workspace
  - `poetry run python -m pre_commit run --all-files` - fail, module unavailable
- Risks / assumptions
  - The live HTTP verification reflects a local `uvicorn` instance with seeded sqlite data and dev-bypass auth.
  - The reported validation output is treated as the source of truth for the pre-commit/coverage status because the direct pre-commit commands could not execute.
- Open questions / blockers
  - None

Fixes #300 