### PR TITLE
Harden empty-repo GitHub provisioning and evidence capture

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ FastAPI + PostgreSQL backend for Winoe's async trial platform. Talent Partners c
 ## Overview
 
 - Domain modules: trials, candidate sessions, tasks, submissions, evaluations, media, notifications, talent_partners/admin, and shared runtime infrastructure.
-- GitHub-native flow: workspace repo provisioning from templates, Codespaces init/status, Actions run dispatch/polling, artifact parsing, and persisted run/test/diff metadata.
+- GitHub-native flow: empty-repo workspace provisioning, Codespaces init/status, Actions evidence capture, artifact parsing, and persisted run/test metadata.
 - Auth model: bearer-token principal model with talent_partner/candidate permission gates, plus admin key and demo admin dependency paths.
 - Current API surface: 57 HTTP endpoints (generated from live OpenAPI).
 
@@ -35,7 +35,7 @@ Dev/test tools: `pytest`, `pytest-asyncio`, `pytest-cov`, `httpx`, `ruff`, `blac
 - PostgreSQL (for local app runtime and Alembic migrations)
 - Optional for QA workflows:
   - Node.js + Newman for API QA runner
-  - Local GitHub credentials/token for template/workspace flows
+  - Local GitHub credentials/token for workspace flows
 
 ## Setup
 
@@ -138,7 +138,7 @@ Canonical env keys are summarized below by primary group.
 | `app/submissions/*` | Workspace provisioning, run persistence, talent_partner presentation |
 | `app/evaluations/*` | Winoe Report API, evaluators, evaluation repositories |
 | `app/media/*` | Recording/transcript storage + privacy services |
-| `app/talent_partners/*` | Talent Partner admin/template and demo admin operations |
+| `app/talent_partners/*` | Talent Partner admin and demo admin operations |
 | `app/shared/jobs/*` | Durable job models, handlers, worker services |
 | `alembic/` | DB migrations |
 | `docs/` | Canonical architecture/API documentation |
@@ -157,8 +157,6 @@ Canonical env keys are summarized below by primary group.
 
 ### Admin Templates / Demo Admin Ops
 
-- `GET /api/admin/templates/health`
-- `POST /api/admin/templates/health/run`
 - `POST /api/admin/candidate_sessions/{candidate_session_id}/day_windows/control`
 - `POST /api/admin/candidate_sessions/{candidate_session_id}/reset`
 - `POST /api/admin/jobs/{job_id}/requeue`
@@ -231,7 +229,7 @@ Detailed schema-level API docs are generated at [`docs/api.md`](docs/api.md).
 
 - Domain-first package organization with thin entrypoints and shared runtime composition (`app/shared/http`).
 - Settings use pydantic-settings with merge compatibility for nested legacy env structures.
-- Talent Partner/candidate authorization is dependency-based; admin template endpoints use explicit API key dependency.
+- Talent Partner/candidate authorization is dependency-based; admin endpoints use explicit API key dependency.
 - GitHub integration keeps transport/client/actions/artifact parsing concerns separated for testability.
 - Durable job status uses polling endpoints plus worker handlers for async side effects.
 - Worker health is tracked through a persisted heartbeat row per worker instance, which later readiness checks can inspect.

--- a/app/config/config_github_config.py
+++ b/app/config/config_github_config.py
@@ -13,7 +13,7 @@ class GithubSettings(BaseSettings):
     GITHUB_ORG: str = "winoe-ai-repos"
     GITHUB_TOKEN: str = ""
     GITHUB_TEMPLATE_OWNER: str = "winoe-ai-repos"
-    GITHUB_ACTIONS_WORKFLOW_FILE: str = "evidence-capture.yml"
+    GITHUB_ACTIONS_WORKFLOW_FILE: str = "winoe-evidence-capture.yml"
     GITHUB_REPO_PREFIX: str = "winoe-ws-"
     GITHUB_CLEANUP_ENABLED: bool = False
     WORKSPACE_RETENTION_DAYS: int = 30

--- a/app/integrations/github/actions_runner/integrations_github_actions_runner_github_actions_runner_artifacts_service.py
+++ b/app/integrations/github/actions_runner/integrations_github_actions_runner_github_actions_runner_artifacts_service.py
@@ -31,18 +31,34 @@ async def parse_artifacts(
     preferred, others = partition_artifacts(artifacts)
     test_artifacts = _pick_test_artifacts(preferred + others)
     evidence_key = (repo_full_name, run_id)
-    parsed, error = await _parse_first_test_artifact(
+    parsed, error, test_evidence = await _parse_first_test_artifact(
         client, cache, repo_full_name, run_id, test_artifacts
     )
-    evidence = await _collect_evidence_artifacts(
-        client, repo_full_name, preferred + others
-    )
-    if evidence:
-        cache.cache_evidence_summary(evidence_key, {"evidenceArtifacts": evidence})
+    evidence = cache.evidence_summary_cache.get(evidence_key)
+    if evidence is None:
+        evidence_artifacts = dict(test_evidence)
+        evidence_artifacts.update(
+            await _collect_evidence_artifacts(
+                client,
+                repo_full_name,
+                preferred + others,
+                excluded_artifact_ids={
+                    int(a["id"]) for a in test_artifacts if a.get("id")
+                },
+            )
+        )
+        if evidence_artifacts:
+            evidence = {"evidenceArtifacts": evidence_artifacts}
+            cache.cache_evidence_summary(evidence_key, evidence)
+    elif test_evidence:
+        evidence = dict(evidence)
+        merged_artifacts = dict(evidence.get("evidenceArtifacts", {}))
+        merged_artifacts.update(test_evidence)
+        evidence["evidenceArtifacts"] = merged_artifacts
     if parsed:
         summary = dict(parsed.summary or {})
         if evidence:
-            summary["evidenceArtifacts"] = evidence
+            summary["evidenceArtifacts"] = evidence.get("evidenceArtifacts", {})
         parsed.summary = summary or None
         cache.cache_evidence_summary(evidence_key, summary)
         return parsed, None
@@ -59,7 +75,7 @@ async def _parse_first_test_artifact(
     repo_full_name: str,
     run_id: int,
     artifacts: list[dict[str, Any]],
-) -> tuple[ParsedTestResults | None, str | None]:
+) -> tuple[ParsedTestResults | None, str | None, dict[str, dict[str, Any]]]:
     """Parse the first parseable test-results artifact."""
     found = False
     last_error: str | None = None
@@ -67,13 +83,14 @@ async def _parse_first_test_artifact(
         artifact_id = artifact.get("id")
         if not artifact_id:
             continue
+        artifact_name = str(artifact.get("name") or "").lower()
         found = True
         cache_key = (repo_full_name, run_id, int(artifact_id))
         cached = cache.artifact_cache.get(cache_key)
         if cached:
             parsed_cached, cached_error = cached
             if parsed_cached or cached_error:
-                return parsed_cached, cached_error
+                return parsed_cached, cached_error, {}
         try:
             content = await client.download_artifact_zip(
                 repo_full_name, int(artifact_id)
@@ -84,22 +101,56 @@ async def _parse_first_test_artifact(
         parsed = parse_test_results_zip(content)
         if parsed:
             cache.cache_artifact_result(cache_key, parsed, None)
-            return parsed, None
+            return (
+                parsed,
+                None,
+                _collect_evidence_from_test_artifact(
+                    content, artifact_name, artifact_id
+                ),
+            )
         last_error = "artifact_corrupt"
         cache.cache_artifact_result(cache_key, None, last_error)
     if found:
-        return None, last_error or "artifact_unavailable"
-    return None, None
+        return None, last_error or "artifact_unavailable", {}
+    return None, None, {}
+
+
+def _collect_evidence_from_test_artifact(
+    content: bytes, artifact_name: str, artifact_id: Any
+) -> dict[str, dict[str, Any]]:
+    """Parse evidence payloads that share the test-results artifact zip."""
+    summary_key = EVIDENCE_ARTIFACT_SUMMARY_KEYS.get(artifact_name)
+    if summary_key is None:
+        return {}
+    parsed = parse_evidence_artifact_zip(content, artifact_name)
+    if parsed is None:
+        return {
+            summary_key: {
+                "artifactName": artifact_name,
+                "artifactId": int(artifact_id),
+                "error": "artifact_corrupt",
+            }
+        }
+    summary = build_evidence_artifact_summary(parsed)
+    summary["artifactId"] = int(artifact_id)
+    return {summary_key: summary}
 
 
 async def _collect_evidence_artifacts(
-    client: GithubClient, repo_full_name: str, artifacts: list[dict[str, Any]]
+    client: GithubClient,
+    repo_full_name: str,
+    artifacts: list[dict[str, Any]],
+    *,
+    excluded_artifact_ids: set[int] | None = None,
 ) -> dict[str, dict[str, Any]]:
     """Collect evidence artifact summaries best-effort."""
     evidence: dict[str, dict[str, Any]] = {}
+    excluded_artifact_ids = excluded_artifact_ids or set()
     for artifact in artifacts:
         artifact_id = artifact.get("id")
         if not artifact_id:
+            continue
+        if int(artifact_id) in excluded_artifact_ids:
             continue
         artifact_name = str(artifact.get("name") or "").lower()
         summary_key = EVIDENCE_ARTIFACT_SUMMARY_KEYS.get(artifact_name)

--- a/app/integrations/github/artifacts/integrations_github_artifacts_evidence_parser_utils.py
+++ b/app/integrations/github/artifacts/integrations_github_artifacts_evidence_parser_utils.py
@@ -14,8 +14,15 @@ from app.integrations.github.artifacts.integrations_github_artifacts_models_mode
 EVIDENCE_ARTIFACT_SUMMARY_KEYS: dict[str, str] = {
     "winoe-commit-metadata": "commitMetadata",
     "winoe-file-creation-timeline": "fileCreationTimeline",
-    "winoe-repo-structure-snapshot": "repoStructureSnapshot",
+    "winoe-repo-tree-summary": "repoTreeSummary",
+    "winoe-dependency-manifests": "dependencyManifests",
+    "winoe-test-detection": "testDetection",
+    "winoe-test-results": "testResults",
+    "winoe-lint-detection": "lintDetection",
     "winoe-lint-results": "lintResults",
+    "winoe-evidence-manifest": "evidenceManifest",
+    # Legacy compatibility only. The v4 active path uses repo-tree summary.
+    "winoe-repo-structure-snapshot": "repoStructureSnapshot",
     "winoe-coverage": "coverage",
 }
 
@@ -36,10 +43,10 @@ def parse_evidence_artifact_zip(
                         data = _safe_json_load(fp)
                     if data is not None:
                         json_files[name] = data
-                elif (
-                    artifact_name.lower() == "winoe-repo-structure-snapshot"
-                    and lower_name.endswith(".txt")
-                ):
+                elif artifact_name.lower() in {
+                    "winoe-repo-structure-snapshot",
+                    "winoe-repo-tree-summary",
+                } and lower_name.endswith(".txt"):
                     with zf.open(name) as fp:
                         text_files[name] = _safe_text_load(fp)
             data = _choose_primary_payload(
@@ -87,15 +94,28 @@ def _choose_primary_payload(
         if len(json_files) == 1:
             return next(iter(json_files.values()))
         preferred_file = {
+            "winoe-repo-tree-summary": "repo_tree_summary.json",
             "winoe-repo-structure-snapshot": "repo-structure-snapshot.json",
-            "winoe-commit-metadata": "commit-metadata.json",
-            "winoe-file-creation-timeline": "file-creation-timeline.json",
-            "winoe-lint-results": "lint-results.json",
+            "winoe-commit-metadata": "commit_metadata.json",
+            "winoe-file-creation-timeline": "file_creation_timeline.json",
+            "winoe-dependency-manifests": "dependency_manifests.json",
+            "winoe-test-detection": "test_detection.json",
+            "winoe-test-results": "test_results.json",
+            "winoe-lint-detection": "lint_detection.json",
+            "winoe-lint-results": "lint_results.json",
+            "winoe-evidence-manifest": "evidence_manifest.json",
         }.get(artifact_name.lower())
         if preferred_file and preferred_file in json_files:
             return json_files[preferred_file]
         return json_files
-    if artifact_name.lower() == "winoe-repo-structure-snapshot" and text_files:
+    if (
+        artifact_name.lower()
+        in {
+            "winoe-repo-structure-snapshot",
+            "winoe-repo-tree-summary",
+        }
+        and text_files
+    ):
         if len(text_files) == 1:
             return next(iter(text_files.values()))
         return text_files

--- a/app/submissions/services/submissions_services_submissions_workspace_bootstrap_service.py
+++ b/app/submissions/services/submissions_services_submissions_workspace_bootstrap_service.py
@@ -43,19 +43,43 @@ _DEVCONTAINER_JSON = {
 _GITIGNORE_TEXT = "\n".join(
     [
         ".DS_Store",
-        ".env",
+        "Thumbs.db",
+        ".idea/",
         ".vscode/",
+        ".history/",
+        ".env",
+        ".env.*",
+        "*.local",
+        "*.log",
         "node_modules/",
+        ".npm/",
         "__pycache__/",
+        "*.pyc",
+        ".pytest_cache/",
+        ".ruff_cache/",
+        ".mypy_cache/",
+        ".tox/",
+        ".venv/",
+        "venv/",
         "dist/",
         "build/",
         "coverage/",
+        ".coverage",
+        ".coverage.*",
         "evidence/",
+        "target/",
+        "bin/",
+        "obj/",
+        "out/",
+        "release/",
+        "debug/",
+        "tmp/",
+        "temp/",
         "",
     ]
 )
 _CODESPACE_RETRY_DELAY_SECONDS = 1
-_EVIDENCE_WORKFLOW_PATH = ".github/workflows/evidence-capture.yml"
+_EVIDENCE_WORKFLOW_PATH = ".github/workflows/winoe-evidence-capture.yml"
 
 
 def build_evidence_capture_workflow_yaml() -> str:
@@ -67,8 +91,6 @@ def build_evidence_capture_workflow_yaml() -> str:
 
         on:
           push:
-            branches:
-              - main
           workflow_dispatch:
 
         permissions:
@@ -83,25 +105,28 @@ def build_evidence_capture_workflow_yaml() -> str:
                 with:
                   fetch-depth: 0
 
-              - name: Prepare artifact directories
-                run: |
-                  mkdir -p artifacts/coverage
-                  mkdir -p artifacts/lint
-                  mkdir -p artifacts/test-results
-
-              - name: Capture repository evidence
+              - name: Capture evidence
                 continue-on-error: true
                 run: |
                   python - <<'PY'
                   import json
+                  import os
                   import pathlib
                   import subprocess
+                  from collections import Counter
                   from datetime import UTC, datetime
 
                   artifacts = pathlib.Path("artifacts")
                   artifacts.mkdir(parents=True, exist_ok=True)
+                  repo_root = pathlib.Path(".")
+                  generated_at = datetime.now(UTC).isoformat()
+                  repository_full_name = os.environ.get("GITHUB_REPOSITORY")
+                  commit_sha = os.environ.get("GITHUB_SHA")
+                  workflow_run_id = os.environ.get("GITHUB_RUN_ID")
+                  schema_version = "1"
+                  written: list[dict[str, object]] = []
 
-                  def run_git(args: list[str]) -> subprocess.CompletedProcess[str]:
+                  def run_git(*args: str) -> subprocess.CompletedProcess[str]:
                       return subprocess.run(
                           ["git", *args],
                           capture_output=True,
@@ -109,234 +134,301 @@ def build_evidence_capture_workflow_yaml() -> str:
                           check=False,
                       )
 
-                  def write_json(path: str, payload: object) -> None:
-                      (artifacts / path).write_text(
-                          json.dumps(payload, indent=2, sort_keys=True) + "\\n",
+                  def write_json(name: str, status: str, payload: object) -> dict[str, object]:
+                      record = {
+                          "schema_version": schema_version,
+                          "repository_full_name": repository_full_name,
+                          "commit_sha": commit_sha,
+                          "workflow_run_id": workflow_run_id,
+                          "generated_at": generated_at,
+                          "status": status,
+                          "payload": payload,
+                      }
+                      (artifacts / name).write_text(
+                          json.dumps(record, indent=2, sort_keys=True) + "\\n",
                           encoding="utf-8",
                       )
+                      written.append({"name": name, "status": status})
+                      return record
 
-                  def snapshot_tree() -> list[str]:
-                      paths: list[str] = []
-                      for path in pathlib.Path(".").rglob("*"):
-                          if ".git" in path.parts or "artifacts" in path.parts:
-                              continue
-                          relative = path.as_posix()
-                          if path.is_dir():
-                              relative += "/"
-                          paths.append(relative)
-                      return sorted(paths)
+                  def trunc(text: str | None, limit: int = 20000) -> str:
+                      if not text:
+                          return ""
+                      return text[:limit]
 
-                  generated_at = datetime.now(UTC).isoformat()
-                  commit_metadata: dict[str, object] = {
-                      "generatedAt": generated_at,
-                      "commits": [],
-                  }
-                  timeline: dict[str, object] = {
-                      "generatedAt": generated_at,
-                      "filesCreated": [],
-                  }
+                  def detect_manifests() -> list[dict[str, object]]:
+                      manifests: list[dict[str, object]] = []
+                      package_path = repo_root / "package.json"
+                      if package_path.exists():
+                          try:
+                              package_data = json.loads(package_path.read_text(encoding="utf-8"))
+                          except ValueError:
+                              package_data = {}
+                          scripts = package_data.get("scripts") if isinstance(package_data, dict) else {}
+                          has_test_script = isinstance(scripts, dict) and "test" in scripts
+                          has_lint_script = isinstance(scripts, dict) and "lint" in scripts
+                          manifests.append(
+                              {
+                                  "path": "package.json",
+                                  "kind": "node",
+                                  "test_command": "npm test" if has_test_script else None,
+                                  "lint_command": "npm run lint" if has_lint_script else None,
+                                  "reason": (
+                                      "detected package.json scripts"
+                                      if has_test_script or has_lint_script
+                                      else "package.json found without test or lint scripts"
+                                  ),
+                              }
+                          )
+                      python_manifest = None
+                      if (repo_root / "pyproject.toml").exists():
+                          python_manifest = "pyproject.toml"
+                      elif (repo_root / "requirements.txt").exists():
+                          python_manifest = "requirements.txt"
+                      if python_manifest is not None:
+                          test_paths = [
+                              "tests",
+                              "test",
+                              "spec",
+                          ]
+                          has_common_tests = any((repo_root / path).exists() for path in test_paths)
+                          manifests.append(
+                              {
+                                  "path": python_manifest,
+                                  "kind": "python",
+                                  "test_command": "python -m pytest" if has_common_tests else None,
+                                  "lint_command": "python -m ruff check .",
+                                  "reason": (
+                                      "detected Python project manifest and common test paths"
+                                      if has_common_tests
+                                      else "detected Python project manifest without obvious test paths"
+                                  ),
+                              }
+                          )
+                      if (repo_root / "go.mod").exists():
+                          manifests.append(
+                              {
+                                  "path": "go.mod",
+                                  "kind": "go",
+                                  "test_command": "go test ./...",
+                                  "lint_command": "golangci-lint run",
+                              }
+                          )
+                      if (repo_root / "pom.xml").exists():
+                          manifests.append(
+                              {
+                                  "path": "pom.xml",
+                                  "kind": "maven",
+                                  "test_command": "mvn test",
+                                  "lint_command": "mvn -q -DskipTests checkstyle:check",
+                              }
+                          )
+                      if (repo_root / "Cargo.toml").exists():
+                          manifests.append(
+                              {
+                                  "path": "Cargo.toml",
+                                  "kind": "rust",
+                                  "test_command": "cargo test",
+                                  "lint_command": "cargo clippy -- -D warnings",
+                              }
+                          )
+                      return manifests
 
-                  head = run_git(["rev-parse", "HEAD"])
-                  if head.returncode == 0:
-                      commit_metadata["headSha"] = head.stdout.strip()
+                  def choose_command(manifests: list[dict[str, object]], key: str) -> dict[str, object]:
+                      for manifest in manifests:
+                          command = manifest.get(key)
+                          if isinstance(command, str) and command.strip():
+                              return {
+                                  "detected": True,
+                                  "tool": manifest.get("kind"),
+                                  "command": command,
+                                  "manifest_path": manifest.get("path"),
+                                  "reason": f"detected from {manifest.get('path')}",
+                              }
+                      return {
+                          "detected": False,
+                          "tool": None,
+                          "command": None,
+                          "manifest_path": None,
+                          "reason": "no supported manifest with a runnable command found",
+                      }
 
-                  rev_list = run_git(["rev-list", "--reverse", "HEAD"])
-                  for sha in rev_list.stdout.splitlines() if rev_list.returncode == 0 else []:
-                      show = run_git(
-                          [
+                  def run_command(command: str | None) -> dict[str, object]:
+                      if not command:
+                          return {
+                              "status": "not_detected",
+                              "command": None,
+                              "exit_code": None,
+                              "stdout": "",
+                              "stderr": "",
+                          }
+                      proc = subprocess.run(
+                          command,
+                          shell=True,
+                          capture_output=True,
+                          text=True,
+                          check=False,
+                      )
+                      return {
+                          "status": "success" if proc.returncode == 0 else "failed",
+                          "command": command,
+                          "exit_code": proc.returncode,
+                          "stdout": trunc(proc.stdout),
+                          "stderr": trunc(proc.stderr),
+                      }
+
+                  head = run_git("rev-parse", "HEAD")
+                  head_sha = head.stdout.strip() if head.returncode == 0 else commit_sha
+                  rev_list = run_git("rev-list", "--reverse", "HEAD")
+                  commits: list[dict[str, object]] = []
+                  if rev_list.returncode == 0:
+                      for sha in rev_list.stdout.splitlines():
+                          show = run_git(
                               "show",
                               "--date=iso-strict",
                               "--format=%H%x09%ad%x09%s",
                               "--numstat",
                               "--no-renames",
                               sha,
-                          ]
-                      )
-                      if show.returncode != 0:
-                          cast_list = commit_metadata["commits"]  # type: ignore[assignment]
-                          cast_list.append({"sha": sha, "error": "git show failed"})
-                          continue
-                      lines = show.stdout.splitlines()
-                      if not lines:
-                          continue
-                      commit_sha, timestamp, message = lines[0].split("\t", 2)
-                      files: list[str] = []
-                      insertions = 0
-                      deletions = 0
-                      for line in lines[1:]:
-                          if not line.strip():
+                          )
+                          if show.returncode != 0 or not show.stdout.strip():
+                              commits.append({"sha": sha, "error": "git show failed"})
                               continue
-                          parts = line.split("\t")
-                          if len(parts) != 3:
+                          lines = show.stdout.splitlines()
+                          commit_line = lines[0].split("\t", 2)
+                          if len(commit_line) != 3:
+                              commits.append({"sha": sha, "error": "unexpected git show output"})
                               continue
-                          added, removed, path = parts
-                          files.append(path)
-                          if added != "-":
-                              insertions += int(added)
-                          if removed != "-":
-                              deletions += int(removed)
-                      cast_list = commit_metadata["commits"]  # type: ignore[assignment]
-                      cast_list.append(
-                          {
-                              "sha": commit_sha,
-                              "timestamp": timestamp,
-                              "message": message,
-                              "filesChanged": files,
-                              "filesChangedCount": len(files),
-                              "insertions": insertions,
-                              "deletions": deletions,
-                          }
-                      )
+                          commit_sha_value, timestamp, message = commit_line
+                          files_changed: list[str] = []
+                          insertions = 0
+                          deletions = 0
+                          for line in lines[1:]:
+                              if not line.strip():
+                                  continue
+                              parts = line.split("\t")
+                              if len(parts) != 3:
+                                  continue
+                              added, removed, path = parts
+                              files_changed.append(path)
+                              if added != "-":
+                                  insertions += int(added)
+                              if removed != "-":
+                                  deletions += int(removed)
+                          commits.append(
+                              {
+                                  "sha": commit_sha_value,
+                                  "timestamp": timestamp,
+                                  "message": message,
+                                  "files_changed": files_changed,
+                                  "files_changed_count": len(files_changed),
+                                  "insertions": insertions,
+                                  "deletions": deletions,
+                              }
+                          )
 
                   creation_log = run_git(
-                      [
-                          "log",
-                          "--reverse",
-                          "--diff-filter=A",
-                          "--date=iso-strict",
-                          "--format=%H%x09%ad%x09%s",
-                          "--name-only",
-                          "--no-renames",
-                      ]
+                      "log",
+                      "--reverse",
+                      "--diff-filter=A",
+                      "--date=iso-strict",
+                      "--format=%H%x09%ad%x09%s",
+                      "--name-only",
+                      "--no-renames",
                   )
+                  creation_events: list[dict[str, object]] = []
                   current_event: dict[str, object] | None = None
-                  for line in creation_log.stdout.splitlines() if creation_log.returncode == 0 else []:
-                      if not line.strip():
-                          current_event = None
-                          continue
-                      if current_event is None and line.count("\t") >= 2:
-                          commit_sha, timestamp, message = line.split("\t", 2)
-                          current_event = {
-                              "commitSha": commit_sha,
-                              "timestamp": timestamp,
-                              "message": message,
-                              "files": [],
-                          }
-                          cast_list = timeline["filesCreated"]  # type: ignore[assignment]
-                          cast_list.append(current_event)
-                          continue
-                      if current_event is not None:
-                          files = current_event.setdefault("files", [])
-                          if isinstance(files, list):
-                              files.append(line.strip())
+                  if creation_log.returncode == 0:
+                      for line in creation_log.stdout.splitlines():
+                          if not line.strip():
+                              current_event = None
+                              continue
+                          if current_event is None and line.count("\t") >= 2:
+                              commit_sha_value, timestamp, message = line.split("\t", 2)
+                              current_event = {
+                                  "commit_sha": commit_sha_value,
+                                  "timestamp": timestamp,
+                                  "message": message,
+                                  "files": [],
+                              }
+                              creation_events.append(current_event)
+                              continue
+                          if current_event is not None:
+                              files = current_event.setdefault("files", [])
+                              if isinstance(files, list):
+                                  files.append(line.strip())
 
-                  write_json("commit-metadata.json", commit_metadata)
-                  write_json("file-creation-timeline.json", timeline)
+                  tree_files = [path for path in run_git("ls-files").stdout.splitlines() if path.strip()]
+                  dir_counts: Counter[str] = Counter()
+                  extension_counts: Counter[str] = Counter()
+                  for path in tree_files:
+                      normalized = pathlib.PurePosixPath(path)
+                      parent = normalized.parent.as_posix()
+                      dir_counts[parent if parent != "." else "."] += 1
+                      extension = normalized.suffix.lower() or "[no extension]"
+                      extension_counts[extension] += 1
+
+                  manifests = detect_manifests()
+                  test_detection = choose_command(manifests, "test_command")
+                  lint_detection = choose_command(manifests, "lint_command")
+
                   write_json(
-                      "repo-structure-snapshot.json",
+                      "commit_metadata.json",
+                      "success",
                       {
-                          "generatedAt": generated_at,
-                          "paths": snapshot_tree(),
+                          "head_commit": head_sha,
+                          "commits": commits,
                       },
                   )
-                  (artifacts / "repo-structure-snapshot.txt").write_text(
-                      "\\n".join(snapshot_tree()) + "\\n",
-                      encoding="utf-8",
+                  write_json(
+                      "file_creation_timeline.json",
+                      "success",
+                      {
+                          "files": creation_events,
+                          "best_effort": True,
+                      },
+                  )
+                  write_json(
+                      "repo_tree_summary.json",
+                      "success",
+                      {
+                          "files": tree_files,
+                          "directories": sorted(dir_counts.items()),
+                          "extension_counts": sorted(extension_counts.items()),
+                          "file_count": len(tree_files),
+                      },
+                  )
+                  write_json(
+                      "dependency_manifests.json",
+                      "success" if manifests else "not_detected",
+                      {
+                          "detected": bool(manifests),
+                          "manifests": manifests,
+                      },
+                  )
+                  write_json("test_detection.json", "success" if test_detection["detected"] else "not_detected", test_detection)
+                  test_results = run_command(test_detection["command"])
+                  write_json("test_results.json", test_results["status"], test_results)
+                  write_json("lint_detection.json", "success" if lint_detection["detected"] else "not_detected", lint_detection)
+                  lint_results = run_command(lint_detection["command"])
+                  write_json("lint_results.json", lint_results["status"], lint_results)
+                  write_json(
+                      "evidence_manifest.json",
+                      "success",
+                      {
+                          "artifacts": written,
+                          "generated_artifacts": [item["name"] for item in written],
+                          "best_effort": True,
+                      },
                   )
                   PY
-
-              - name: Detect and run tests
-                continue-on-error: true
-                run: |
-                  set +e
-                  test_tool="none"
-                  test_command="not-detected"
-                  test_status=0
-                  mkdir -p artifacts/coverage artifacts/test-results
-
-                  if [ -f package.json ]; then
-                    test_tool="npm"
-                    test_command="npm test -- --coverage"
-                    npm test -- --coverage > artifacts/test-results/test-output.log 2>&1
-                    test_status=$?
-                    if [ -d coverage ]; then
-                      cp -R coverage/. artifacts/coverage/ 2>/dev/null || true
-                    fi
-                  elif [ -f requirements.txt ] || [ -f pyproject.toml ]; then
-                    test_tool="pytest"
-                    test_command="python -m pytest --cov=. --cov-report=term-missing --cov-report=xml:artifacts/coverage/coverage.xml"
-                    python -m pytest --cov=. --cov-report=term-missing --cov-report=xml:artifacts/coverage/coverage.xml > artifacts/test-results/test-output.log 2>&1
-                    test_status=$?
-                  elif [ -f go.mod ]; then
-                    test_tool="go"
-                    test_command="go test ./... -coverprofile=artifacts/coverage/coverage.out"
-                    go test ./... -coverprofile=artifacts/coverage/coverage.out > artifacts/test-results/test-output.log 2>&1
-                    test_status=$?
-                  elif [ -f pom.xml ]; then
-                    test_tool="maven"
-                    test_command="mvn test"
-                    mvn test > artifacts/test-results/test-output.log 2>&1
-                    test_status=$?
-                  else
-                    printf '%s\\n' 'No supported test tooling detected.' > artifacts/test-results/test-output.log
-                  fi
-
-                  if [ "${test_tool}" = "none" ]; then
-                    passed=0
-                    failed=0
-                    total=0
-                  elif [ "${test_status}" -eq 0 ]; then
-                    passed=1
-                    failed=0
-                    total=1
-                  else
-                    passed=0
-                    failed=1
-                    total=1
-                  fi
-
-                  cat > artifacts/test-results/test-results.json <<EOF
-                  {
-                    "passed": ${passed},
-                    "failed": ${failed},
-                    "total": ${total},
-                    "detectedTool": "${test_tool}",
-                    "command": "${test_command}",
-                    "exitCode": ${test_status},
-                    "coveragePath": "artifacts/coverage",
-                    "outputLog": "artifacts/test-results/test-output.log",
-                    "summary": {
-                      "detectedTool": "${test_tool}",
-                      "command": "${test_command}",
-                      "exitCode": ${test_status},
-                      "coveragePath": "artifacts/coverage",
-                      "outputLog": "artifacts/test-results/test-output.log"
-                    }
-                  }
-                  EOF
-
-                  if [ ! -s artifacts/test-results/test-output.log ]; then
-                    printf '%s\\n' 'No test output captured.' > artifacts/test-results/test-output.log
-                  fi
-
-              - name: Run lint analysis
-                id: lint
-                continue-on-error: true
-                uses: github/super-linter/slim@v6
-                env:
-                  GITHUB_TOKEN: ${{ github.token }}
-                  DEFAULT_BRANCH: main
-                  VALIDATE_ALL_CODEBASE: true
-                  FILTER_REGEX_INCLUDE: .*
-                  USE_FIND_ALGORITHM: true
-
-              - name: Record lint outcome
-                if: always()
-                run: |
-                  cat > artifacts/lint/lint-results.json <<EOF
-                  {
-                    "actionOutcome": "${{ steps.lint.outcome }}",
-                    "actionConclusion": "${{ steps.lint.conclusion }}",
-                    "notes": "Super-Linter outcome is captured best-effort and never blocks the candidate workspace."
-                  }
-                  EOF
 
               - name: Upload commit metadata
                 if: always()
                 uses: actions/upload-artifact@v4
                 with:
                   name: winoe-commit-metadata
-                  path: artifacts/commit-metadata.json
+                  path: artifacts/commit_metadata.json
                   retention-days: 90
                   if-no-files-found: ignore
 
@@ -345,43 +437,70 @@ def build_evidence_capture_workflow_yaml() -> str:
                 uses: actions/upload-artifact@v4
                 with:
                   name: winoe-file-creation-timeline
-                  path: artifacts/file-creation-timeline.json
+                  path: artifacts/file_creation_timeline.json
                   retention-days: 90
                   if-no-files-found: ignore
 
-              - name: Upload repository structure snapshot
+              - name: Upload repository tree summary
                 if: always()
                 uses: actions/upload-artifact@v4
                 with:
-                  name: winoe-repo-structure-snapshot
-                  path: artifacts/repo-structure-snapshot.*
+                  name: winoe-repo-tree-summary
+                  path: artifacts/repo_tree_summary.json
                   retention-days: 90
                   if-no-files-found: ignore
 
-              - name: Upload test evidence
+              - name: Upload dependency manifests
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                  name: winoe-dependency-manifests
+                  path: artifacts/dependency_manifests.json
+                  retention-days: 90
+                  if-no-files-found: ignore
+
+              - name: Upload test detection
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                  name: winoe-test-detection
+                  path: artifacts/test_detection.json
+                  retention-days: 90
+                  if-no-files-found: ignore
+
+              - name: Upload test results
                 if: always()
                 uses: actions/upload-artifact@v4
                 with:
                   name: winoe-test-results
-                  path: artifacts/test-results
+                  path: artifacts/test_results.json
                   retention-days: 90
                   if-no-files-found: ignore
 
-              - name: Upload coverage evidence
+              - name: Upload lint detection
                 if: always()
                 uses: actions/upload-artifact@v4
                 with:
-                  name: winoe-coverage
-                  path: artifacts/coverage
+                  name: winoe-lint-detection
+                  path: artifacts/lint_detection.json
                   retention-days: 90
                   if-no-files-found: ignore
 
-              - name: Upload lint evidence
+              - name: Upload lint results
                 if: always()
                 uses: actions/upload-artifact@v4
                 with:
                   name: winoe-lint-results
-                  path: artifacts/lint
+                  path: artifacts/lint_results.json
+                  retention-days: 90
+                  if-no-files-found: ignore
+
+              - name: Upload evidence manifest
+                if: always()
+                uses: actions/upload-artifact@v4
+                with:
+                  name: winoe-evidence-manifest
+                  path: artifacts/evidence_manifest.json
                   retention-days: 90
                   if-no-files-found: ignore
         """
@@ -446,6 +565,14 @@ def _bootstrap_file_payloads(
             "type": "blob",
         },
         {
+            "path": "README.md",
+            "content": _project_brief_readme(
+                trial=trial, scenario_version=scenario_version, task=task
+            ),
+            "mode": "100644",
+            "type": "blob",
+        },
+        {
             "path": ".gitignore",
             "content": _GITIGNORE_TEXT,
             "mode": "100644",
@@ -457,23 +584,15 @@ def _bootstrap_file_payloads(
             "mode": "100644",
             "type": "blob",
         },
-        {
-            "path": "README.md",
-            "content": _project_brief_readme(
-                trial=trial, scenario_version=scenario_version, task=task
-            ),
-            "mode": "100644",
-            "type": "blob",
-        },
     ]
 
 
 def _bootstrap_paths() -> list[str]:
     return [
         ".devcontainer/devcontainer.json",
+        "README.md",
         ".gitignore",
         _EVIDENCE_WORKFLOW_PATH,
-        "README.md",
     ]
 
 
@@ -519,24 +638,6 @@ async def _ensure_bootstrap_actor_access(
     return github_username
 
 
-async def _delete_repo_safely(github_client: GithubClient, repo_full_name: str) -> None:
-    """Delete a repository best-effort during invite cleanup."""
-    delete_repo = getattr(github_client, "delete_repo", None)
-    if not callable(delete_repo):
-        return
-    try:
-        await delete_repo(repo_full_name)
-    except GithubError as exc:
-        if exc.status_code not in {404, 422}:
-            logger.warning(
-                "github_repo_cleanup_failed",
-                extra={
-                    "repo_full_name": repo_full_name,
-                    "status_code": exc.status_code,
-                },
-            )
-
-
 def _codespace_degradation_reason(exc: GithubError) -> str | None:
     """Return the explicit repo-only fallback reason for codespace creation.
 
@@ -557,7 +658,7 @@ def _should_retry_codespace_error(exc: GithubError) -> bool:
 async def _create_candidate_repo(
     *, github_client: GithubClient, owner: str, repo_name: str, default_branch: str
 ) -> dict[str, Any]:
-    """Create the repo using the empty-repo API, with a legacy test-double fallback."""
+    """Create the repo using the empty-repo API."""
     create_empty_repo = getattr(github_client, "create_empty_repo", None)
     if callable(create_empty_repo):
         return await create_empty_repo(
@@ -565,17 +666,6 @@ async def _create_candidate_repo(
             repo_name=repo_name,
             private=True,
             default_branch=default_branch,
-        )
-
-    generate_repo_from_template = getattr(
-        github_client, "generate_repo_from_template", None
-    )
-    if callable(generate_repo_from_template):
-        return await generate_repo_from_template(
-            template_full_name="legacy/empty-repo",
-            new_repo_name=repo_name,
-            owner=owner,
-            private=True,
         )
 
     raise HTTPException(
@@ -605,8 +695,6 @@ async def bootstrap_empty_candidate_repo(
     )
     repo_full_name = f"{resolved_owner}/{resolved_repo_name}"
     default_branch = _DEFAULT_BRANCH
-    legacy_repo_compat = not callable(getattr(github_client, "create_empty_repo", None))
-    repo_created = False
     trial_id = getattr(trial, "id", None)
     candidate_session_id = getattr(candidate_session, "id", None)
 
@@ -626,7 +714,6 @@ async def bootstrap_empty_candidate_repo(
             repo_name=resolved_repo_name,
             default_branch=default_branch,
         )
-        repo_created = True
         _log_bootstrap_event(
             "github_workspace_repo_created",
             trial_id=trial_id,
@@ -656,35 +743,6 @@ async def bootstrap_empty_candidate_repo(
         )
     except GithubError:
         existing_branch_sha = None
-    if legacy_repo_compat:
-        bootstrap_sha = existing_branch_sha
-        codespace_name = None
-        codespace_state = None
-        codespace_url = None
-        _log_bootstrap_event(
-            "github_workspace_bootstrap_completed",
-            trial_id=trial_id,
-            candidate_session_id=candidate_session_id,
-            repo_full_name=repo_full_name,
-            default_branch=default_branch,
-            repo_id=repo_id,
-            bootstrap_commit_sha=bootstrap_sha,
-            codespace_name=codespace_name,
-            codespace_state=codespace_state,
-            codespace_url=codespace_url,
-            legacy_repo_compat=True,
-            elapsed_ms=_elapsed_ms(overall_started_at),
-        )
-        return BootstrapRepoResult(
-            template_repo_full_name=None,
-            repo_full_name=repo_full_name,
-            default_branch=default_branch,
-            repo_id=repo_id,
-            bootstrap_commit_sha=bootstrap_sha,
-            codespace_name=codespace_name,
-            codespace_state=codespace_state,
-            codespace_url=codespace_url,
-        )
 
     bootstrap_needed = False
     for path in _bootstrap_paths():
@@ -968,8 +1026,6 @@ async def bootstrap_empty_candidate_repo(
         )
         return result
     except Exception:
-        if repo_created:
-            await _delete_repo_safely(github_client, repo_full_name)
         raise
 
 

--- a/app/submissions/services/submissions_services_submissions_workspace_creation_group_repo_service.py
+++ b/app/submissions/services/submissions_services_submissions_workspace_creation_group_repo_service.py
@@ -65,6 +65,7 @@ async def get_or_create_workspace_group(
         repo_full_name = created_repo.repo_full_name
         default_branch = created_repo.default_branch
         repo_id = created_repo.repo_id
+        # Legacy DB column name; this now stores the repo bootstrap commit SHA.
         base_template_sha = created_repo.bootstrap_commit_sha
         codespace_name = created_repo.codespace_name
         codespace_state = created_repo.codespace_state

--- a/app/submissions/services/submissions_services_submissions_workspace_creation_grouped_service.py
+++ b/app/submissions/services/submissions_services_submissions_workspace_creation_grouped_service.py
@@ -120,7 +120,7 @@ async def provision_grouped_workspace(
             create_workspace_kwargs["commit"] = False
             create_workspace_kwargs["refresh"] = False
         created = await workspace_repo.create_workspace(db, **create_workspace_kwargs)
-        return await hydrate_existing_workspace(
+        result = await hydrate_existing_workspace(
             db,
             created,
             candidate_session,
@@ -130,6 +130,8 @@ async def provision_grouped_workspace(
             hydrate_precommit_bundle,
             commit,
         )
+        result._provisioned_repo_created = True
+        return result
     except IntegrityError:
         await db.rollback()
         logger.warning(

--- a/app/submissions/services/submissions_services_submissions_workspace_creation_single_service.py
+++ b/app/submissions/services/submissions_services_submissions_workspace_creation_single_service.py
@@ -80,6 +80,7 @@ async def provision_single_workspace(
         create_workspace_kwargs["refresh"] = False
     workspace = await workspace_repo.create_workspace(db, **create_workspace_kwargs)
     if not hydrate_precommit_bundle:
+        workspace._provisioned_repo_created = True
         return workspace
     precommit_result = await apply_precommit_bundle_if_available(
         db,
@@ -91,6 +92,8 @@ async def provision_single_workspace(
         base_template_sha=workspace.base_template_sha,
         existing_precommit_sha=workspace.precommit_sha,
     )
-    return await persist_precommit_result(
+    result = await persist_precommit_result(
         db, workspace=workspace, precommit_result=precommit_result, commit=commit
     )
+    result._provisioned_repo_created = True
+    return result

--- a/app/submissions/services/submissions_services_submissions_workspace_provision_service.py
+++ b/app/submissions/services/submissions_services_submissions_workspace_provision_service.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.integrations.github.client import GithubClient
 from app.shared.database.shared_database_models_model import CandidateSession, Task
+from app.shared.utils.shared_utils_errors_utils import ApiError
 from app.submissions.repositories.github_native.workspaces import (
     submissions_repositories_github_native_workspaces_submissions_github_native_workspaces_core_repository as workspace_repo,
 )
@@ -45,6 +46,16 @@ async def ensure_workspace(
     """Fetch or create a workspace for the candidate+task."""
     if github_username:
         validate_github_username(github_username)
+    elif bootstrap_empty_repo:
+        raise ApiError(
+            status_code=400,
+            detail=(
+                "Candidate GitHub username is required before opening the "
+                "Trial workspace."
+            ),
+            error_code="GITHUB_USERNAME_REQUIRED",
+            retryable=False,
+        )
 
     resolved_workspace = (
         workspace_resolution

--- a/app/trials/services/trials_services_trials_invite_preprovision_service.py
+++ b/app/trials/services/trials_services_trials_invite_preprovision_service.py
@@ -30,11 +30,12 @@ async def preprovision_workspaces(
     *,
     now,
     fresh_candidate_session: bool = False,
-) -> None:
+) -> list[str]:
     """Execute preprovision workspaces."""
     repo_prefix = settings.github.GITHUB_REPO_PREFIX
     destination_owner = settings.github.GITHUB_ORG
     processed_workspace_keys: set[str] = set()
+    provisioned_repo_full_names: list[str] = []
     ensure_workspace_params = inspect.signature(
         submission_service.ensure_workspace
     ).parameters
@@ -49,6 +50,20 @@ async def preprovision_workspaces(
         workspace_key = resolve_workspace_key_for_task(task)
         if workspace_key and workspace_key in processed_workspace_keys:
             continue
+        github_username = (
+            getattr(candidate_session, "github_username", None) or ""
+        ).strip()
+        if not github_username:
+            logger.info(
+                "github_workspace_preprovision_skipped_missing_username",
+                extra={
+                    "trial_id": getattr(candidate_session, "trial_id", None),
+                    "candidate_session_id": getattr(candidate_session, "id", None),
+                    "task_id": task.id,
+                    "day_index": task.day_index,
+                },
+            )
+            continue
         try:
             ensure_workspace_kwargs = {
                 "candidate_session": candidate_session,
@@ -56,7 +71,7 @@ async def preprovision_workspaces(
                 "scenario_version": scenario_version,
                 "task": task,
                 "github_client": github_client,
-                "github_username": "",
+                "github_username": github_username,
                 "repo_prefix": repo_prefix,
                 "destination_owner": destination_owner,
                 "now": now,
@@ -79,10 +94,23 @@ async def preprovision_workspaces(
                 ensure_workspace_kwargs["commit"] = False
             if supports_hydrate_precommit_bundle:
                 ensure_workspace_kwargs["hydrate_precommit_bundle"] = False
-            await submission_service.ensure_workspace(db, **ensure_workspace_kwargs)
+            workspace = await submission_service.ensure_workspace(
+                db, **ensure_workspace_kwargs
+            )
+            repo_full_name = getattr(workspace, "repo_full_name", None)
+            if (
+                repo_full_name
+                and getattr(workspace, "_provisioned_repo_created", False)
+                and repo_full_name not in provisioned_repo_full_names
+            ):
+                provisioned_repo_full_names.append(repo_full_name)
             if workspace_key:
                 processed_workspace_keys.add(workspace_key)
-        except GithubError as exc:
+        except Exception as exc:
+            if provisioned_repo_full_names and not hasattr(
+                exc, "provisioned_repo_full_names"
+            ):
+                exc.provisioned_repo_full_names = tuple(provisioned_repo_full_names)
             logger.error(
                 "github_workspace_preprovision_failed",
                 extra={
@@ -100,3 +128,7 @@ async def preprovision_workspaces(
                 },
             )
             raise
+    return provisioned_repo_full_names
+
+
+__all__ = ["preprovision_workspaces", "GithubError"]

--- a/app/trials/services/trials_services_trials_invite_workflow_service.py
+++ b/app/trials/services/trials_services_trials_invite_workflow_service.py
@@ -7,13 +7,9 @@ from datetime import datetime
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from app.config import settings
 from app.integrations.github import GithubClient
 from app.notifications.services import service as notification_service
 from app.shared.time.shared_time_now_service import utcnow as shared_utcnow
-from app.submissions.services.submissions_services_submissions_workspace_bootstrap_service import (
-    build_candidate_repo_name,
-)
 from app.trials import services as sim_service
 from app.trials.services import (
     trials_services_trials_invite_preprovision_service as invite_preprovision,
@@ -22,23 +18,26 @@ from app.trials.services import (
 logger = logging.getLogger(__name__)
 
 
-async def _cleanup_candidate_repo(
-    github_client: GithubClient, repo_full_name: str
-) -> None:
-    """Delete a freshly created candidate repo best-effort."""
-    try:
-        await github_client.delete_repo(repo_full_name)
-    except Exception as exc:  # pragma: no cover - cleanup should not mask root cause
-        logger.warning(
-            "candidate_repo_cleanup_failed",
-            extra={"repo_full_name": repo_full_name, "error": str(exc)},
-        )
-
-
 async def _rollback_if_supported(db: AsyncSession) -> None:
     rollback = getattr(db, "rollback", None)
     if callable(rollback):
         await rollback()
+
+
+async def _cleanup_provisioned_repos(
+    github_client: GithubClient, repo_full_names: tuple[str, ...] | list[str]
+) -> None:
+    delete_repo = getattr(github_client, "delete_repo", None)
+    if not callable(delete_repo):
+        return
+    for repo_full_name in dict.fromkeys(repo_full_names):
+        try:
+            await delete_repo(repo_full_name)
+        except Exception:
+            logger.warning(
+                "github_workspace_preprovision_cleanup_failed",
+                extra={"repo_full_name": repo_full_name},
+            )
 
 
 async def create_candidate_invite_workflow(
@@ -93,8 +92,9 @@ async def create_candidate_invite_workflow(
     )
     fresh_candidate_session = bool(getattr(cs, "_invite_newly_created", False))
     invite_url = sim_service.invite_url(cs.token)
+    provisioned_repo_full_names: tuple[str, ...] = ()
     try:
-        await invite_preprovision.preprovision_workspaces(
+        provisioned_repo_full_names = await invite_preprovision.preprovision_workspaces(
             db,
             cs,
             sim,
@@ -112,14 +112,17 @@ async def create_candidate_invite_workflow(
             email_service=email_service,
             now=now,
         )
-    except Exception:
-        await _rollback_if_supported(db)
+    except Exception as exc:
         if fresh_candidate_session:
-            repo_name = build_candidate_repo_name(
-                settings.github.GITHUB_REPO_PREFIX, cs
+            cleanup_targets = getattr(exc, "provisioned_repo_full_names", ())
+            if not cleanup_targets:
+                cleanup_targets = provisioned_repo_full_names
+            if cleanup_targets is None:
+                cleanup_targets = ()
+            await _cleanup_provisioned_repos(
+                github_client,
+                tuple(cleanup_targets),
             )
-            await _cleanup_candidate_repo(
-                github_client, f"{settings.github.GITHUB_ORG}/{repo_name}"
-            )
+        await _rollback_if_supported(db)
         raise
     return cs, sim, outcome, invite_url

--- a/docs/codespaces_actions.md
+++ b/docs/codespaces_actions.md
@@ -4,17 +4,17 @@ Winoe now runs code tasks entirely from an empty candidate repo, Codespaces for 
 
 ## Candidate flow (backend endpoints)
 0) `POST /api/trials/{trialId}/invite`
-   - Creates an empty Day 2/Day 3 workspace repo with devcontainer, brief, and evidence workflow.
+   - Creates an empty Trial workspace repo with devcontainer, brief, and evidence workflow.
 1) `POST /api/tasks/{taskId}/codespace/init`
    - Creates or resolves the candidate repo; invites candidate via GitHub username.
-   - Returns repo URL + Codespaces URL, default branch, workspace id, and stores `base_template_sha` (default branch head).
+   - Returns repo URL + Codespaces URL, default branch, workspace id, and stores the repo head SHA.
 2) `POST /api/tasks/{taskId}/run`
    - Triggers `workflow_dispatch` on the workspace repo with optional `workflowInputs` + `branch`.
    - Polls the dispatched run and parses artifacts; returns `{status, passed, failed, total, stdout, stderr, runId, workflowUrl, commitSha}`.
 3) `GET /api/tasks/{taskId}/run/{runId}`
    - Fetches an existing run result (polling helper) and returns the same normalized payload.
 4) `POST /api/tasks/{taskId}/submit`
-   - Triggers run (if needed) and stores commit/workflow ids, test output, and `diff_summary_json` from `base_template_sha...head_sha`.
+   - Triggers run (if needed) and stores commit/workflow ids, test output, and evidence summary from the candidate repo.
 5) `GET /api/tasks/{taskId}/codespace/status`
    - Returns repo metadata, last test summary, and `codespaceUrl` as a `codespaces.new` deep link (no GitHub API side effects).
 
@@ -32,11 +32,11 @@ Talent Partner endpoints include repo/commit/workflow/diff URLs for detail and l
 - `WINOE_GITHUB_API_BASE` (default `https://api.github.com`)
 - `WINOE_GITHUB_ORG`
 - `WINOE_GITHUB_TOKEN` (bot/app token with repo + actions)
-- `WINOE_GITHUB_ACTIONS_WORKFLOW_FILE` (defaults to `evidence-capture.yml`)
+- `WINOE_GITHUB_ACTIONS_WORKFLOW_FILE` (defaults to `winoe-evidence-capture.yml`)
 - `WINOE_GITHUB_REPO_PREFIX`
 
 ## YC demo checklist
-- Create/verify template repos for each task with the correct workflow file.
+- Create or recover candidate repos with the correct workflow file.
 - Ensure Actions workflow uploads the artifact described above.
 - Configure env vars (above) and restart backend.
-- Run candidate flow end-to-end: init codespace, run tests, submit; verify talent_partner list/detail show repo/commit/workflow/diff links and parsed test counts.
+- Run candidate flow end-to-end: init codespace, run tests, submit; verify talent_partner list/detail show repo/commit/workflow links and parsed evidence counts.

--- a/pr.md
+++ b/pr.md
@@ -1,91 +1,178 @@
-# 1. Title
+# Harden empty-repo GitHub provisioning and evidence capture
 
-Unblock real Day 2 candidate verification by fixing GitHub/Codespace reliability, repo activation, and Actions dispatch behavior
+## Summary
 
-# 2. Linked / Related Issues
+This PR hardens GitHub provisioning for the v4 from-scratch Tech Trial flow.
 
-- Winoe-AI/winoe-backend issue #285: Require GitHub username capture and fix Codespace init contract
-- Winoe-AI/winoe-backend issue #286: Enforce Codespace-only Day 2/3 workflow and remove offline/local work permission
-- Related frontend dependency: Winoe-AI/winoe-frontend issue #183
+Candidate workspaces are now created as empty repos and initialized only with Winoe-owned workspace files. Candidate GitHub username is required before workspace provisioning, collaborator permissioning uses that username, evidence capture runs through the canonical workflow `.github/workflows/winoe-evidence-capture.yml`, stable evidence artifact names are parsed reliably, and cleanup is bounded and idempotent.
 
-# 3. Problem / Why
+## What changed
 
-Day 2 could not be verified end to end on the real stack until the backend-side Codespace and Actions contract was made reliable.
+- Empty-repo repo creation and recovery path for candidate workspaces.
+- Required bootstrap files are created in the repo:
+  - `.devcontainer/devcontainer.json`
+  - `README.md`
+  - `.gitignore`
+  - `.github/workflows/winoe-evidence-capture.yml`
+- Devcontainer defaults to the Microsoft universal image unless a language-specific image is selected for the Talent Partner's preferred language.
+- `README.md` is used as the Project Brief.
+- No app starter code is added to candidate repos.
+- Generated `.gitignore` does not ignore lockfiles.
+- Candidate GitHub username is required before provisioning continues.
+- Collaborator add behavior is retried safely when permissioning already exists or was partially applied.
+- Evidence workflow and artifact parser behavior were updated for the new canonical workflow and stable artifact names.
+- Invite and preprovision cleanup paths are more precise so they only remove resources created during the current attempt.
+- Retry and idempotency paths are covered by tests.
+- Documentation was updated to match the v4 empty-repo provisioning flow.
 
-The original blockers were the ones tracked in #285 and #286:
+## v4 pivot alignment
 
-- GitHub username capture and Codespace init contract support were incomplete.
-- The workflow still had ambiguity around Codespace-only candidate work.
-- The backend needed to produce the right day-flow state so the frontend could open, poll, and close Day 2 correctly.
+- No generated-from-template repo path is used in active provisioning.
+- No template catalog dependency is used in active provisioning.
+- No precommit bundle is applied to candidate repos in the v4 path.
+- No Codespace Specializor or Specializer component is used.
+- The repo is evaluated as candidate-authored from scratch.
 
-During live QA, additional reliability issues surfaced that had to be fixed before real candidate flow could be trusted:
+This wording reflects the active path only. It does not claim historical compatibility code was removed unless the implementation actually changed it.
 
-- shared-time consistency and candidate-session day-flow correctness
-- workspace repo / Codespace bootstrap robustness
-- archived workspace repos causing `workflow_dispatch` runs to queue without jobs
-- repo activation before Codespace init
-- repo activation before GitHub Actions dispatch
+## Evidence / artifacts
 
-# 4. What Changed
+Canonical artifact names:
 
-- Backend support now matches the GitHub username / Codespace init contract expected by the candidate flow.
-- Codespace-only workflow enforcement is supported from the backend side.
-- Candidate-session day-flow and shared-time handling were tightened so the frontend receives stable open/closed behavior.
-- Workspace repo and Codespace bootstrap state handling was hardened.
-- Workspace repos are activated / unarchived before Codespace init.
-- Workspace repos are activated / unarchived before GitHub Actions run dispatch.
-- The run-tests path now avoids the failure mode where a `workflow_dispatch` stays queued with `jobs: []`.
-- Targeted backend tests were added or updated around repo activation and run-tests behavior.
+- `winoe-commit-metadata`
+- `winoe-file-creation-timeline`
+- `winoe-repo-tree-summary`
+- `winoe-dependency-manifests`
+- `winoe-test-detection`
+- `winoe-test-results`
+- `winoe-lint-detection`
+- `winoe-lint-results`
+- `winoe-evidence-manifest`
 
-# 5. Key Files Changed
+Canonical JSON files:
 
-- `app/integrations/github/client/integrations_github_client_github_client_repos_client.py`
-- `app/submissions/services/submissions_services_submissions_workspace_bootstrap_service.py`
-- `app/submissions/services/submissions_services_submissions_workspace_repo_state_service.py`
-- `app/submissions/services/use_cases/submissions_services_use_cases_submissions_use_cases_run_tests_service.py`
-- Targeted backend tests covering repo activation, Codespace init, and run dispatch behavior
+- `commit_metadata.json`
+- `file_creation_timeline.json`
+- `repo_tree_summary.json`
+- `dependency_manifests.json`
+- `test_detection.json`
+- `test_results.json`
+- `lint_detection.json`
+- `lint_results.json`
+- `evidence_manifest.json`
 
-# 6. QA / Validation Summary
+Wrapper schema fields:
 
-Validation was done in two layers:
+- `schema_version`
+- `repository_full_name`
+- `commit_sha`
+- `workflow_run_id`
+- `generated_at`
+- `status`
+- `payload`
 
-- Targeted backend checks passed for repo activation and run-tests behavior.
-- Ruff checks passed for the touched backend surface.
-- Full-stack live QA later exercised the real frontend + backend stack with a real browser auth session and no QA-driver state seeding.
+Test and lint detection distinguishes:
 
-The backend changes were verified by observing the real candidate flow from open Day 2 through run-tests completion and submit completion on the live stack.
+- `detected`
+- `not_detected`
+- failed command execution as evidence
 
-# 7. Live Evidence Summary
+## Idempotency and recovery
 
-- A live GitHub Actions run on `winoe-ai-repos/winoe-ws-36` was observed stuck in `queued` with `jobs: []`, which confirmed the archived-repo / activation failure mode.
-- After repo activation, a later Actions run succeeded, confirming the backend fix for dispatch reliability.
-- The final contract-live QA on the real stack reached terminal run-tests success and a successful submit on the candidate flow.
-- The frontend open-day and closed-day artifacts show the backend-backed open/closed day behavior that the UI now consumes.
+- Provisioning retry reuses the existing repo and workspace.
+- Missing bootstrap files are repaired.
+- Missing workflow files are repaired.
+- Collaborator add is safe on retry.
+- Codespace creation and recovery paths are retried safely.
+- Duplicate workspace groups and workspaces are avoided.
+- Day 2 and Day 3 share the canonical coding repo where expected.
 
-# 8. Risks / Follow-Ups
+## Cleanup behavior
 
-- This backend PR unblocked real Day 2 Actions dispatch and verification, but it does not by itself close the frontend issue.
-- If GitHub template repo state changes again, repo activation / unarchive preflight should continue to run before init and dispatch.
-- Any future Codespace or Actions contract changes should be revalidated against the live candidate flow, not just unit tests.
+- Cleanup is idempotent.
+- Invite rollback cleanup only targets repos created during the current attempt.
+- Existing or reused repos are not deleted accidentally.
+- Trial termination cleanup remains scoped to the Trial and workspace.
+- Already-cleaned resources are handled safely.
 
-# 9. Reviewer Notes
+## QA evidence
 
-- The important outcome here is reliability: real Day 2 candidate execution can now be verified on the live stack.
-- This work is the backend side of the broader Day 2 fix; the frontend PR #183 is still the UI-facing part of the overall flow.
-- The root causes were not just one endpoint. They were a combination of contract mismatch, repo state handling, and Actions dispatch robustness.
-- The queued-with-no-jobs failure mode is the key evidence that repo activation had to happen before dispatch.
+```text
+QA PASS — ready for PR prompt
+
+Environment:
+- Branch: feature/harden-github-provisioning-for-empty-repo-codespace-creation-and-evidence-capture
+- Commit: d39e7dbf0b091bc239d4d50870d8d52a4af00d0b
+- Backend command: ./scripts/local_qa_backend.sh
+- Worker command: python -m app.shared.jobs.shared_jobs_worker_cli_service worker
+- Backend health: GET /health returned {"status":"ok"}
+- Worker readiness: GET /ready returned ready with fresh worker heartbeat
+
+Manual QA covered:
+- missing GitHub username gate
+- username-present provisioning
+- repo contents inspection
+- idempotent retry
+- partial recovery
+- evidence workflow contract
+- artifact parsing/retrieval
+- cleanup/termination
+- retired-terminology active-path check
+```
+
+```text
+Live GitHub push execution was not performed in this QA pass. Route probes used an in-memory stub GitHub provider. GitHub Actions workflow execution was verified by workflow YAML contract and backend tests; artifact parsing/retrieval was verified through backend test paths.
+```
+
+## Validation
+
+```text
+bash ./precommit.sh
+✅ passed
+1865 passed, 13 warnings
+Coverage: 96.00%
+Required coverage: 96%
+```
+
+```text
+git diff --check
+✅ passed
+```
+
+## Risks / limitations
+
+- Live GitHub push execution was not performed in this QA pass.
+- Evidence capture execution was verified through workflow contract checks and backend tests rather than a live GitHub Actions run.
+- Cleanup correctness depends on the repo/workspace identifiers returned by the current attempt, so future changes to those identifiers should be revalidated.
+
+## Issue checklist
+
+- [x] Empty repo creation is idempotent and safe to retry
+- [x] Repo initialized with `.devcontainer/devcontainer.json`, `README.md`, `.gitignore`, and evidence-capture Actions workflow
+- [x] Devcontainer uses Microsoft universal image by default
+- [x] Recovery from partial GitHub API failure / partial repo initialization
+- [x] Candidate username-based permissioning via collaborator add
+- [x] GitHub Actions evidence-capture workflow runs on push
+- [x] Workflow captures commit metadata, file creation order, test detection, and linting results
+- [x] Evidence artifacts are uploaded and parseable/retrievable through backend paths
+- [x] Cleanup on Trial termination is idempotent and scoped
+
+## PR title
+
+Harden empty-repo GitHub provisioning and evidence capture
 
 Worker Report:
-
 - Summary
-  - Updated `pr.md` only to describe the backend reliability work that unblocked real Day 2 verification.
+  - Updated `pr.md` only to describe the v4 empty-repo GitHub provisioning and evidence capture flow.
 - Files changed
   - `pr.md`
 - Commands run
-  - `sed -n '1,260p' pr.md` - pass
-  - `rg -n "queued|jobs: \[\]|activation|unarchive|workflow_dispatch|repo|Codespace|github username|pollAfterMs|run_tests|Submit" ...` - pass
+  - `git status --short` - pass
+  - `git diff --check` - pass
+  - `bash ./precommit.sh` - pass
+  - `git diff --check` - pass
 - Risks / assumptions
-  - Assumed the live QA findings are the final source of truth for backend root causes and validation wording.
-  - Kept the backend PR honest about scope: it unblocked verification, but it does not alone close the frontend issue.
+  - Assumed the provided QA and validation text is the canonical PR-materials source.
+  - Kept the document aligned to the active v4 path and avoided retired product language in the main narrative.
 - Open questions / blockers
   - None

--- a/tests/config/test_config_github_settings_validators_utils.py
+++ b/tests/config/test_config_github_settings_validators_utils.py
@@ -11,7 +11,7 @@ def test_github_settings_defaults_canonical_destination_org():
 
     assert settings.GITHUB_ORG == "winoe-ai-repos"
     assert settings.GITHUB_TEMPLATE_OWNER == "winoe-ai-repos"
-    assert settings.GITHUB_ACTIONS_WORKFLOW_FILE == "evidence-capture.yml"
+    assert settings.GITHUB_ACTIONS_WORKFLOW_FILE == "winoe-evidence-capture.yml"
 
 
 def test_github_settings_reject_negative_workspace_retention_days():

--- a/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_artifacts_runner_service.py
+++ b/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_artifacts_runner_service.py
@@ -34,6 +34,18 @@ class StubClient(GithubClient):
         return self._contents[artifact_id]
 
 
+def _wrap_artifact_payload(payload):
+    return {
+        "schema_version": "1",
+        "repository_full_name": "org/repo",
+        "commit_sha": "abc123",
+        "workflow_run_id": "11",
+        "generated_at": "2026-03-13T00:00:00Z",
+        "status": "success",
+        "payload": payload,
+    }
+
+
 def test_is_dispatched_run_filters_event_and_created_at():
     runner = GithubActionsRunner(
         DummyClient(), workflow_file="winoe-evidence-capture.yml"
@@ -102,58 +114,130 @@ async def test_parse_artifacts_surfaces_evidence_artifacts():
                 }
             ),
         )
+        zf.writestr(
+            "test_results.json",
+            json.dumps(
+                _wrap_artifact_payload(
+                    {"status": "success", "command": "python -m pytest"}
+                )
+            ),
+        )
 
     commit_buf = io.BytesIO()
     with ZipFile(commit_buf, "w") as zf:
         zf.writestr(
-            "commit-metadata.json",
-            json.dumps({"generatedAt": "2026-03-13T00:00:00Z", "commits": []}),
+            "commit_metadata.json",
+            json.dumps(
+                _wrap_artifact_payload(
+                    {"generatedAt": "2026-03-13T00:00:00Z", "commits": []}
+                )
+            ),
         )
 
     timeline_buf = io.BytesIO()
     with ZipFile(timeline_buf, "w") as zf:
         zf.writestr(
-            "file-creation-timeline.json",
-            json.dumps({"generatedAt": "2026-03-13T00:00:00Z", "filesCreated": []}),
+            "file_creation_timeline.json",
+            json.dumps(
+                _wrap_artifact_payload(
+                    {"generatedAt": "2026-03-13T00:00:00Z", "filesCreated": []}
+                )
+            ),
         )
 
     snapshot_buf = io.BytesIO()
     with ZipFile(snapshot_buf, "w") as zf:
         zf.writestr(
-            "repo-structure-snapshot.json",
+            "repo_tree_summary.json",
             json.dumps(
-                {"generatedAt": "2026-03-13T00:00:00Z", "paths": ["src/app.py"]}
+                _wrap_artifact_payload(
+                    {"generatedAt": "2026-03-13T00:00:00Z", "paths": ["src/app.py"]}
+                )
             ),
         )
-        zf.writestr("repo-structure-snapshot.txt", "src/app.py\n")
+        zf.writestr("repo_tree_summary.txt", "src/app.py\n")
+
+    dependency_buf = io.BytesIO()
+    with ZipFile(dependency_buf, "w") as zf:
+        zf.writestr(
+            "dependency_manifests.json",
+            json.dumps(
+                _wrap_artifact_payload(
+                    {"generatedAt": "2026-03-13T00:00:00Z", "manifests": []}
+                )
+            ),
+        )
+
+    test_detection_buf = io.BytesIO()
+    with ZipFile(test_detection_buf, "w") as zf:
+        zf.writestr(
+            "test_detection.json",
+            json.dumps(
+                _wrap_artifact_payload(
+                    {
+                        "detected": True,
+                        "command": "python -m pytest",
+                        "reason": "detected from pyproject.toml",
+                    }
+                )
+            ),
+        )
+
+    lint_detection_buf = io.BytesIO()
+    with ZipFile(lint_detection_buf, "w") as zf:
+        zf.writestr(
+            "lint_detection.json",
+            json.dumps(
+                _wrap_artifact_payload(
+                    {
+                        "detected": True,
+                        "command": "python -m ruff check .",
+                        "reason": "detected from pyproject.toml",
+                    }
+                )
+            ),
+        )
 
     lint_buf = io.BytesIO()
     with ZipFile(lint_buf, "w") as zf:
         zf.writestr(
-            "lint-results.json",
-            json.dumps({"actionOutcome": "success", "notes": "ok"}),
+            "lint_results.json",
+            json.dumps(
+                _wrap_artifact_payload(
+                    {"status": "success", "command": "python -m ruff check ."}
+                )
+            ),
         )
 
-    coverage_buf = io.BytesIO()
-    with ZipFile(coverage_buf, "w") as zf:
-        zf.writestr("coverage.xml", "<coverage />")
+    evidence_manifest_buf = io.BytesIO()
+    with ZipFile(evidence_manifest_buf, "w") as zf:
+        zf.writestr(
+            "evidence_manifest.json",
+            json.dumps(_wrap_artifact_payload({"artifacts": ["commit_metadata.json"]})),
+        )
 
     client = StubClient(
         artifacts=[
             {"id": 1, "name": "winoe-test-results"},
             {"id": 2, "name": "winoe-commit-metadata"},
             {"id": 3, "name": "winoe-file-creation-timeline"},
-            {"id": 4, "name": "winoe-repo-structure-snapshot"},
-            {"id": 5, "name": "winoe-lint-results"},
-            {"id": 6, "name": "winoe-coverage"},
+            {"id": 4, "name": "winoe-repo-tree-summary"},
+            {"id": 5, "name": "winoe-dependency-manifests"},
+            {"id": 6, "name": "winoe-test-detection"},
+            {"id": 7, "name": "winoe-lint-detection"},
+            {"id": 8, "name": "winoe-lint-results"},
+            {"id": 9, "name": "winoe-evidence-manifest"},
         ],
         contents={
             1: test_buf.getvalue(),
             2: commit_buf.getvalue(),
             3: timeline_buf.getvalue(),
             4: snapshot_buf.getvalue(),
-            5: lint_buf.getvalue(),
-            6: coverage_buf.getvalue(),
+            5: dependency_buf.getvalue(),
+            6: test_detection_buf.getvalue(),
+            7: lint_detection_buf.getvalue(),
+            8: lint_buf.getvalue(),
+            9: evidence_manifest_buf.getvalue(),
         },
     )
     runner = GithubActionsRunner(client, workflow_file="winoe-evidence-capture.yml")
@@ -163,15 +247,29 @@ async def test_parse_artifacts_surfaces_evidence_artifacts():
     assert parsed is not None
     assert parsed.summary is not None
     evidence = parsed.summary["evidenceArtifacts"]
-    assert evidence["commitMetadata"]["data"]["generatedAt"] == "2026-03-13T00:00:00Z"
-    assert evidence["fileCreationTimeline"]["data"]["filesCreated"] == []
-    assert evidence["repoStructureSnapshot"]["data"]["paths"] == ["src/app.py"]
+    assert evidence["commitMetadata"]["data"]["schema_version"] == "1"
+    assert evidence["commitMetadata"]["data"]["repository_full_name"] == "org/repo"
     assert (
-        evidence["repoStructureSnapshot"]["textFiles"]["repo-structure-snapshot.txt"]
+        evidence["commitMetadata"]["data"]["payload"]["generatedAt"]
+        == "2026-03-13T00:00:00Z"
+    )
+    assert evidence["fileCreationTimeline"]["data"]["payload"]["filesCreated"] == []
+    assert evidence["repoTreeSummary"]["data"]["payload"]["paths"] == ["src/app.py"]
+    assert (
+        evidence["repoTreeSummary"]["textFiles"]["repo_tree_summary.txt"]
         == "src/app.py\n"
     )
-    assert evidence["lintResults"]["data"]["actionOutcome"] == "success"
-    assert evidence["coverage"]["files"] == ["coverage.xml"]
+    assert evidence["dependencyManifests"]["data"]["payload"]["manifests"] == []
+    assert evidence["testDetection"]["data"]["payload"]["command"] == "python -m pytest"
+    assert evidence["testResults"]["data"]["payload"]["command"] == "python -m pytest"
+    assert (
+        evidence["lintDetection"]["data"]["payload"]["command"]
+        == "python -m ruff check ."
+    )
+    assert evidence["lintResults"]["data"]["payload"]["status"] == "success"
+    assert evidence["evidenceManifest"]["data"]["payload"]["artifacts"] == [
+        "commit_metadata.json"
+    ]
 
 
 @pytest.mark.asyncio
@@ -179,8 +277,21 @@ async def test_parse_artifacts_caches_evidence_summary_when_test_results_missing
     commit_buf = io.BytesIO()
     with ZipFile(commit_buf, "w") as zf:
         zf.writestr(
-            "commit-metadata.json",
-            json.dumps({"generatedAt": "2026-03-13T00:00:00Z", "commits": []}),
+            "commit_metadata.json",
+            json.dumps(
+                {
+                    "schema_version": "1",
+                    "repository_full_name": "org/repo",
+                    "commit_sha": "abc123",
+                    "workflow_run_id": "12",
+                    "generated_at": "2026-03-13T00:00:00Z",
+                    "status": "success",
+                    "payload": {
+                        "generatedAt": "2026-03-13T00:00:00Z",
+                        "commits": [],
+                    },
+                }
+            ),
         )
 
     client = StubClient(
@@ -243,7 +354,7 @@ async def test_parse_artifact_helpers_cover_download_failure_and_expired_filters
 
     assert _pick_test_artifacts(artifacts) == [{"id": 2, "name": "winoe-test-results"}]
 
-    parsed, error = await _parse_first_test_artifact(
+    parsed, error, evidence = await _parse_first_test_artifact(
         FailureClient(),
         runner.cache,
         "org/repo",
@@ -252,6 +363,7 @@ async def test_parse_artifact_helpers_cover_download_failure_and_expired_filters
     )
     assert parsed is None
     assert error == "artifact_download_failed"
+    assert evidence == {}
 
     class EvidenceClient(GithubClient):
         def __init__(self):

--- a/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_build_result_artifact_error_sets_error_service.py
+++ b/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_build_result_artifact_error_sets_error_service.py
@@ -43,11 +43,19 @@ async def test_build_result_surfaces_evidence_summary_when_artifacts_missing():
             buf = io.BytesIO()
             with zipfile.ZipFile(buf, "w") as zf:
                 zf.writestr(
-                    "commit-metadata.json",
+                    "commit_metadata.json",
                     json.dumps(
                         {
-                            "generatedAt": "2026-03-13T00:00:00Z",
-                            "commits": [],
+                            "schema_version": "1",
+                            "repository_full_name": "org/repo",
+                            "commit_sha": "abc123",
+                            "workflow_run_id": "11",
+                            "generated_at": "2026-03-13T00:00:00Z",
+                            "status": "success",
+                            "payload": {
+                                "generatedAt": "2026-03-13T00:00:00Z",
+                                "commits": [],
+                            },
                         }
                     ),
                 )
@@ -91,11 +99,19 @@ async def test_build_result_surfaces_evidence_summary_when_test_results_corrupt(
             buf = io.BytesIO()
             with zipfile.ZipFile(buf, "w") as zf:
                 zf.writestr(
-                    "commit-metadata.json",
+                    "commit_metadata.json",
                     json.dumps(
                         {
-                            "generatedAt": "2026-03-13T00:00:00Z",
-                            "commits": [],
+                            "schema_version": "1",
+                            "repository_full_name": "org/repo",
+                            "commit_sha": "abc123",
+                            "workflow_run_id": "11",
+                            "generated_at": "2026-03-13T00:00:00Z",
+                            "status": "success",
+                            "payload": {
+                                "generatedAt": "2026-03-13T00:00:00Z",
+                                "commits": [],
+                            },
                         }
                     ),
                 )

--- a/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_dispatch_and_wait_returns_running_when_run_is_queued_service.py
+++ b/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_dispatch_and_wait_returns_running_when_run_is_queued_service.py
@@ -35,7 +35,7 @@ async def test_dispatch_and_wait_returns_running_when_run_is_queued(monkeypatch)
 
     runner = GithubActionsRunner(
         QueuedClient(),
-        workflow_file="evidence-capture.yml",
+        workflow_file="winoe-evidence-capture.yml",
         poll_interval_seconds=0.01,
         max_poll_seconds=0.05,
     )

--- a/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_dispatch_uses_canonical_workflow_service.py
+++ b/tests/integrations/github/actions_runner/test_integrations_github_actions_runner_dispatch_uses_canonical_workflow_service.py
@@ -17,7 +17,7 @@ async def test_dispatch_uses_canonical_evidence_capture_workflow_first():
             return None
 
     client = StubClient()
-    runner = GithubActionsRunner(client, workflow_file="evidence-capture.yml")
+    runner = GithubActionsRunner(client, workflow_file="winoe-evidence-capture.yml")
 
     used = await runner._dispatch_with_fallbacks(
         "org/repo",
@@ -25,7 +25,7 @@ async def test_dispatch_uses_canonical_evidence_capture_workflow_first():
         inputs={"trialId": "123"},
     )
 
-    assert used == "evidence-capture.yml"
+    assert used == "winoe-evidence-capture.yml"
     assert client.calls == [
-        ("org/repo", "evidence-capture.yml", "main", {"trialId": "123"})
+        ("org/repo", "winoe-evidence-capture.yml", "main", {"trialId": "123"})
     ]

--- a/tests/integrations/github/artifacts/test_integrations_github_artifacts_service.py
+++ b/tests/integrations/github/artifacts/test_integrations_github_artifacts_service.py
@@ -11,6 +11,18 @@ from app.integrations.github.artifacts import (
 )
 
 
+def _wrapped_payload(*, payload):
+    return {
+        "schema_version": "1",
+        "repository_full_name": "org/repo",
+        "commit_sha": "abc123",
+        "workflow_run_id": "99",
+        "generated_at": "2026-03-13T00:00:00Z",
+        "status": "success",
+        "payload": payload,
+    }
+
+
 def test_parse_test_results_prefers_json():
     buf = io.BytesIO()
     with ZipFile(buf, "w") as zf:
@@ -93,23 +105,32 @@ def test_parse_evidence_artifact_prefers_json_and_keeps_manifest():
     buf = io.BytesIO()
     with ZipFile(buf, "w") as zf:
         zf.writestr(
-            "repo-structure-snapshot.json",
-            json.dumps({"generatedAt": "2026-03-13T00:00:00Z", "paths": ["a.py"]}),
+            "repo_tree_summary.json",
+            json.dumps(
+                _wrapped_payload(
+                    payload={"generatedAt": "2026-03-13T00:00:00Z", "paths": ["a.py"]}
+                )
+            ),
         )
-        zf.writestr("repo-structure-snapshot.txt", "a.py\n")
-    parsed = parse_evidence_artifact_zip(
-        buf.getvalue(), "winoe-repo-structure-snapshot"
-    )
+        zf.writestr("repo_tree_summary.txt", "a.py\n")
+    parsed = parse_evidence_artifact_zip(buf.getvalue(), "winoe-repo-tree-summary")
     assert parsed is not None
-    assert parsed.artifact_name == "winoe-repo-structure-snapshot"
+    assert parsed.artifact_name == "winoe-repo-tree-summary"
     assert parsed.files == [
-        "repo-structure-snapshot.json",
-        "repo-structure-snapshot.txt",
+        "repo_tree_summary.json",
+        "repo_tree_summary.txt",
     ]
     assert parsed.data == {
-        "generatedAt": "2026-03-13T00:00:00Z",
-        "paths": ["a.py"],
+        "schema_version": "1",
+        "repository_full_name": "org/repo",
+        "commit_sha": "abc123",
+        "workflow_run_id": "99",
+        "generated_at": "2026-03-13T00:00:00Z",
+        "status": "success",
+        "payload": {"generatedAt": "2026-03-13T00:00:00Z", "paths": ["a.py"]},
     }
     summary = build_evidence_artifact_summary(parsed)
-    assert summary["artifactName"] == "winoe-repo-structure-snapshot"
-    assert summary["jsonFiles"]["repo-structure-snapshot.json"]["paths"] == ["a.py"]
+    assert summary["artifactName"] == "winoe-repo-tree-summary"
+    assert summary["jsonFiles"]["repo_tree_summary.json"]["payload"]["paths"] == [
+        "a.py"
+    ]

--- a/tests/shared/http/dependencies/test_shared_http_dependencies_github_native_service.py
+++ b/tests/shared/http/dependencies/test_shared_http_dependencies_github_native_service.py
@@ -18,7 +18,7 @@ def test_actions_runner_singleton_reused_and_custom_client_gets_new_runner():
         runner1.workflow_file
         == github_native.settings.github.GITHUB_ACTIONS_WORKFLOW_FILE
     )
-    assert runner1.workflow_file == "evidence-capture.yml"
+    assert runner1.workflow_file == "winoe-evidence-capture.yml"
 
     custom_client = GithubClient(
         base_url="https://api.github.com", token="custom-token", default_org="org"

--- a/tests/shared/jobs/handlers/test_shared_jobs_handlers_github_workflow_artifact_parse_build_actions_runner_returns_configured_runner_and_client_handler.py
+++ b/tests/shared/jobs/handlers/test_shared_jobs_handlers_github_workflow_artifact_parse_build_actions_runner_returns_configured_runner_and_client_handler.py
@@ -13,7 +13,7 @@ async def test_build_actions_runner_returns_configured_runner_and_client():
             runner.workflow_file
             == parse_handler.settings.github.GITHUB_ACTIONS_WORKFLOW_FILE
         )
-        assert runner.workflow_file == "evidence-capture.yml"
+        assert runner.workflow_file == "winoe-evidence-capture.yml"
         assert runner.poll_interval_seconds == 2.0
         assert runner.max_poll_seconds == 90.0
     finally:

--- a/tests/submissions/services/test_submissions_candidate_service_ensure_workspace_creates_repo_service.py
+++ b/tests/submissions/services/test_submissions_candidate_service_ensure_workspace_creates_repo_service.py
@@ -12,16 +12,19 @@ async def test_ensure_workspace_creates_repo(async_session):
     cs = await create_candidate_session(async_session, trial=sim, status="in_progress")
 
     class StubGithubClient:
-        async def generate_repo_from_template(self, **kw):
-            owner = kw["owner"]
-            new_repo_name = kw["new_repo_name"]
+        async def create_empty_repo(
+            self, *, owner, repo_name, private=True, default_branch="main"
+        ):
             return {
                 "owner": {"login": owner},
-                "name": new_repo_name,
-                "full_name": f"{owner}/{new_repo_name}",
+                "name": repo_name,
+                "full_name": f"{owner}/{repo_name}",
                 "id": 5,
-                "default_branch": "main",
+                "default_branch": default_branch,
             }
+
+        async def get_file_contents(self, *_args, **_kwargs):
+            raise GithubError("missing", status_code=404)
 
         async def add_collaborator(
             self, repo_full_name, username, *, permission="push"
@@ -30,6 +33,36 @@ async def test_ensure_workspace_creates_repo(async_session):
 
         async def get_branch(self, repo_full_name, branch):
             return {"commit": {"sha": "base-sha"}}
+
+        async def create_blob(self, _repo_full_name, *, content):
+            return {"sha": "blob-sha"}
+
+        async def create_tree(self, _repo_full_name, *, tree, base_tree=None):
+            return {"sha": "tree-sha"}
+
+        async def create_commit(self, _repo_full_name, *, message, tree, parents):
+            return {"sha": "commit-sha"}
+
+        async def create_ref(self, _repo_full_name, *, ref, sha):
+            return {"ref": ref, "sha": sha}
+
+        async def update_ref(self, _repo_full_name, *, ref, sha, force=False):
+            return {"ref": ref, "sha": sha, "force": force}
+
+        async def create_codespace(
+            self,
+            repo_full_name,
+            *,
+            ref=None,
+            devcontainer_path=None,
+            machine=None,
+            location=None,
+        ):
+            return {
+                "name": "codespace-1",
+                "state": "available",
+                "web_url": "https://codespace.example",
+            }
 
     ws = await svc.ensure_workspace(
         async_session,
@@ -42,4 +75,33 @@ async def test_ensure_workspace_creates_repo(async_session):
         now=datetime.now(UTC),
     )
     assert ws.repo_full_name == f"org/prefix-{cs.id}-coding"
-    assert ws.base_template_sha == "base-sha"
+    assert ws.base_template_sha == "commit-sha"
+
+
+@pytest.mark.asyncio
+async def test_ensure_workspace_requires_username_for_empty_repo(async_session):
+    talent_partner = await create_talent_partner(async_session, email="ws2@sim.com")
+    sim, tasks = await create_trial(async_session, created_by=talent_partner)
+    cs = await create_candidate_session(async_session, trial=sim, status="in_progress")
+
+    class StubGithubClient:
+        async def create_empty_repo(self, **_kw):
+            raise AssertionError(
+                "empty repo creation should be gated before GitHub calls"
+            )
+
+    with pytest.raises(HTTPException) as excinfo:
+        await svc.ensure_workspace(
+            async_session,
+            candidate_session=cs,
+            task=tasks[1],
+            github_client=StubGithubClient(),
+            github_username="",
+            repo_prefix="prefix-",
+            destination_owner="org",
+            now=datetime.now(UTC),
+            bootstrap_empty_repo=True,
+        )
+
+    assert excinfo.value.status_code == 400
+    assert getattr(excinfo.value, "error_code", None) == "GITHUB_USERNAME_REQUIRED"

--- a/tests/submissions/services/test_submissions_candidate_service_ensure_workspace_handles_branch_fetch_error_service.py
+++ b/tests/submissions/services/test_submissions_candidate_service_ensure_workspace_handles_branch_fetch_error_service.py
@@ -13,7 +13,7 @@ async def test_ensure_workspace_handles_branch_fetch_error(async_session):
     expected_repo_name = f"pref-{cs.id}-coding"
 
     class StubGithub:
-        async def generate_repo_from_template(self, **_kw):
+        async def create_empty_repo(self, **_kw):
             return {
                 "owner": {"login": "org"},
                 "name": expected_repo_name,
@@ -22,8 +22,33 @@ async def test_ensure_workspace_handles_branch_fetch_error(async_session):
                 "id": 1,
             }
 
+        async def get_file_contents(self, *_a, **_k):
+            raise GithubError("missing", status_code=404)
+
         async def get_branch(self, *_a, **_k):
             raise GithubError("no branch")
+
+        async def create_or_update_file(self, *_a, **_k):
+            return {"content": {"sha": "readme-sha"}}
+
+        async def create_blob(self, *_a, **_k):
+            return {"sha": "blob-sha"}
+
+        async def create_tree(self, *_a, **_k):
+            return {"sha": "tree-sha"}
+
+        async def create_commit(self, *_a, **_k):
+            return {"sha": "commit-sha"}
+
+        async def create_ref(self, *_a, **_k):
+            return {"ref": "refs/heads/main", "sha": "commit-sha"}
+
+        async def create_codespace(self, *_a, **_k):
+            return {
+                "name": "codespace-1",
+                "state": "available",
+                "web_url": "https://codespace.example",
+            }
 
         async def add_collaborator(self, *_a, **_k):
             return None
@@ -38,4 +63,4 @@ async def test_ensure_workspace_handles_branch_fetch_error(async_session):
         destination_owner="org",
         now=datetime.now(UTC),
     )
-    assert ws.base_template_sha is None
+    assert ws.base_template_sha == "commit-sha"

--- a/tests/submissions/services/test_submissions_workspace_bootstrap_service.py
+++ b/tests/submissions/services/test_submissions_workspace_bootstrap_service.py
@@ -18,7 +18,7 @@ def test_build_evidence_capture_workflow_yaml_is_valid_and_structured():
     parsed = yaml.load(workflow_text, Loader=yaml.BaseLoader)
 
     assert parsed["name"] == "Winoe Evidence Capture"
-    assert parsed["on"]["push"]["branches"] == ["main"]
+    assert parsed["on"]["push"] in ({}, None, "")
     assert "workflow_dispatch" in parsed["on"]
 
     steps = parsed["jobs"]["capture"]["steps"]
@@ -27,9 +27,7 @@ def test_build_evidence_capture_workflow_yaml_is_valid_and_structured():
     )
     assert checkout_step["with"]["fetch-depth"] == "0"
 
-    capture_step = next(
-        step for step in steps if step["name"] == "Capture repository evidence"
-    )
+    capture_step = next(step for step in steps if step["name"] == "Capture evidence")
     assert capture_step["continue-on-error"] == "true"
 
     upload_steps = {
@@ -41,12 +39,13 @@ def test_build_evidence_capture_workflow_yaml_is_valid_and_structured():
     assert (
         upload_steps["winoe-file-creation-timeline"]["with"]["retention-days"] == "90"
     )
-    assert (
-        upload_steps["winoe-repo-structure-snapshot"]["with"]["retention-days"] == "90"
-    )
+    assert upload_steps["winoe-repo-tree-summary"]["with"]["retention-days"] == "90"
+    assert upload_steps["winoe-dependency-manifests"]["with"]["retention-days"] == "90"
+    assert upload_steps["winoe-test-detection"]["with"]["retention-days"] == "90"
     assert upload_steps["winoe-test-results"]["with"]["retention-days"] == "90"
-    assert upload_steps["winoe-coverage"]["with"]["retention-days"] == "90"
+    assert upload_steps["winoe-lint-detection"]["with"]["retention-days"] == "90"
     assert upload_steps["winoe-lint-results"]["with"]["retention-days"] == "90"
+    assert upload_steps["winoe-evidence-manifest"]["with"]["retention-days"] == "90"
 
 
 @pytest.mark.asyncio
@@ -158,31 +157,46 @@ async def test_bootstrap_empty_candidate_repo_writes_only_allowed_files():
     assert result.codespace_url == "https://codespace-77.github.dev"
     assert [entry["path"] for entry in client.tree_entries] == [
         ".devcontainer/devcontainer.json",
-        ".gitignore",
-        ".github/workflows/evidence-capture.yml",
         "README.md",
+        ".gitignore",
+        ".github/workflows/winoe-evidence-capture.yml",
     ]
-    assert ".github/workflows/winoe-evidence-capture.yml" not in {
+    assert ".github/workflows/evidence-capture.yml" not in {
         entry["path"] for entry in client.tree_entries
     }
     workflow_entry = next(
         entry
         for entry in client.tree_entries
-        if entry["path"] == ".github/workflows/evidence-capture.yml"
+        if entry["path"] == ".github/workflows/winoe-evidence-capture.yml"
     )
     workflow_text = workflow_entry["content"]
     assert "push:" in workflow_text
-    assert "branches:" in workflow_text
     assert "continue-on-error: true" in workflow_text
     assert "fetch-depth: 0" in workflow_text
     assert "retention-days: 90" in workflow_text
-    assert "npm test -- --coverage" in workflow_text
-    assert "python -m pytest --cov=." in workflow_text
+    assert "commit_metadata.json" in workflow_text
+    assert "file_creation_timeline.json" in workflow_text
+    assert "repo_tree_summary.json" in workflow_text
+    assert "dependency_manifests.json" in workflow_text
+    assert "test_detection.json" in workflow_text
+    assert "test_results.json" in workflow_text
+    assert "lint_detection.json" in workflow_text
+    assert "lint_results.json" in workflow_text
+    assert "evidence_manifest.json" in workflow_text
+    assert "package.json found without test or lint scripts" in workflow_text
+    assert "detected package.json scripts" in workflow_text
+    assert "detected Python project manifest and common test paths" in workflow_text
     assert (
-        "go test ./... -coverprofile=artifacts/coverage/coverage.out" in workflow_text
+        "detected Python project manifest without obvious test paths" in workflow_text
     )
-    assert "mvn test" in workflow_text
-    assert "github/super-linter/slim@v6" in workflow_text
+    assert "no supported manifest with a runnable command found" in workflow_text
+    gitignore_entry = next(
+        entry for entry in client.tree_entries if entry["path"] == ".gitignore"
+    )
+    assert "package-lock.json" not in gitignore_entry["content"]
+    assert "pnpm-lock.yaml" not in gitignore_entry["content"]
+    assert "yarn.lock" not in gitignore_entry["content"]
+    assert gitignore_entry["content"].count(".vscode/") == 1
     readme_entry = next(
         entry for entry in client.tree_entries if entry["path"] == "README.md"
     )
@@ -872,15 +886,19 @@ async def test_bootstrap_empty_candidate_repo_initializes_empty_repo_via_content
     assert len(client.created_blobs) == 4
     assert [entry["path"] for entry in client.tree_entries] == [
         ".devcontainer/devcontainer.json",
-        ".gitignore",
-        ".github/workflows/evidence-capture.yml",
         "README.md",
+        ".gitignore",
+        ".github/workflows/winoe-evidence-capture.yml",
     ]
-    workflow_text = client.created_blobs[2]
+    workflow_text = client.created_blobs[3]
     assert "workflow_dispatch:" in workflow_text
     assert "continue-on-error: true" in workflow_text
     assert "retention-days: 90" in workflow_text
-    assert "github/super-linter/slim@v6" in workflow_text
+    assert "repo_tree_summary.json" in workflow_text
+    assert "evidence_manifest.json" in workflow_text
+    assert "package-lock.json" not in client.created_blobs[2]
+    assert "pnpm-lock.yaml" not in client.created_blobs[2]
+    assert "yarn.lock" not in client.created_blobs[2]
     assert client.commit_args == {
         "message": "chore: bootstrap candidate repo",
         "tree": "tree-sha",
@@ -892,7 +910,141 @@ async def test_bootstrap_empty_candidate_repo_initializes_empty_repo_via_content
 
 
 @pytest.mark.asyncio
-async def test_bootstrap_empty_candidate_repo_cleans_up_on_late_failure():
+async def test_bootstrap_empty_candidate_repo_recovers_when_bootstrap_files_are_missing():
+    candidate_session = SimpleNamespace(id=90)
+    trial = SimpleNamespace(title="Recovery trial", role="Backend Engineer")
+    scenario_version = SimpleNamespace(
+        storyline_md="# Recovery",
+        project_brief_md="# Project Brief\n\n## Business Context\n\nRecover partially seeded repos.\n",
+    )
+
+    collaborator_calls: list[tuple[str, str]] = []
+
+    class StubGithubClient:
+        def __init__(self):
+            self.created_blobs = []
+            self.tree_entries = None
+            self.commit_args = None
+            self.ref_args = None
+            self.codespace_request = None
+            self.created_repo_calls = 0
+
+        async def create_empty_repo(
+            self, *, owner, repo_name, private=True, default_branch="main"
+        ):
+            self.created_repo_calls += 1
+            raise GithubError("repo exists", status_code=422)
+
+        async def get_repo(self, repo_full_name):
+            return {
+                "owner": {"login": repo_full_name.split("/", 1)[0]},
+                "name": repo_full_name.split("/", 1)[1],
+                "full_name": repo_full_name,
+                "id": 999,
+                "default_branch": "main",
+            }
+
+        async def get_branch(self, *_args, **_kwargs):
+            return {"commit": {"sha": "existing-sha"}}
+
+        async def get_file_contents(self, repo_full_name, file_path, *, ref=None):
+            if file_path == "README.md":
+                return {"content": "existing readme"}
+            raise GithubError("missing", status_code=404)
+
+        async def create_blob(self, _repo_full_name, *, content):
+            sha = f"blob-{len(self.created_blobs) + 1}"
+            self.created_blobs.append(content)
+            return {"sha": sha}
+
+        async def get_commit(self, _repo_full_name, sha):
+            assert sha == "existing-sha"
+            return {"tree": {"sha": "existing-tree-sha"}}
+
+        async def create_tree(self, _repo_full_name, *, tree, base_tree=None):
+            self.tree_entries = tree
+            assert base_tree == "existing-tree-sha"
+            return {"sha": "tree-sha"}
+
+        async def create_commit(self, _repo_full_name, *, message, tree, parents):
+            self.commit_args = {
+                "message": message,
+                "tree": tree,
+                "parents": parents,
+            }
+            return {"sha": "commit-sha"}
+
+        async def update_ref(self, _repo_full_name, *, ref, sha, force=False):
+            self.ref_args = (ref, sha, force)
+            return {"ref": ref, "sha": sha}
+
+        async def get_authenticated_user_login(self):
+            return "octocat"
+
+        async def create_codespace(
+            self,
+            repo_full_name,
+            *,
+            ref=None,
+            devcontainer_path=None,
+            machine=None,
+            location=None,
+        ):
+            self.codespace_request = {
+                "repo_full_name": repo_full_name,
+                "ref": ref,
+                "devcontainer_path": devcontainer_path,
+                "machine": machine,
+                "location": location,
+            }
+            return {
+                "name": "codespace-90",
+                "state": "available",
+                "web_url": "https://codespace-90.github.dev",
+            }
+
+    client = StubGithubClient()
+
+    async def _add_collaborator_if_needed(github_client, repo_full_name, username):
+        collaborator_calls.append((repo_full_name, username))
+
+    original_add_collaborator = bootstrap_service.add_collaborator_if_needed
+    bootstrap_service.add_collaborator_if_needed = _add_collaborator_if_needed
+    try:
+        result = await bootstrap_service.bootstrap_empty_candidate_repo(
+            github_client=client,
+            candidate_session=candidate_session,
+            trial=trial,
+            scenario_version=scenario_version,
+            task=SimpleNamespace(title="Day 2 coding"),
+            repo_prefix="winoe-ws-",
+            destination_owner="winoe-ai-repos",
+        )
+    finally:
+        bootstrap_service.add_collaborator_if_needed = original_add_collaborator
+
+    assert client.created_repo_calls == 1
+    assert len(client.created_blobs) == 4
+    assert [entry["path"] for entry in client.tree_entries] == [
+        ".devcontainer/devcontainer.json",
+        "README.md",
+        ".gitignore",
+        ".github/workflows/winoe-evidence-capture.yml",
+    ]
+    assert collaborator_calls == [("winoe-ai-repos/winoe-ws-90", "octocat")]
+    assert client.codespace_request == {
+        "repo_full_name": "winoe-ai-repos/winoe-ws-90",
+        "ref": "main",
+        "devcontainer_path": ".devcontainer/devcontainer.json",
+        "machine": None,
+        "location": None,
+    }
+    assert result.bootstrap_commit_sha == "commit-sha"
+    assert result.codespace_url == "https://codespace-90.github.dev"
+
+
+@pytest.mark.asyncio
+async def test_bootstrap_empty_candidate_repo_keeps_repo_on_late_failure():
     candidate_session = SimpleNamespace(id=89)
     trial = SimpleNamespace(title="Cleanup trial", role="Backend Engineer")
     scenario_version = SimpleNamespace(
@@ -962,7 +1114,7 @@ async def test_bootstrap_empty_candidate_repo_cleans_up_on_late_failure():
             destination_owner="winoe-ai-repos",
         )
 
-    assert client.deleted_repos == ["winoe-ai-repos/winoe-ws-89"]
+    assert client.deleted_repos == []
 
 
 @pytest.mark.asyncio

--- a/tests/tasks/routes/test_tasks_run_codespace_init_day3_keeps_legacy_task_scoped_behavior_routes.py
+++ b/tests/tasks/routes/test_tasks_run_codespace_init_day3_keeps_legacy_task_scoped_behavior_routes.py
@@ -39,23 +39,23 @@ async def test_codespace_init_day3_keeps_legacy_task_scoped_behavior(
         created_at=datetime.now(UTC),
     )
 
-    calls: dict[str, int] = {"generate": 0}
+    calls: dict[str, int] = {"create": 0}
 
     class StubGithubClient:
-        async def generate_repo_from_template(
-            self,
-            *,
-            template_full_name: str,
-            new_repo_name: str,
-            owner=None,
-            private=True,
+        async def create_empty_repo(
+            self, *, owner, repo_name, private=True, default_branch="main"
         ):
-            calls["generate"] += 1
+            calls["create"] += 1
             return {
-                "full_name": f"{owner}/{new_repo_name}",
-                "id": 900 + calls["generate"],
-                "default_branch": "main",
+                "owner": {"login": owner},
+                "name": repo_name,
+                "full_name": f"{owner}/{repo_name}",
+                "id": 900 + calls["create"],
+                "default_branch": default_branch,
             }
+
+        async def get_file_contents(self, *_a, **_k):
+            raise GithubError("missing", status_code=404)
 
         async def add_collaborator(
             self, repo_full_name: str, username: str, *, permission: str = "push"
@@ -63,7 +63,32 @@ async def test_codespace_init_day3_keeps_legacy_task_scoped_behavior(
             return {"ok": True}
 
         async def get_branch(self, repo_full_name: str, branch: str):
-            return {"commit": {"sha": "base-sha"}}
+            raise GithubError("missing", status_code=404)
+
+        async def create_or_update_file(self, *_a, **_k):
+            return {"content": {"sha": "readme-sha"}}
+
+        async def create_blob(self, *_a, **_k):
+            return {"sha": "blob-sha"}
+
+        async def create_tree(self, *_a, **_k):
+            return {"sha": "tree-sha"}
+
+        async def create_commit(self, *_a, **_k):
+            return {"sha": "commit-sha"}
+
+        async def create_ref(self, *_a, **_k):
+            return {"ref": "refs/heads/main", "sha": "commit-sha"}
+
+        async def create_codespace(self, *_a, **_k):
+            return {
+                "name": "codespace-day3",
+                "state": "available",
+                "web_url": "https://codespace.example",
+            }
+
+        async def get_authenticated_user_login(self):
+            return "octocat"
 
     with override_dependencies(
         {candidate_submissions.get_github_client: lambda: StubGithubClient()}
@@ -91,7 +116,7 @@ async def test_codespace_init_day3_keeps_legacy_task_scoped_behavior(
     assert day2_status.json()["repoFullName"] == legacy_day2.repo_full_name
     assert day3_status.status_code == 200, day3_status.text
     assert day3_status.json()["repoFullName"] == day3_repo
-    assert calls["generate"] == 1
+    assert calls["create"] == 1
 
     workspace_groups = (
         (

--- a/tests/tasks/routes/test_tasks_run_codespace_init_error_includes_error_code_and_sanitizes_tokens_routes.py
+++ b/tests/tasks/routes/test_tasks_run_codespace_init_error_includes_error_code_and_sanitizes_tokens_routes.py
@@ -23,7 +23,7 @@ async def test_codespace_init_error_includes_error_code_and_sanitizes_tokens(
     await async_session.commit()
 
     class ErrorGithubClient:
-        async def generate_repo_from_template(self, **_kwargs):
+        async def create_empty_repo(self, **_kwargs):
             raise GithubError(
                 "Authorization: Bearer eyJFAKE.JWT.TOKEN ghp_FAKEGITHUBTOKEN123",
                 status_code=403,

--- a/tests/tasks/routes/test_tasks_run_codespace_init_invalid_token_maps_to_specific_error_routes.py
+++ b/tests/tasks/routes/test_tasks_run_codespace_init_invalid_token_maps_to_specific_error_routes.py
@@ -23,7 +23,7 @@ async def test_codespace_init_invalid_token_maps_to_specific_error(
     await async_session.commit()
 
     class ErrorGithubClient:
-        async def generate_repo_from_template(self, **_kwargs):
+        async def create_empty_repo(self, **_kwargs):
             raise GithubError("bad token", status_code=401)
 
     with override_dependencies(

--- a/tests/tasks/routes/test_tasks_run_codespace_init_maps_github_errors_to_502_routes.py
+++ b/tests/tasks/routes/test_tasks_run_codespace_init_maps_github_errors_to_502_routes.py
@@ -25,7 +25,7 @@ async def test_codespace_init_maps_github_errors_to_502(
     await async_session.commit()
 
     class ErrorGithubClient:
-        async def generate_repo_from_template(self, **_kwargs):
+        async def create_empty_repo(self, **_kwargs):
             raise GithubError("Bad credentials", status_code=403)
 
     with override_dependencies(

--- a/tests/tasks/routes/test_tasks_run_codespace_init_reuses_existing_workspace_and_skips_github_routes.py
+++ b/tests/tasks/routes/test_tasks_run_codespace_init_reuses_existing_workspace_and_skips_github_routes.py
@@ -35,19 +35,12 @@ async def test_codespace_init_reuses_existing_workspace_and_skips_github(
         created_at=datetime.now(UTC),
     )
 
-    calls: dict[str, int] = {"generate": 0}
+    calls: dict[str, int] = {"create": 0}
 
     class CountingGithubClient:
-        async def generate_repo_from_template(
-            self,
-            *,
-            template_full_name: str,
-            new_repo_name: str,
-            owner=None,
-            private=True,
-        ):
-            calls["generate"] += 1
-            raise AssertionError("generate_repo_from_template should not be called")
+        async def create_empty_repo(self, **_kwargs):
+            calls["create"] += 1
+            raise AssertionError("create_empty_repo should not be called")
 
         async def add_collaborator(
             self, repo_full_name: str, username: str, *, permission: str = "push"
@@ -75,7 +68,7 @@ async def test_codespace_init_reuses_existing_workspace_and_skips_github(
     body = resp.json()
     assert body["workspaceId"] == existing.id
     assert body["repoFullName"] == existing.repo_full_name
-    assert calls["generate"] == 0
+    assert calls["create"] == 0
 
     rows = await async_session.execute(
         select(Workspace).where(

--- a/tests/tasks/routes/test_tasks_run_codespace_status_day2_and_day3_share_single_repo_routes.py
+++ b/tests/tasks/routes/test_tasks_run_codespace_status_day2_and_day3_share_single_repo_routes.py
@@ -24,31 +24,56 @@ async def test_codespace_status_day2_and_day3_share_single_repo(
     )
     await async_session.commit()
 
-    calls: dict[str, int] = {"generate": 0}
+    calls: dict[str, int] = {"create": 0}
 
     class StubGithubClient:
-        async def generate_repo_from_template(
-            self,
-            *,
-            template_full_name: str,
-            new_repo_name: str,
-            owner=None,
-            private=True,
+        async def create_empty_repo(
+            self, *, owner, repo_name, private=True, default_branch="main"
         ):
-            calls["generate"] += 1
+            calls["create"] += 1
             return {
-                "full_name": f"{owner}/{new_repo_name}",
-                "id": 800 + calls["generate"],
-                "default_branch": "main",
+                "owner": {"login": owner},
+                "name": repo_name,
+                "full_name": f"{owner}/{repo_name}",
+                "id": 800 + calls["create"],
+                "default_branch": default_branch,
+            }
+
+        async def get_file_contents(self, *_a, **_k):
+            raise GithubError("missing", status_code=404)
+
+        async def get_branch(self, repo_full_name: str, branch: str):
+            return {"commit": {"sha": "base-sha"}}
+
+        async def create_or_update_file(self, *_a, **_k):
+            return {"content": {"sha": "readme-sha"}}
+
+        async def create_blob(self, *_a, **_k):
+            return {"sha": "blob-sha"}
+
+        async def create_tree(self, *_a, **_k):
+            return {"sha": "tree-sha"}
+
+        async def create_commit(self, *_a, **_k):
+            return {"sha": "commit-sha"}
+
+        async def create_ref(self, *_a, **_k):
+            return {"ref": "refs/heads/main", "sha": "commit-sha"}
+
+        async def update_ref(self, *_a, **_k):
+            return {"ref": "refs/heads/main", "sha": "commit-sha"}
+
+        async def create_codespace(self, *_a, **_k):
+            return {
+                "name": "codespace-1",
+                "state": "available",
+                "web_url": "https://codespace.example",
             }
 
         async def add_collaborator(
             self, repo_full_name: str, username: str, *, permission: str = "push"
         ):
             return {"ok": True}
-
-        async def get_branch(self, repo_full_name: str, branch: str):
-            return {"commit": {"sha": "base-sha"}}
 
     with override_dependencies(
         {candidate_submissions.get_github_client: lambda: StubGithubClient()}
@@ -74,4 +99,4 @@ async def test_codespace_status_day2_and_day3_share_single_repo(
 
     assert day3_status.status_code == 200, day3_status.text
     assert day3_status.json()["repoFullName"] == day2_repo
-    assert calls["generate"] == 1
+    assert calls["create"] == 1

--- a/tests/tasks/routes/test_tasks_run_get_run_result_github_error_maps_to_502_routes.py
+++ b/tests/tasks/routes/test_tasks_run_get_run_result_github_error_maps_to_502_routes.py
@@ -30,30 +30,52 @@ async def test_get_run_result_github_error_maps_to_502(
             raise GithubError("nope")
 
     class StubGithubClient:
-        async def generate_repo_from_template(
-            self,
-            *,
-            template_full_name: str,
-            new_repo_name: str,
-            owner=None,
-            private=True,
+        async def create_empty_repo(
+            self, *, owner, repo_name, private=True, default_branch="main"
         ):
-            destination_owner = settings.github.GITHUB_ORG
             return {
-                "owner": {"login": destination_owner},
-                "name": new_repo_name,
-                "full_name": f"{destination_owner}/{new_repo_name}",
+                "owner": {"login": owner},
+                "name": repo_name,
+                "full_name": f"{owner}/{repo_name}",
                 "id": 1,
-                "default_branch": "main",
+                "default_branch": default_branch,
+            }
+
+        async def get_file_contents(self, *_a, **_k):
+            raise GithubError("missing", status_code=404)
+
+        async def get_branch(self, repo_full_name: str, branch: str):
+            return {"commit": {"sha": "base"}}
+
+        async def create_or_update_file(self, *_a, **_k):
+            return {"content": {"sha": "readme-sha"}}
+
+        async def create_blob(self, *_a, **_k):
+            return {"sha": "blob-sha"}
+
+        async def create_tree(self, *_a, **_k):
+            return {"sha": "tree-sha"}
+
+        async def create_commit(self, *_a, **_k):
+            return {"sha": "commit-sha"}
+
+        async def create_ref(self, *_a, **_k):
+            return {"ref": "refs/heads/main", "sha": "commit-sha"}
+
+        async def update_ref(self, *_a, **_k):
+            return {"ref": "refs/heads/main", "sha": "commit-sha"}
+
+        async def create_codespace(self, *_a, **_k):
+            return {
+                "name": "codespace-1",
+                "state": "available",
+                "web_url": "https://codespace.example",
             }
 
         async def add_collaborator(
             self, repo_full_name: str, username: str, *, permission: str = "push"
         ):
             return {"ok": True}
-
-        async def get_branch(self, repo_full_name: str, branch: str):
-            return {"commit": {"sha": "base"}}
 
         async def get_compare(self, repo_full_name: str, base: str, head: str):
             return {}

--- a/tests/tasks/routes/test_tasks_run_run_day3_uses_day2_canonical_repo_routes.py
+++ b/tests/tasks/routes/test_tasks_run_run_day3_uses_day2_canonical_repo_routes.py
@@ -24,31 +24,56 @@ async def test_run_day3_uses_day2_canonical_repo(
     )
     await async_session.commit()
 
-    calls: dict[str, object] = {"generate": 0, "run_repos": []}
+    calls: dict[str, object] = {"create": 0, "run_repos": []}
 
     class StubGithubClient:
-        async def generate_repo_from_template(
-            self,
-            *,
-            template_full_name: str,
-            new_repo_name: str,
-            owner=None,
-            private=True,
+        async def create_empty_repo(
+            self, *, owner, repo_name, private=True, default_branch="main"
         ):
-            calls["generate"] = int(calls["generate"]) + 1
+            calls["create"] = int(calls["create"]) + 1
             return {
-                "full_name": f"{owner}/{new_repo_name}",
-                "id": 850 + int(calls["generate"]),
-                "default_branch": "main",
+                "owner": {"login": owner},
+                "name": repo_name,
+                "full_name": f"{owner}/{repo_name}",
+                "id": 850 + int(calls["create"]),
+                "default_branch": default_branch,
+            }
+
+        async def get_file_contents(self, *_a, **_k):
+            raise GithubError("missing", status_code=404)
+
+        async def get_branch(self, repo_full_name: str, branch: str):
+            return {"commit": {"sha": "base-sha"}}
+
+        async def create_or_update_file(self, *_a, **_k):
+            return {"content": {"sha": "readme-sha"}}
+
+        async def create_blob(self, *_a, **_k):
+            return {"sha": "blob-sha"}
+
+        async def create_tree(self, *_a, **_k):
+            return {"sha": "tree-sha"}
+
+        async def create_commit(self, *_a, **_k):
+            return {"sha": "commit-sha"}
+
+        async def create_ref(self, *_a, **_k):
+            return {"ref": "refs/heads/main", "sha": "commit-sha"}
+
+        async def update_ref(self, *_a, **_k):
+            return {"ref": "refs/heads/main", "sha": "commit-sha"}
+
+        async def create_codespace(self, *_a, **_k):
+            return {
+                "name": "codespace-1",
+                "state": "available",
+                "web_url": "https://codespace.example",
             }
 
         async def add_collaborator(
             self, repo_full_name: str, username: str, *, permission: str = "push"
         ):
             return {"ok": True}
-
-        async def get_branch(self, repo_full_name: str, branch: str):
-            return {"commit": {"sha": "base-sha"}}
 
     class StubActionsRunner:
         async def dispatch_and_wait(self, *, repo_full_name: str, ref: str, inputs):
@@ -95,5 +120,5 @@ async def test_run_day3_uses_day2_canonical_repo(
 
     assert day3_run.status_code == 200, day3_run.text
     assert day3_run.json()["commitSha"] == "run-sha"
-    assert calls["generate"] == 1
+    assert calls["create"] == 1
     assert calls["run_repos"] == [day2_repo]

--- a/tests/tasks/routes/test_tasks_run_run_tests_handles_artifact_missing_status_error_routes.py
+++ b/tests/tasks/routes/test_tasks_run_run_tests_handles_artifact_missing_status_error_routes.py
@@ -41,20 +41,47 @@ async def test_run_tests_handles_artifact_missing_status_error(
             )
 
     class StubGithubClient:
-        async def generate_repo_from_template(
-            self, *, template_full_name, new_repo_name, owner=None, private=True
+        async def create_empty_repo(
+            self, *, owner, repo_name, private=True, default_branch="main"
         ):
             return {
-                "full_name": f"{owner}/{new_repo_name}",
+                "owner": {"login": owner},
+                "name": repo_name,
+                "full_name": f"{owner}/{repo_name}",
                 "id": 999,
-                "default_branch": "main",
+                "default_branch": default_branch,
             }
+
+        async def get_file_contents(self, *_a, **_k):
+            raise GithubError("missing", status_code=404)
 
         async def add_collaborator(self, *_a, **_k):
             return {"ok": True}
 
         async def get_branch(self, *_a, **_k):
             return {"commit": {"sha": "base"}}
+
+        async def create_blob(self, *_a, **_k):
+            return {"sha": "blob-sha"}
+
+        async def create_tree(self, *_a, **_k):
+            return {"sha": "tree-sha"}
+
+        async def create_commit(self, *_a, **_k):
+            return {"sha": "commit-sha"}
+
+        async def create_ref(self, *_a, **_k):
+            return {"ref": "refs/heads/main", "sha": "commit-sha"}
+
+        async def update_ref(self, *_a, **_k):
+            return {"ref": "refs/heads/main", "sha": "commit-sha"}
+
+        async def create_codespace(self, *_a, **_k):
+            return {
+                "name": "codespace-1",
+                "state": "available",
+                "web_url": "https://example.com/codespace",
+            }
 
         async def get_compare(self, *_a, **_k):
             return {}
@@ -66,11 +93,12 @@ async def test_run_tests_handles_artifact_missing_status_error(
         }
     ):
         headers = candidate_header_factory(cs)
-        await async_client.post(
+        init_resp = await async_client.post(
             f"/api/tasks/{tasks[1].id}/codespace/init",
             headers=headers,
             json={"githubUsername": "octocat"},
         )
+        assert init_resp.status_code == 200, init_resp.text
         resp = await async_client.post(
             f"/api/tasks/{tasks[1].id}/run",
             headers=headers,

--- a/tests/tasks/routes/test_tasks_run_run_tests_maps_github_not_found_error_routes.py
+++ b/tests/tasks/routes/test_tasks_run_run_tests_maps_github_not_found_error_routes.py
@@ -30,28 +30,47 @@ async def test_run_tests_maps_github_not_found_error(
             raise GithubError("missing", status_code=404)
 
     class StubGithubClient:
-        async def generate_repo_from_template(
-            self,
-            *,
-            template_full_name: str,
-            new_repo_name: str,
-            owner=None,
-            private=True,
+        async def create_empty_repo(
+            self, *, owner, repo_name, private=True, default_branch="main"
         ):
-            destination_owner = settings.github.GITHUB_ORG
             return {
-                "owner": {"login": destination_owner},
-                "name": new_repo_name,
-                "full_name": f"{destination_owner}/{new_repo_name}",
+                "owner": {"login": owner},
+                "name": repo_name,
+                "full_name": f"{owner}/{repo_name}",
                 "id": 1,
-                "default_branch": "main",
+                "default_branch": default_branch,
             }
+
+        async def get_file_contents(self, *_a, **_k):
+            raise GithubError("missing", status_code=404)
 
         async def add_collaborator(self, *_a, **_k):
             return {"ok": True}
 
         async def get_branch(self, *_a, **_k):
             return {"commit": {"sha": "base"}}
+
+        async def create_blob(self, *_a, **_k):
+            return {"sha": "blob-sha"}
+
+        async def create_tree(self, *_a, **_k):
+            return {"sha": "tree-sha"}
+
+        async def create_commit(self, *_a, **_k):
+            return {"sha": "commit-sha"}
+
+        async def create_ref(self, *_a, **_k):
+            return {"ref": "refs/heads/main", "sha": "commit-sha"}
+
+        async def update_ref(self, *_a, **_k):
+            return {"ref": "refs/heads/main", "sha": "commit-sha"}
+
+        async def create_codespace(self, *_a, **_k):
+            return {
+                "name": "codespace-1",
+                "state": "available",
+                "web_url": "https://example.com/codespace",
+            }
 
         async def get_compare(self, *_a, **_k):
             return {}
@@ -63,11 +82,12 @@ async def test_run_tests_maps_github_not_found_error(
         }
     ):
         headers = candidate_header_factory(cs)
-        await async_client.post(
+        init_resp = await async_client.post(
             f"/api/tasks/{tasks[1].id}/codespace/init",
             headers=headers,
             json={"githubUsername": "octocat"},
         )
+        assert init_resp.status_code == 200, init_resp.text
         resp = await async_client.post(
             f"/api/tasks/{tasks[1].id}/run",
             headers=headers,

--- a/tests/tasks/routes/test_tasks_submit_code_submission_uses_preprovisioned_workspace_routes.py
+++ b/tests/tasks/routes/test_tasks_submit_code_submission_uses_preprovisioned_workspace_routes.py
@@ -38,6 +38,13 @@ async def test_code_submission_uses_preprovisioned_workspace(
     assert day2["currentDayIndex"] == 2
     day2_task_id = day2["currentTask"]["id"]
 
+    init_resp = await async_client.post(
+        f"/api/tasks/{day2_task_id}/codespace/init",
+        headers=candidate_headers(cs_id, access_token),
+        json={"githubUsername": "janegithub"},
+    )
+    assert init_resp.status_code == 200, init_resp.text
+
     workspace = (
         await async_session.execute(
             select(Workspace).where(

--- a/tests/trials/routes/test_trials_api_invite_github_failure_reuses_candidate_session_routes.py
+++ b/tests/trials/routes/test_trials_api_invite_github_failure_reuses_candidate_session_routes.py
@@ -17,82 +17,14 @@ async def test_invite_github_failure_does_not_persist_failed_candidate_session(
     day3_task = next(t for t in tasks if t.day_index == 3)
     day2_task.type = "code"
     day3_task.type = "code"
-    day2_task_id = day2_task.id
-    day3_task_id = day3_task.id
     await async_session.commit()
 
-    class FailingGithubClient:
+    class GithubClientStub:
         async def generate_repo_from_template(self, **_kwargs):
             raise AssertionError("generate_repo_from_template should not be called")
 
-        async def create_empty_repo(self, **_kw):
-            raise GithubError("boom")
-
-        async def get_file_contents(self, *_a, **_k):
-            raise GithubError("missing", status_code=404)
-
-        async def get_branch(self, *_a, **_k):
-            raise GithubError("missing", status_code=404)
-
-        async def create_tree(self, *_a, **_k):
-            return {"sha": "tree-sha"}
-
-        async def create_commit(self, *_a, **_k):
-            return {"sha": "commit-sha"}
-
-        async def create_ref(self, *_a, **_k):
-            return {"ref": "refs/heads/main", "sha": "commit-sha"}
-
-        async def add_collaborator(self, *_a, **_k):
-            return {"ok": True}
-
-    class SuccessGithubClient:
-        async def generate_repo_from_template(self, **_kwargs):
-            raise AssertionError("generate_repo_from_template should not be called")
-
-        async def create_empty_repo(
-            self, *, owner, repo_name, private=True, default_branch="main"
-        ):
-            return {
-                "full_name": f"{owner}/{repo_name}",
-                "id": 200,
-                "default_branch": default_branch,
-                "owner": {"login": owner},
-                "name": repo_name,
-            }
-
-        async def get_file_contents(self, *_a, **_k):
-            raise GithubError("missing", status_code=404)
-
-        async def get_branch(self, repo_full_name, branch):
-            raise GithubError("missing", status_code=404)
-
-        async def create_tree(self, *_a, **_k):
-            return {"sha": "tree-sha"}
-
-        async def create_commit(self, *_a, **_k):
-            return {"sha": "commit-sha"}
-
-        async def create_ref(self, *_a, **_k):
-            return {"ref": "refs/heads/main", "sha": "commit-sha"}
-
-        async def create_codespace(
-            self,
-            repo_full_name,
-            *,
-            ref=None,
-            devcontainer_path=None,
-            machine=None,
-            location=None,
-        ):
-            return {
-                "name": f"codespace-{repo_full_name.split('/', 1)[-1]}",
-                "state": "available",
-                "web_url": "https://codespace.example",
-            }
-
-        async def add_collaborator(self, *_a, **_k):
-            return {"ok": True}
+        async def create_empty_repo(self, **_kwargs):
+            raise AssertionError("create_empty_repo should not be called")
 
     provider = MemoryEmailProvider()
     email_service = EmailService(provider, sender="noreply@test.com")
@@ -100,7 +32,7 @@ async def test_invite_github_failure_does_not_persist_failed_candidate_session(
     with override_dependencies(
         {
             get_email_service: lambda: email_service,
-            get_github_client: lambda: FailingGithubClient(),
+            get_github_client: lambda: GithubClientStub(),
         }
     ):
         res = await async_client.post(
@@ -108,7 +40,8 @@ async def test_invite_github_failure_does_not_persist_failed_candidate_session(
             json={"candidateName": "Jane Doe", "inviteEmail": "jane@example.com"},
             headers={"x-dev-user-email": talent_partner_email},
         )
-    assert res.status_code == 502, res.text
+    assert res.status_code == 200, res.text
+    assert res.json()["outcome"] == "created"
 
     existing = (
         (
@@ -121,41 +54,15 @@ async def test_invite_github_failure_does_not_persist_failed_candidate_session(
         .scalars()
         .all()
     )
-    assert existing == []
-
-    with override_dependencies(
-        {
-            get_email_service: lambda: email_service,
-            get_github_client: lambda: SuccessGithubClient(),
-        }
-    ):
-        res = await async_client.post(
-            f"/api/trials/{trial_id}/invite",
-            json={"candidateName": "Jane Doe", "inviteEmail": "jane@example.com"},
-            headers={"x-dev-user-email": talent_partner_email},
-        )
-    assert res.status_code == 200, res.text
-    body = res.json()
-    assert body["outcome"] == "created"
-
-    created = (
-        (
-            await async_session.execute(
-                select(CandidateSession).where(
-                    CandidateSession.invite_email == "jane@example.com"
-                )
-            )
-        )
-        .scalars()
-        .all()
-    )
-    assert len(created) == 1
-    assert body["candidateSessionId"] == created[0].id
+    assert len(existing) == 1
+    assert existing[0].github_username is None
 
     workspaces = (
         (
             await async_session.execute(
-                select(Workspace).where(Workspace.candidate_session_id == created[0].id)
+                select(Workspace).where(
+                    Workspace.candidate_session_id == existing[0].id
+                )
             )
         )
         .scalars()
@@ -165,14 +72,12 @@ async def test_invite_github_failure_does_not_persist_failed_candidate_session(
         (
             await async_session.execute(
                 select(WorkspaceGroup).where(
-                    WorkspaceGroup.candidate_session_id == created[0].id
+                    WorkspaceGroup.candidate_session_id == existing[0].id
                 )
             )
         )
         .scalars()
         .all()
     )
-    assert len(workspace_groups) == 1
-    assert workspace_groups[0].workspace_key == "coding"
-    assert len(workspaces) == 1
-    assert workspaces[0].task_id in {day2_task_id, day3_task_id}
+    assert workspace_groups == []
+    assert workspaces == []

--- a/tests/trials/routes/test_trials_api_invite_preprovisions_day2_day3_workspaces_routes.py
+++ b/tests/trials/routes/test_trials_api_invite_preprovisions_day2_day3_workspaces_routes.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import pytest
 
 from app.config import settings
+from tests.shared.factories import create_candidate_session
 from tests.trials.routes.trials_api_utils import *
 
 
 @pytest.mark.asyncio
-async def test_invite_preprovisions_day2_day3_workspaces(
+async def test_invite_preprovisions_day2_day3_workspaces_skips_without_github_username(
     async_client,
     async_session,
     auth_header_factory,
@@ -119,6 +120,154 @@ async def test_invite_preprovisions_day2_day3_workspaces(
     assert resend_res.json()["outcome"] == "resent"
 
     cs = (await async_session.execute(select(CandidateSession))).scalar_one()
+    assert cs.github_username is None
+    workspaces = (
+        (
+            await async_session.execute(
+                select(Workspace).where(Workspace.candidate_session_id == cs.id)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    workspace_groups = (
+        (
+            await async_session.execute(
+                select(WorkspaceGroup).where(
+                    WorkspaceGroup.candidate_session_id == cs.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert len(stub_client.created_repos) == 0
+    assert stub_client.tree_entries == []
+    assert stub_client.created_refs == []
+    assert len(workspace_groups) == 0
+    assert len(workspaces) == 0
+
+
+@pytest.mark.asyncio
+async def test_invite_preprovisions_day2_day3_workspaces_with_candidate_username(
+    async_client,
+    async_session,
+    auth_header_factory,
+    override_dependencies,
+    monkeypatch,
+):
+    talent_partner = await create_talent_partner(
+        async_session, email="preprov2@app.com"
+    )
+    sim, tasks = await create_trial(async_session, created_by=talent_partner)
+
+    day2_tasks = [t for t in tasks if t.day_index == 2]
+    day3_tasks = [t for t in tasks if t.day_index == 3]
+    assert day2_tasks and day3_tasks
+    day2_tasks[0].type = "code"
+    day3_tasks[0].type = "code"
+    await async_session.commit()
+
+    candidate_session = await create_candidate_session(
+        async_session,
+        trial=sim,
+        invite_email="jane@example.com",
+    )
+    candidate_session.github_username = "octocat"
+    await async_session.commit()
+
+    monkeypatch.setattr(settings.github, "GITHUB_ORG", "winoe-ai-repos")
+
+    class StubGithubClient:
+        def __init__(self):
+            self.created_repos: list[tuple[str, str]] = []
+            self.tree_entries: list[dict] = []
+            self.created_refs: list[tuple[str, str]] = []
+            self.collaborators: list[str] = []
+            self.codespace_requests: list[dict[str, str | None]] = []
+
+        async def generate_repo_from_template(self, **_kwargs):
+            raise AssertionError("generate_repo_from_template should not be called")
+
+        async def create_empty_repo(
+            self, *, owner, repo_name, private=True, default_branch="main"
+        ):
+            self.created_repos.append((owner, repo_name))
+            return {
+                "owner": {"login": owner},
+                "name": repo_name,
+                "full_name": f"{owner}/{repo_name}",
+                "id": 200 + len(self.created_repos),
+                "default_branch": default_branch,
+            }
+
+        async def get_file_contents(self, repo_full_name, file_path, *, ref=None):
+            raise GithubError("missing", status_code=404)
+
+        async def get_branch(self, repo_full_name, branch):
+            raise GithubError("missing", status_code=404)
+
+        async def create_tree(self, repo_full_name, *, tree, base_tree=None):
+            self.tree_entries = tree
+            return {"sha": "tree-sha"}
+
+        async def create_commit(self, repo_full_name, *, message, tree, parents):
+            return {"sha": "commit-sha"}
+
+        async def create_ref(self, repo_full_name, *, ref, sha):
+            self.created_refs.append((ref, sha))
+            return {"ref": ref, "sha": sha}
+
+        async def create_codespace(
+            self,
+            repo_full_name,
+            *,
+            ref=None,
+            devcontainer_path=None,
+            machine=None,
+            location=None,
+        ):
+            self.codespace_requests.append(
+                {
+                    "repo_full_name": repo_full_name,
+                    "ref": ref,
+                    "devcontainer_path": devcontainer_path,
+                }
+            )
+            return {
+                "name": f"codespace-{repo_full_name.split('/', 1)[-1]}",
+                "state": "available",
+                "web_url": "https://codespace.example",
+            }
+
+        async def add_collaborator(
+            self, repo_full_name, username, *, permission="push"
+        ):
+            self.collaborators.append(username)
+            return {"ok": True}
+
+    provider = MemoryEmailProvider()
+    email_service = EmailService(provider, sender="noreply@test.com")
+    stub_client = StubGithubClient()
+
+    with override_dependencies(
+        {
+            get_email_service: lambda: email_service,
+            get_github_client: lambda: stub_client,
+        }
+    ):
+        res = await async_client.post(
+            f"/api/trials/{sim.id}/invite",
+            json={"candidateName": "Jane Doe", "inviteEmail": "jane@example.com"},
+            headers=auth_header_factory(talent_partner),
+        )
+
+    assert res.status_code == 200, res.text
+    body = res.json()
+    assert body["outcome"] == "resent"
+
+    cs = (await async_session.execute(select(CandidateSession))).scalar_one()
     workspaces = (
         (
             await async_session.execute(
@@ -141,34 +290,71 @@ async def test_invite_preprovisions_day2_day3_workspaces(
     )
 
     assert len(stub_client.created_repos) == 1
-    expected_repo_name = f"winoe-ws-{cs.id}"
-    assert stub_client.created_repos[0] == ("winoe-ai-repos", expected_repo_name)
+    assert stub_client.created_repos[0] == ("winoe-ai-repos", f"winoe-ws-{cs.id}")
     assert [entry["path"] for entry in stub_client.tree_entries] == [
         ".devcontainer/devcontainer.json",
-        ".gitignore",
-        ".github/workflows/evidence-capture.yml",
         "README.md",
+        ".gitignore",
+        ".github/workflows/winoe-evidence-capture.yml",
     ]
-    workflow_entry = next(
-        entry
-        for entry in stub_client.tree_entries
-        if entry["path"] == ".github/workflows/evidence-capture.yml"
-    )
-    assert "push:" in workflow_entry["content"]
-    assert "workflow_dispatch:" in workflow_entry["content"]
-    assert "continue-on-error: true" in workflow_entry["content"]
-    assert "retention-days: 90" in workflow_entry["content"]
     readme_entry = next(
         entry for entry in stub_client.tree_entries if entry["path"] == "README.md"
     )
     assert "Project Brief" in readme_entry["content"]
-    assert "Business Context" in readme_entry["content"]
-    assert "Acceptance Criteria" not in readme_entry["content"]
-    assert stub_client.created_refs == [("refs/heads/main", "commit-sha")]
+    assert "template" not in readme_entry["content"].lower()
+    assert stub_client.collaborators and all(
+        username == "octocat" for username in stub_client.collaborators
+    )
+    assert stub_client.codespace_requests == [
+        {
+            "repo_full_name": f"winoe-ai-repos/winoe-ws-{cs.id}",
+            "ref": "main",
+            "devcontainer_path": ".devcontainer/devcontainer.json",
+        }
+    ]
     assert len(workspace_groups) == 1
     assert workspace_groups[0].workspace_key == "coding"
     assert len(workspaces) == 1
-    assert workspaces[0].workspace_group_id == workspace_groups[0].id
-    assert workspaces[0].repo_full_name == f"winoe-ai-repos/{expected_repo_name}"
-    assert workspace_groups[0].repo_full_name == f"winoe-ai-repos/{expected_repo_name}"
-    assert all(ws.base_template_sha == "commit-sha" for ws in workspaces)
+
+    with override_dependencies(
+        {
+            get_email_service: lambda: email_service,
+            get_github_client: lambda: stub_client,
+        }
+    ):
+        resend_res = await async_client.post(
+            f"/api/trials/{sim.id}/invite",
+            json={"candidateName": "Jane Doe", "inviteEmail": "jane@example.com"},
+            headers=auth_header_factory(talent_partner),
+        )
+
+    assert resend_res.status_code == 200, resend_res.text
+    assert resend_res.json()["outcome"] == "resent"
+    assert len(stub_client.created_repos) == 1
+    assert len(stub_client.codespace_requests) == 1
+    assert (
+        len(
+            (
+                await async_session.execute(
+                    select(Workspace).where(Workspace.candidate_session_id == cs.id)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        == 1
+    )
+    assert (
+        len(
+            (
+                await async_session.execute(
+                    select(WorkspaceGroup).where(
+                        WorkspaceGroup.candidate_session_id == cs.id
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        == 1
+    )

--- a/tests/trials/routes/test_trials_routes_unit_routes.py
+++ b/tests/trials/routes/test_trials_routes_unit_routes.py
@@ -74,7 +74,10 @@ async def test_create_candidate_invite_github_error(monkeypatch):
         return SimpleNamespace(id=11, template_key="python-fastapi")
 
     async def fake_create(db, trial_id, payload, now, scenario_version_id=None):
-        return SimpleNamespace(id=10, token="tok"), "created"
+        return (
+            SimpleNamespace(id=10, token="tok", github_username="octocat"),
+            "created",
+        )
 
     async def fail_workspace(_db, **_kwargs):
         raise GithubError("nope", status_code=403)

--- a/tests/trials/services/test_trials_invite_preprovision_service_workspace_key_none_branch_service.py
+++ b/tests/trials/services/test_trials_invite_preprovision_service_workspace_key_none_branch_service.py
@@ -39,6 +39,7 @@ async def test_preprovision_workspaces_skips_processed_key_tracking_when_key_mis
                 "trial_id": trial.id,
                 "scenario_version_id": scenario_version.id,
                 "task_id": task.id,
+                "github_username": github_username,
                 "destination_owner": destination_owner,
                 "workspace_resolution": workspace_resolution,
                 "commit": commit,
@@ -64,7 +65,7 @@ async def test_preprovision_workspaces_skips_processed_key_tracking_when_key_mis
         _ensure_workspace,
     )
 
-    candidate_session = SimpleNamespace(id=42, trial_id=7)
+    candidate_session = SimpleNamespace(id=42, trial_id=7, github_username="octocat")
     tasks = [SimpleNamespace(id=501, day_index=2, type="code", template_repo=None)]
 
     await preprovision_service.preprovision_workspaces(
@@ -81,10 +82,283 @@ async def test_preprovision_workspaces_skips_processed_key_tracking_when_key_mis
     assert len(captured_calls) == 1
     assert captured_calls[0]["task_id"] == 501
     assert captured_calls[0]["destination_owner"] == "fallback-org"
+    assert captured_calls[0]["github_username"] == "octocat"
     assert captured_calls[0]["workspace_resolution"] is None
     assert captured_calls[0]["commit"] is False
     assert captured_calls[0]["hydrate_precommit_bundle"] is False
     assert captured_calls[0]["bootstrap_empty_repo"] is True
+
+
+@pytest.mark.asyncio
+async def test_preprovision_workspaces_skips_when_github_username_missing(
+    monkeypatch,
+):
+    captured_calls: list[dict] = []
+
+    async def _ensure_workspace(*_args, **_kwargs):
+        captured_calls.append({"called": True})
+
+    monkeypatch.setattr(
+        preprovision_service.settings.github,
+        "GITHUB_REPO_PREFIX",
+        "winoe",
+    )
+    monkeypatch.setattr(
+        preprovision_service.settings.github,
+        "GITHUB_ORG",
+        "fallback-org",
+    )
+    monkeypatch.setattr(
+        preprovision_service, "resolve_workspace_key_for_task", lambda _t: "coding"
+    )
+    monkeypatch.setattr(
+        preprovision_service.submission_service,
+        "ensure_workspace",
+        _ensure_workspace,
+    )
+
+    candidate_session = SimpleNamespace(id=42, trial_id=7, github_username=None)
+    tasks = [SimpleNamespace(id=501, day_index=2, type="code", template_repo=None)]
+
+    result = await preprovision_service.preprovision_workspaces(
+        db=object(),
+        candidate_session=candidate_session,
+        trial=SimpleNamespace(id=7),
+        scenario_version=SimpleNamespace(id=11),
+        tasks=tasks,
+        github_client=object(),
+        now=datetime(2026, 3, 27, 12, 0, tzinfo=UTC),
+        fresh_candidate_session=True,
+    )
+
+    assert result == []
+    assert captured_calls == []
+
+
+@pytest.mark.asyncio
+async def test_preprovision_workspaces_returns_only_new_repos_for_cleanup(
+    monkeypatch,
+):
+    captured_calls: list[dict] = []
+
+    async def _ensure_workspace(
+        _db,
+        *,
+        candidate_session,
+        trial,
+        scenario_version,
+        task,
+        github_client,
+        github_username,
+        repo_prefix,
+        destination_owner,
+        now,
+        workspace_resolution=None,
+        commit=True,
+        hydrate_precommit_bundle=True,
+        bootstrap_empty_repo=False,
+    ):
+        workspace = SimpleNamespace(
+            repo_full_name=(
+                "fallback-org/winoe-reused"
+                if task.id == 501
+                else "fallback-org/winoe-new"
+            )
+        )
+        if task.id == 502:
+            workspace._provisioned_repo_created = True
+        captured_calls.append(
+            {
+                "task_id": task.id,
+                "workspace_resolution": workspace_resolution,
+                "repo_full_name": workspace.repo_full_name,
+            }
+        )
+        return workspace
+
+    monkeypatch.setattr(
+        preprovision_service.settings.github,
+        "GITHUB_REPO_PREFIX",
+        "winoe",
+    )
+    monkeypatch.setattr(
+        preprovision_service.settings.github,
+        "GITHUB_ORG",
+        "fallback-org",
+    )
+
+    def _resolve_workspace_key(task):
+        return None if task.id == 501 else "coding"
+
+    monkeypatch.setattr(
+        preprovision_service, "resolve_workspace_key_for_task", _resolve_workspace_key
+    )
+    monkeypatch.setattr(
+        preprovision_service.submission_service,
+        "ensure_workspace",
+        _ensure_workspace,
+    )
+
+    candidate_session = SimpleNamespace(id=42, trial_id=7, github_username="octocat")
+    tasks = [
+        SimpleNamespace(id=501, day_index=2, type="code", template_repo=None),
+        SimpleNamespace(id=502, day_index=3, type="code", template_repo=None),
+    ]
+
+    result = await preprovision_service.preprovision_workspaces(
+        db=object(),
+        candidate_session=candidate_session,
+        trial=SimpleNamespace(id=7),
+        scenario_version=SimpleNamespace(id=11),
+        tasks=tasks,
+        github_client=object(),
+        now=datetime(2026, 3, 27, 12, 0, tzinfo=UTC),
+        fresh_candidate_session=True,
+    )
+
+    assert len(captured_calls) == 2
+    assert result == ["fallback-org/winoe-new"]
+
+
+@pytest.mark.asyncio
+async def test_preprovision_workspaces_skips_duplicate_workspace_key(
+    monkeypatch,
+):
+    captured_calls: list[int] = []
+
+    async def _ensure_workspace(
+        _db,
+        *,
+        candidate_session,
+        trial,
+        scenario_version,
+        task,
+        github_client,
+        github_username,
+        repo_prefix,
+        destination_owner,
+        now,
+        workspace_resolution=None,
+        commit=True,
+        hydrate_precommit_bundle=True,
+        bootstrap_empty_repo=False,
+    ):
+        captured_calls.append(task.id)
+        return SimpleNamespace(repo_full_name=f"fallback-org/winoe-{task.id}")
+
+    monkeypatch.setattr(
+        preprovision_service.settings.github,
+        "GITHUB_REPO_PREFIX",
+        "winoe",
+    )
+    monkeypatch.setattr(
+        preprovision_service.settings.github,
+        "GITHUB_ORG",
+        "fallback-org",
+    )
+    monkeypatch.setattr(
+        preprovision_service, "resolve_workspace_key_for_task", lambda _t: "coding"
+    )
+    monkeypatch.setattr(
+        preprovision_service.submission_service,
+        "ensure_workspace",
+        _ensure_workspace,
+    )
+
+    candidate_session = SimpleNamespace(id=42, trial_id=7, github_username="octocat")
+    tasks = [
+        SimpleNamespace(id=501, day_index=2, type="code", template_repo=None),
+        SimpleNamespace(id=502, day_index=3, type="code", template_repo=None),
+    ]
+
+    result = await preprovision_service.preprovision_workspaces(
+        db=object(),
+        candidate_session=candidate_session,
+        trial=SimpleNamespace(id=7),
+        scenario_version=SimpleNamespace(id=11),
+        tasks=tasks,
+        github_client=object(),
+        now=datetime(2026, 3, 27, 12, 0, tzinfo=UTC),
+        fresh_candidate_session=True,
+    )
+
+    assert captured_calls == [501]
+    assert result == []
+
+
+@pytest.mark.asyncio
+async def test_preprovision_workspaces_attaches_cleanup_targets_on_error(
+    monkeypatch,
+):
+    created_repos: list[str] = []
+
+    async def _ensure_workspace(
+        _db,
+        *,
+        candidate_session,
+        trial,
+        scenario_version,
+        task,
+        github_client,
+        github_username,
+        repo_prefix,
+        destination_owner,
+        now,
+        workspace_resolution=None,
+        commit=True,
+        hydrate_precommit_bundle=True,
+        bootstrap_empty_repo=False,
+    ):
+        repo_full_name = f"fallback-org/winoe-{task.id}"
+        created_repos.append(repo_full_name)
+        if task.id == 502:
+            raise preprovision_service.GithubError("boom", status_code=403)
+        return SimpleNamespace(
+            repo_full_name=repo_full_name, _provisioned_repo_created=True
+        )
+
+    monkeypatch.setattr(
+        preprovision_service.settings.github,
+        "GITHUB_REPO_PREFIX",
+        "winoe",
+    )
+    monkeypatch.setattr(
+        preprovision_service.settings.github,
+        "GITHUB_ORG",
+        "fallback-org",
+    )
+    monkeypatch.setattr(
+        preprovision_service, "resolve_workspace_key_for_task", lambda _t: None
+    )
+    monkeypatch.setattr(
+        preprovision_service.submission_service,
+        "ensure_workspace",
+        _ensure_workspace,
+    )
+
+    candidate_session = SimpleNamespace(id=42, trial_id=7, github_username="octocat")
+    tasks = [
+        SimpleNamespace(id=501, day_index=2, type="code", template_repo=None),
+        SimpleNamespace(id=502, day_index=3, type="code", template_repo=None),
+    ]
+
+    with pytest.raises(preprovision_service.GithubError) as excinfo:
+        await preprovision_service.preprovision_workspaces(
+            db=object(),
+            candidate_session=candidate_session,
+            trial=SimpleNamespace(id=7),
+            scenario_version=SimpleNamespace(id=11),
+            tasks=tasks,
+            github_client=object(),
+            now=datetime(2026, 3, 27, 12, 0, tzinfo=UTC),
+            fresh_candidate_session=True,
+        )
+
+    assert created_repos == [
+        "fallback-org/winoe-501",
+        "fallback-org/winoe-502",
+    ]
+    assert excinfo.value.provisioned_repo_full_names == ("fallback-org/winoe-501",)
 
 
 @pytest.mark.asyncio
@@ -116,6 +390,7 @@ async def test_preprovision_workspaces_reraises_github_error_for_workspace_key(
                 "trial_id": trial.id,
                 "scenario_version_id": scenario_version.id,
                 "task_id": task.id,
+                "github_username": github_username,
                 "destination_owner": destination_owner,
                 "workspace_resolution": workspace_resolution,
                 "commit": commit,
@@ -144,7 +419,7 @@ async def test_preprovision_workspaces_reraises_github_error_for_workspace_key(
         _ensure_workspace,
     )
 
-    candidate_session = SimpleNamespace(id=42, trial_id=7)
+    candidate_session = SimpleNamespace(id=42, trial_id=7, github_username="octocat")
     task = SimpleNamespace(
         id=501,
         day_index=2,
@@ -166,6 +441,7 @@ async def test_preprovision_workspaces_reraises_github_error_for_workspace_key(
 
     assert len(captured_calls) == 1
     assert captured_calls[0]["destination_owner"] == "winoe-ai-repos"
+    assert captured_calls[0]["github_username"] == "octocat"
     assert captured_calls[0]["workspace_resolution"].workspace_key == "coding"
     assert captured_calls[0]["commit"] is False
     assert captured_calls[0]["hydrate_precommit_bundle"] is False

--- a/tests/trials/services/test_trials_invite_workflow_service.py
+++ b/tests/trials/services/test_trials_invite_workflow_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import UTC, datetime
 from types import SimpleNamespace
 
@@ -17,6 +18,32 @@ class FakeDB:
 
     async def rollback(self) -> None:
         self.rollback_calls += 1
+
+
+@pytest.mark.asyncio
+async def test_invite_workflow_cleanup_helper_handles_missing_and_failing_delete_repo(
+    caplog,
+):
+    caplog.set_level(logging.WARNING)
+
+    await invite_workflow._cleanup_provisioned_repos(object(), ["org/repo"])
+
+    class GithubStub:
+        def __init__(self) -> None:
+            self.deleted_repos: list[str] = []
+
+        async def delete_repo(self, repo_full_name: str):
+            self.deleted_repos.append(repo_full_name)
+            raise RuntimeError("boom")
+
+    github_client = GithubStub()
+    await invite_workflow._cleanup_provisioned_repos(github_client, ["org/repo"])
+
+    assert github_client.deleted_repos == ["org/repo"]
+    assert any(
+        record.message == "github_workspace_preprovision_cleanup_failed"
+        for record in caplog.records
+    )
 
 
 @pytest.mark.asyncio
@@ -111,7 +138,7 @@ async def test_invite_workflow_cleans_up_created_repo_when_email_send_fails(
         return candidate_session, "created"
 
     async def _preprovision(*_args, **_kwargs):
-        return None
+        return ["winoe-ai-repos/winoe-ws-77"]
 
     async def _send_invite_email(*_args, **_kwargs):
         raise RuntimeError("email provider down")
@@ -162,3 +189,169 @@ async def test_invite_workflow_cleans_up_created_repo_when_email_send_fails(
 
     assert db.rollback_calls == 1
     assert github_client.deleted_repos == ["winoe-ai-repos/winoe-ws-77"]
+
+
+@pytest.mark.asyncio
+async def test_invite_workflow_cleans_up_created_repo_when_preprovision_fails(
+    monkeypatch,
+):
+    db = FakeDB()
+    trial = SimpleNamespace(id=6, title="Trial", role="Engineer")
+    scenario_version = SimpleNamespace(id=10)
+    candidate_session = SimpleNamespace(
+        id=78,
+        token="tok-78",
+        _invite_newly_created=True,
+    )
+    payload = SimpleNamespace(inviteEmail="jane@example.com", candidateName="Jane Doe")
+
+    class GithubStub:
+        def __init__(self) -> None:
+            self.deleted_repos: list[str] = []
+
+        async def delete_repo(self, repo_full_name: str):
+            self.deleted_repos.append(repo_full_name)
+
+    github_client = GithubStub()
+
+    async def _require_owned(*_args, **_kwargs):
+        return trial, [SimpleNamespace(id=1, day_index=2, type="code")]
+
+    async def _lock_active(*_args, **_kwargs):
+        return scenario_version
+
+    async def _create_or_resend(*_args, **_kwargs):
+        return candidate_session, "created"
+
+    async def _preprovision(*_args, **_kwargs):
+        exc = RuntimeError("bootstrap failed")
+        exc.provisioned_repo_full_names = ("winoe-ai-repos/winoe-ws-78",)
+        raise exc
+
+    monkeypatch.setattr(
+        invite_workflow.sim_service,
+        "require_owned_trial_with_tasks",
+        _require_owned,
+    )
+    monkeypatch.setattr(
+        invite_workflow.sim_service,
+        "require_trial_invitable",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        invite_workflow.sim_service,
+        "lock_active_scenario_for_invites",
+        _lock_active,
+    )
+    monkeypatch.setattr(
+        invite_workflow.sim_service,
+        "create_or_resend_invite",
+        _create_or_resend,
+    )
+    monkeypatch.setattr(
+        invite_workflow.invite_preprovision,
+        "preprovision_workspaces",
+        _preprovision,
+    )
+    monkeypatch.setattr(settings.github, "GITHUB_ORG", "winoe-ai-repos")
+    monkeypatch.setattr(settings.github, "GITHUB_REPO_PREFIX", "winoe-ws-")
+
+    with pytest.raises(RuntimeError, match="bootstrap failed"):
+        await invite_workflow.create_candidate_invite_workflow(
+            db=db,
+            trial_id=6,
+            payload=payload,
+            user_id=9,
+            email_service=object(),
+            github_client=github_client,
+            now=datetime.now(UTC),
+        )
+
+    assert db.rollback_calls == 1
+    assert github_client.deleted_repos == ["winoe-ai-repos/winoe-ws-78"]
+
+
+@pytest.mark.asyncio
+async def test_invite_workflow_handles_none_cleanup_targets_from_preprovision(
+    monkeypatch,
+):
+    db = FakeDB()
+    trial = SimpleNamespace(id=7, title="Trial", role="Engineer")
+    scenario_version = SimpleNamespace(id=11)
+    candidate_session = SimpleNamespace(
+        id=79,
+        token="tok-79",
+        _invite_newly_created=True,
+    )
+    payload = SimpleNamespace(inviteEmail="jane@example.com", candidateName="Jane Doe")
+
+    class GithubStub:
+        def __init__(self) -> None:
+            self.deleted_repos: list[str] = []
+
+        async def delete_repo(self, repo_full_name: str):
+            self.deleted_repos.append(repo_full_name)
+
+    github_client = GithubStub()
+
+    async def _require_owned(*_args, **_kwargs):
+        return trial, [SimpleNamespace(id=1, day_index=2, type="code")]
+
+    async def _lock_active(*_args, **_kwargs):
+        return scenario_version
+
+    async def _create_or_resend(*_args, **_kwargs):
+        return candidate_session, "created"
+
+    async def _preprovision(*_args, **_kwargs):
+        return None
+
+    async def _send_invite_email(*_args, **_kwargs):
+        raise RuntimeError("email provider down")
+
+    monkeypatch.setattr(
+        invite_workflow.sim_service,
+        "require_owned_trial_with_tasks",
+        _require_owned,
+    )
+    monkeypatch.setattr(
+        invite_workflow.sim_service,
+        "require_trial_invitable",
+        lambda *_args, **_kwargs: None,
+    )
+    monkeypatch.setattr(
+        invite_workflow.sim_service,
+        "lock_active_scenario_for_invites",
+        _lock_active,
+    )
+    monkeypatch.setattr(
+        invite_workflow.sim_service,
+        "create_or_resend_invite",
+        _create_or_resend,
+    )
+    monkeypatch.setattr(
+        invite_workflow.invite_preprovision,
+        "preprovision_workspaces",
+        _preprovision,
+    )
+    monkeypatch.setattr(
+        invite_workflow.notification_service,
+        "send_invite_email",
+        _send_invite_email,
+    )
+    monkeypatch.setattr(settings.github, "GITHUB_ORG", "winoe-ai-repos")
+    monkeypatch.setattr(settings.github, "GITHUB_REPO_PREFIX", "winoe-ws-")
+
+    with pytest.raises(RuntimeError, match="email provider down"):
+        await invite_workflow.create_candidate_invite_workflow(
+            db=db,
+            trial_id=7,
+            payload=payload,
+            user_id=9,
+            email_service=object(),
+            github_client=github_client,
+            now=datetime.now(UTC),
+        )
+
+    assert db.rollback_calls == 1
+    assert github_client.deleted_repos == []


### PR DESCRIPTION
# Harden empty-repo GitHub provisioning and evidence capture

## Summary

This PR hardens GitHub provisioning for the v4 from-scratch Tech Trial flow.

Candidate workspaces are now created as empty repos and initialized only with Winoe-owned workspace files. Candidate GitHub username is required before workspace provisioning, collaborator permissioning uses that username, evidence capture runs through the canonical workflow `.github/workflows/winoe-evidence-capture.yml`, stable evidence artifact names are parsed reliably, and cleanup is bounded and idempotent.

## What changed

- Empty-repo repo creation and recovery path for candidate workspaces.
- Required bootstrap files are created in the repo:
  - `.devcontainer/devcontainer.json`
  - `README.md`
  - `.gitignore`
  - `.github/workflows/winoe-evidence-capture.yml`
- Devcontainer defaults to the Microsoft universal image unless a language-specific image is selected for the Talent Partner's preferred language.
- `README.md` is used as the Project Brief.
- No app starter code is added to candidate repos.
- Generated `.gitignore` does not ignore lockfiles.
- Candidate GitHub username is required before provisioning continues.
- Collaborator add behavior is retried safely when permissioning already exists or was partially applied.
- Evidence workflow and artifact parser behavior were updated for the new canonical workflow and stable artifact names.
- Invite and preprovision cleanup paths are more precise so they only remove resources created during the current attempt.
- Retry and idempotency paths are covered by tests.
- Documentation was updated to match the v4 empty-repo provisioning flow.

## v4 pivot alignment

- No generated-from-template repo path is used in active provisioning.
- No template catalog dependency is used in active provisioning.
- No precommit bundle is applied to candidate repos in the v4 path.
- No Codespace Specializor or Specializer component is used.
- The repo is evaluated as candidate-authored from scratch.

This wording reflects the active path only. It does not claim historical compatibility code was removed unless the implementation actually changed it.

## Evidence / artifacts

Canonical artifact names:

- `winoe-commit-metadata`
- `winoe-file-creation-timeline`
- `winoe-repo-tree-summary`
- `winoe-dependency-manifests`
- `winoe-test-detection`
- `winoe-test-results`
- `winoe-lint-detection`
- `winoe-lint-results`
- `winoe-evidence-manifest`

Canonical JSON files:

- `commit_metadata.json`
- `file_creation_timeline.json`
- `repo_tree_summary.json`
- `dependency_manifests.json`
- `test_detection.json`
- `test_results.json`
- `lint_detection.json`
- `lint_results.json`
- `evidence_manifest.json`

Wrapper schema fields:

- `schema_version`
- `repository_full_name`
- `commit_sha`
- `workflow_run_id`
- `generated_at`
- `status`
- `payload`

Test and lint detection distinguishes:

- `detected`
- `not_detected`
- failed command execution as evidence

## Idempotency and recovery

- Provisioning retry reuses the existing repo and workspace.
- Missing bootstrap files are repaired.
- Missing workflow files are repaired.
- Collaborator add is safe on retry.
- Codespace creation and recovery paths are retried safely.
- Duplicate workspace groups and workspaces are avoided.
- Day 2 and Day 3 share the canonical coding repo where expected.

## Cleanup behavior

- Cleanup is idempotent.
- Invite rollback cleanup only targets repos created during the current attempt.
- Existing or reused repos are not deleted accidentally.
- Trial termination cleanup remains scoped to the Trial and workspace.
- Already-cleaned resources are handled safely.

## QA evidence

```text
QA PASS — ready for PR prompt

Environment:
- Branch: feature/harden-github-provisioning-for-empty-repo-codespace-creation-and-evidence-capture
- Commit: d39e7dbf0b091bc239d4d50870d8d52a4af00d0b
- Backend command: ./scripts/local_qa_backend.sh
- Worker command: python -m app.shared.jobs.shared_jobs_worker_cli_service worker
- Backend health: GET /health returned {"status":"ok"}
- Worker readiness: GET /ready returned ready with fresh worker heartbeat

Manual QA covered:
- missing GitHub username gate
- username-present provisioning
- repo contents inspection
- idempotent retry
- partial recovery
- evidence workflow contract
- artifact parsing/retrieval
- cleanup/termination
- retired-terminology active-path check
```

```text
Live GitHub push execution was not performed in this QA pass. Route probes used an in-memory stub GitHub provider. GitHub Actions workflow execution was verified by workflow YAML contract and backend tests; artifact parsing/retrieval was verified through backend test paths.
```

## Validation

```text
bash ./precommit.sh
✅ passed
1865 passed, 13 warnings
Coverage: 96.00%
Required coverage: 96%
```

```text
git diff --check
✅ passed
```

## Risks / limitations

- Live GitHub push execution was not performed in this QA pass.
- Evidence capture execution was verified through workflow contract checks and backend tests rather than a live GitHub Actions run.
- Cleanup correctness depends on the repo/workspace identifiers returned by the current attempt, so future changes to those identifiers should be revalidated.

## Issue checklist

- [x] Empty repo creation is idempotent and safe to retry
- [x] Repo initialized with `.devcontainer/devcontainer.json`, `README.md`, `.gitignore`, and evidence-capture Actions workflow
- [x] Devcontainer uses Microsoft universal image by default
- [x] Recovery from partial GitHub API failure / partial repo initialization
- [x] Candidate username-based permissioning via collaborator add
- [x] GitHub Actions evidence-capture workflow runs on push
- [x] Workflow captures commit metadata, file creation order, test detection, and linting results
- [x] Evidence artifacts are uploaded and parseable/retrievable through backend paths
- [x] Cleanup on Trial termination is idempotent and scoped

## PR title

Harden empty-repo GitHub provisioning and evidence capture

Worker Report:
- Summary
  - Updated `pr.md` only to describe the v4 empty-repo GitHub provisioning and evidence capture flow.
- Files changed
  - `pr.md`
- Commands run
  - `git status --short` - pass
  - `git diff --check` - pass
  - `bash ./precommit.sh` - pass
  - `git diff --check` - pass
- Risks / assumptions
  - Assumed the provided QA and validation text is the canonical PR-materials source.
  - Kept the document aligned to the active v4 path and avoided retired product language in the main narrative.
- Open questions / blockers
  - None


Fixes #301 