### PR TITLE
Update Day 2/3 Code Implementation Reviewer for from-scratch evaluation

### DIFF
--- a/app/ai/prompt_assets/v1/winoe-day-2&3-rubric.md
+++ b/app/ai/prompt_assets/v1/winoe-day-2&3-rubric.md
@@ -1,20 +1,57 @@
 # Winoe Day 2 And 3 Rubric
 
 ## Instructions
-You are Winoe's CODE IMPLEMENTATION REVIEWER AI SUB AGENT for Days 2 and 3.
+You are Winoe's Code Implementation Reviewer Sub-Agent for Days 2 and 3 of a from-scratch Tech Trial.
 
-Review the candidate's implementation like a staff engineer reading a real pull request and its test evidence. Focus on what the candidate actually shipped in the shared Day 2/3 repository, not on idealized solutions.
+Review the candidate's work like a staff engineer reading a complete repository that the candidate built from a blank canvas. There is no pre-existing application code to compare against. Evaluate the complete system and the development process, not a change set against an earlier codebase.
 
-Evaluate correctness, code quality, testing, reliability, maintainability, and task completion. Use transcript or rubric context only when it helps interpret the work; the code and evidence should remain primary.
+Use the Evidence Trail as primary evidence. For Days 2 and 3, that includes the full repository, complete commit history, file creation timeline, project structure and scaffolding, dependency and build choices, test coverage progression, README evolution, and other workflow or lint/test metadata where available.
+
+AI tool usage is allowed. Do not penalize AI usage by itself. Note concerns only when the evidence supports them, such as bulk generation without engineering judgment, inconsistent patterns, broken generated code, shallow tests, dependency sprawl, hallucinated APIs, or fix-up commits that suggest weak understanding.
+
+Evaluate the implementation in a tech-stack-agnostic way. Do not penalize the candidate for language or framework choice by itself. Judge whether the chosen stack fits the Project Brief, the role level, the constraints, and the final implementation quality.
 
 Return only the required JSON object.
 
 ## Rubric
-Use the following standards:
+Use a 100-point scoring model with these weighted dimensions:
 
-- Reward production-ready code that addresses the actual task.
-- Reward thoughtful tests and good evidence of verification.
-- Reward changes that are coherent with the existing repository architecture.
-- Reward sensible tradeoffs, maintainability, and bug awareness.
-- Penalize partial completion, brittle fixes, regressions, weak testing, or cosmetic work that avoids the core task.
-- Keep the scoring consistent across all candidates for the same trial version.
+- Project scaffolding quality - 18 points
+- Architectural coherence - 18 points
+- Code quality and maintainability - 17 points
+- Testing discipline - 15 points
+- Development process and commit history - 12 points
+- Documentation and handoff readiness - 10 points
+- Requirements coverage and product completeness - 10 points
+
+### 1. Project scaffolding quality - 18 points
+Evaluate the project structure, configuration, build system, dependency choices, developer ergonomics, and whether the repository is easy to understand, run, test, and extend. Reward a simple but coherent setup when it is appropriate to the Project Brief and timebox. Do not reward unnecessary complexity.
+
+### 2. Architectural coherence - 18 points
+Evaluate whether the implementation architecture fits the Project Brief, whether module boundaries and responsibility splits are clear, whether API and data modeling choices are consistent, and whether the complete repository shows a coherent design intent.
+
+### 3. Code quality and maintainability - 17 points
+Evaluate readability, naming, modularity, simplicity, error handling, input validation, edge case handling, security basics appropriate to the role, consistency across files, and whether the code is maintainable rather than brittle or overfit.
+
+### 4. Testing discipline - 15 points
+Evaluate meaningful coverage, test quality, unit/integration/e2e balance where appropriate, stability-oriented assertions, readable tests, and whether the test history shows thoughtful verification. Do not reward superficial coverage padding.
+
+### 5. Development process and commit history - 12 points
+Evaluate commit frequency, commit message clarity, file creation order, whether the work progressed systematically, whether tests and docs evolved alongside implementation, whether dependency and config choices appear deliberate, and whether the history suggests planning, iteration, refactoring, and stabilization. Use the complete commit history and file timeline as evidence, not just the final snapshot.
+
+### 6. Documentation and handoff readiness - 10 points
+Evaluate README clarity, setup and run instructions, API or workflow documentation where relevant, useful inline comments, explanation of tradeoffs or limitations, and whether another engineer could pick up the project with minimal friction.
+
+### 7. Requirements coverage and product completeness - 10 points
+Evaluate whether the implementation satisfies the Project Brief, handles required constraints, prioritizes the right work for the timebox, and delivers a coherent working system rather than disconnected pieces.
+
+## Required notes
+
+### From-scratch evaluation note
+The complete repository is the candidate's work. There is no baseline application code to diff against. Reviewers must evaluate the finished system, the file structure, the scaffolding, the dependency and build choices, and the development history as first-class evidence.
+
+### Tech-stack-agnostic note
+Candidates may choose any stack unless the Project Brief explicitly constrains them. Do not penalize framework or language choice by itself. Evaluate whether the chosen stack is appropriate, coherent, maintainable, and well executed for the task.
+
+### AI tool usage note
+AI coding assistants are allowed. AI usage is not penalized by itself. Positive signal includes generated or assisted code that is reviewed, shaped, tested, documented, and integrated coherently. Concern signal includes large unexplained code dumps, inconsistent patterns, broken generated code, shallow tests, dependency sprawl, hallucinated APIs, or fix-up commits that suggest weak understanding. Do not infer AI usage from style alone. Any observation about AI usage must be backed by evidence from the repository history, file creation timeline, tests, or other artifacts in the Evidence Trail.

--- a/app/evaluations/services/evaluations_services_evaluations_evaluator_models_service.py
+++ b/app/evaluations/services/evaluations_services_evaluations_evaluator_models_service.py
@@ -7,6 +7,22 @@ from typing import Any, Protocol
 
 
 @dataclass(slots=True)
+class CodeImplementationEvidenceContext:
+    """Represent repository/process evidence for Days 2 and 3."""
+
+    repository_snapshot: dict[str, Any] | None = None
+    repository_url: str | None = None
+    repository_reference: str | None = None
+    repository_artifact_references: list[dict[str, Any]] = field(default_factory=list)
+    commit_history: list[dict[str, Any]] = field(default_factory=list)
+    file_creation_timeline: list[dict[str, Any]] = field(default_factory=list)
+    test_coverage_progression: list[dict[str, Any]] = field(default_factory=list)
+    dependency_metadata: dict[str, Any] | None = None
+    documentation_evolution: list[dict[str, Any]] = field(default_factory=list)
+    evidence_status: dict[str, str] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
 class DayEvaluationInput:
     """Represent day evaluation input data and behavior."""
 
@@ -40,6 +56,9 @@ class EvaluationInputBundle:
     rubric_version: str
     disabled_day_indexes: list[int]
     day_inputs: list[DayEvaluationInput]
+    code_implementation_evidence: CodeImplementationEvidenceContext = field(
+        default_factory=CodeImplementationEvidenceContext
+    )
     trial_context_json: dict[str, Any] | None = None
     ai_policy_snapshot_json: dict[str, Any] | None = None
     ai_policy_snapshot_digest: str | None = None
@@ -96,6 +115,7 @@ class WinoeReportEvaluator(Protocol):
 __all__ = [
     "DayEvaluationInput",
     "DayEvaluationResult",
+    "CodeImplementationEvidenceContext",
     "EvaluationInputBundle",
     "EvaluationResult",
     "ReviewerReportResult",

--- a/app/evaluations/services/evaluations_services_evaluations_evaluator_runtime_service.py
+++ b/app/evaluations/services/evaluations_services_evaluations_evaluator_runtime_service.py
@@ -16,6 +16,7 @@ from app.evaluations.services.evaluations_services_evaluations_evaluator_evidenc
     _build_day_evidence,
 )
 from app.evaluations.services.evaluations_services_evaluations_evaluator_models_service import (
+    CodeImplementationEvidenceContext,
     DayEvaluationResult,
     EvaluationInputBundle,
     EvaluationResult,
@@ -330,6 +331,36 @@ def _build_day_run_context(
     bundle: EvaluationInputBundle,
     day_input,
 ) -> str:
+    evidence_lines: list[str] = []
+    evidence = bundle.code_implementation_evidence
+    if day_input.day_index in {2, 3} and isinstance(
+        evidence, CodeImplementationEvidenceContext
+    ):
+        status = evidence.evidence_status or {}
+        evidence_lines.extend(
+            [
+                "Code implementation evidence is supplied in the user prompt as codeImplementationEvidence.",
+                (
+                    "Repository snapshot status: "
+                    f"{status.get('repository_snapshot', 'unknown')}"
+                ),
+                (
+                    "Commit history status: "
+                    f"{status.get('commit_history', 'unknown')}"
+                ),
+                (
+                    "File creation timeline status: "
+                    f"{status.get('file_creation_timeline', 'unknown')}"
+                ),
+                (
+                    "Test coverage progression status: "
+                    f"{status.get('test_coverage_progression', 'unknown')}"
+                ),
+                (
+                    "Do not infer process quality when commit history, file creation timeline, or test coverage progression are unavailable."
+                ),
+            ]
+        )
     return (
         f"Candidate session ID: {bundle.candidate_session_id}\n"
         f"Scenario version ID: {bundle.scenario_version_id}\n"
@@ -337,6 +368,7 @@ def _build_day_run_context(
         f"Task type: {day_input.task_type or 'unknown'}\n"
         f"Commit SHA: {day_input.commit_sha or 'n/a'}\n"
         f"Transcript ref: {day_input.transcript_reference or 'n/a'}"
+        + ("\n" + "\n".join(evidence_lines) if evidence_lines else "")
     )
 
 
@@ -354,6 +386,11 @@ def _build_day_review_prompt(
     day_input,
     rubric_prompt: str,
 ) -> str:
+    code_implementation_evidence = (
+        _serialize_code_implementation_evidence(bundle.code_implementation_evidence)
+        if day_input.day_index in {2, 3}
+        else None
+    )
     return json.dumps(
         {
             "trialContext": bundle.trial_context_json or {},
@@ -375,11 +412,54 @@ def _build_day_review_prompt(
                 "cutoffCommitSha": day_input.cutoff_commit_sha,
                 "evalBasisRef": day_input.eval_basis_ref,
             },
+            "reviewContext": {
+                "codeImplementationEvidence": code_implementation_evidence,
+                "instructions": (
+                    "Use codeImplementationEvidence as primary evidence for Days 2 and 3. "
+                    "If commit history, file creation timeline, or test coverage progression are unavailable, say so explicitly and do not infer process quality."
+                    if day_input.day_index in {2, 3}
+                    else None
+                ),
+            },
             "rubricGuidance": rubric_prompt,
         },
         indent=2,
         sort_keys=True,
     )
+
+
+def _serialize_code_implementation_evidence(
+    evidence: CodeImplementationEvidenceContext,
+) -> dict[str, object]:
+    """Serialize code implementation evidence into prompt-ready JSON."""
+    return {
+        "repositorySnapshot": (
+            dict(evidence.repository_snapshot)
+            if isinstance(evidence.repository_snapshot, dict)
+            else None
+        ),
+        "repositoryUrl": evidence.repository_url,
+        "repositoryReference": evidence.repository_reference,
+        "repositoryArtifactReferences": [
+            dict(item) for item in evidence.repository_artifact_references
+        ],
+        "commitHistory": [dict(item) for item in evidence.commit_history],
+        "fileCreationTimeline": [
+            dict(item) for item in evidence.file_creation_timeline
+        ],
+        "testCoverageProgression": [
+            dict(item) for item in evidence.test_coverage_progression
+        ],
+        "dependencyMetadata": (
+            dict(evidence.dependency_metadata)
+            if isinstance(evidence.dependency_metadata, dict)
+            else None
+        ),
+        "documentationEvolution": [
+            dict(item) for item in evidence.documentation_evolution
+        ],
+        "evidenceStatus": dict(evidence.evidence_status),
+    }
 
 
 def _deterministic_day_review(

--- a/app/evaluations/services/evaluations_services_evaluations_evaluator_service.py
+++ b/app/evaluations/services/evaluations_services_evaluations_evaluator_service.py
@@ -12,6 +12,7 @@ from app.evaluations.services.evaluations_services_evaluations_evaluator_helpers
     _to_excerpt,
 )
 from app.evaluations.services.evaluations_services_evaluations_evaluator_models_service import (
+    CodeImplementationEvidenceContext,
     DayEvaluationInput,
     DayEvaluationResult,
     EvaluationInputBundle,
@@ -28,6 +29,7 @@ from app.evaluations.services.evaluations_services_evaluations_evaluator_scoring
 )
 
 __all__ = [
+    "CodeImplementationEvidenceContext",
     "DayEvaluationInput",
     "DayEvaluationResult",
     "DeterministicWinoeReportEvaluator",

--- a/app/evaluations/services/evaluations_services_evaluations_winoe_report_pipeline_day_inputs_service.py
+++ b/app/evaluations/services/evaluations_services_evaluations_winoe_report_pipeline_day_inputs_service.py
@@ -2,8 +2,14 @@
 
 from __future__ import annotations
 
+import json
+from typing import Any
+
 from app.evaluations.services import (
     evaluations_services_evaluations_evaluator_service as evaluator_service,
+)
+from app.evaluations.services.evaluations_services_evaluations_evaluator_models_service import (
+    CodeImplementationEvidenceContext,
 )
 from app.evaluations.services.evaluations_services_evaluations_winoe_report_pipeline_constants_service import (
     DEFAULT_RUBRIC_VERSION,
@@ -16,6 +22,295 @@ from app.shared.database.shared_database_models_model import (
     Submission,
     Task,
 )
+
+
+def _load_json_object(value: object) -> dict[str, Any] | None:
+    if isinstance(value, dict):
+        return value
+    if not isinstance(value, str) or not value.strip():
+        return None
+    try:
+        parsed = json.loads(value)
+    except ValueError:
+        return None
+    return parsed if isinstance(parsed, dict) else None
+
+
+def _submission_test_summary(submission: Submission | None) -> dict[str, Any] | None:
+    if submission is None:
+        return None
+    return _load_json_object(submission.test_output)
+
+
+def _submission_inner_summary(submission: Submission | None) -> dict[str, Any] | None:
+    summary = _submission_test_summary(submission)
+    if not isinstance(summary, dict):
+        return None
+    inner_summary = summary.get("summary")
+    return inner_summary if isinstance(inner_summary, dict) else None
+
+
+def _summary_evidence_artifacts(
+    submission: Submission | None,
+) -> dict[str, dict[str, Any]] | None:
+    summary = _submission_inner_summary(submission)
+    if not isinstance(summary, dict):
+        return None
+    evidence_artifacts = summary.get("evidenceArtifacts")
+    return evidence_artifacts if isinstance(evidence_artifacts, dict) else None
+
+
+def _summary_without_evidence(submission: Submission | None) -> dict[str, Any] | None:
+    summary = _submission_inner_summary(submission)
+    if not isinstance(summary, dict):
+        return None
+    filtered = {
+        key: value for key, value in summary.items() if key != "evidenceArtifacts"
+    }
+    return filtered or None
+
+
+def _artifact_payload(
+    evidence_artifacts: dict[str, dict[str, Any]] | None,
+    key: str,
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None]:
+    if not isinstance(evidence_artifacts, dict):
+        return None, None
+    artifact = evidence_artifacts.get(key)
+    if not isinstance(artifact, dict):
+        return None, None
+    data = artifact.get("data")
+    if not isinstance(data, dict):
+        return artifact, None
+    payload = data.get("payload")
+    return artifact, payload if isinstance(payload, dict) else None
+
+
+def _string_list(value: object) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str):
+            continue
+        normalized = item.strip()
+        if normalized:
+            result.append(normalized)
+    return result
+
+
+def _commit_history_from_submission(
+    *,
+    submission: Submission,
+    day_index: int,
+    evidence_artifacts: dict[str, dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    artifact, payload = _artifact_payload(evidence_artifacts, "commitMetadata")
+    if artifact is None or payload is None:
+        return []
+    commits = payload.get("commits")
+    if not isinstance(commits, list):
+        return []
+    artifact_id = artifact.get("artifactId")
+    commit_history: list[dict[str, Any]] = []
+    for commit in commits:
+        if not isinstance(commit, dict):
+            continue
+        sha = commit.get("sha")
+        if not isinstance(sha, str) or not sha.strip():
+            continue
+        files_changed_paths = _string_list(commit.get("files_changed"))
+        files_changed_count = commit.get("files_changed_count")
+        commit_history.append(
+            {
+                "sha": sha.strip(),
+                "message": commit.get("message"),
+                "committedAt": commit.get("timestamp"),
+                "authoredAt": commit.get("timestamp"),
+                "author": commit.get("author"),
+                "filesChanged": files_changed_count
+                if isinstance(files_changed_count, int)
+                else len(files_changed_paths),
+                "filesChangedPaths": files_changed_paths,
+                "additions": commit.get("insertions"),
+                "deletions": commit.get("deletions"),
+                "dayIndex": day_index,
+                "submissionId": submission.id,
+                "evidenceArtifactId": artifact_id,
+            }
+        )
+    return commit_history
+
+
+def _file_creation_timeline_from_submission(
+    *,
+    submission: Submission,
+    day_index: int,
+    evidence_artifacts: dict[str, dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    artifact, payload = _artifact_payload(evidence_artifacts, "fileCreationTimeline")
+    if artifact is None or payload is None:
+        return []
+    files = payload.get("files")
+    if not isinstance(files, list):
+        return []
+    artifact_id = artifact.get("artifactId")
+    timeline: list[dict[str, Any]] = []
+    for event in files:
+        if not isinstance(event, dict):
+            continue
+        created_at = event.get("timestamp")
+        first_commit_sha = event.get("commit_sha")
+        message = event.get("message")
+        paths = event.get("files")
+        if not isinstance(paths, list):
+            continue
+        for path in paths:
+            if not isinstance(path, str) or not path.strip():
+                continue
+            timeline.append(
+                {
+                    "path": path.strip(),
+                    "createdAt": created_at,
+                    "firstCommitSha": first_commit_sha,
+                    "commitMessage": message,
+                    "dayIndex": day_index,
+                    "submissionId": submission.id,
+                    "evidenceArtifactId": artifact_id,
+                }
+            )
+    return timeline
+
+
+def _dependency_metadata_from_submission(
+    *,
+    day_index: int,
+    submission: Submission,
+    evidence_artifacts: dict[str, dict[str, Any]] | None,
+) -> dict[str, Any] | None:
+    artifact, payload = _artifact_payload(evidence_artifacts, "dependencyManifests")
+    if artifact is None or payload is None:
+        return None
+    manifests = payload.get("manifests")
+    if not isinstance(manifests, list):
+        return None
+    return {
+        "dayIndex": day_index,
+        "submissionId": submission.id,
+        "evidenceArtifactId": artifact.get("artifactId"),
+        "detected": bool(payload.get("detected")),
+        "manifests": [dict(item) for item in manifests if isinstance(item, dict)],
+    }
+
+
+def _repository_snapshot_status(
+    *,
+    repository_reference: str | None,
+    day_submission_refs: list[dict[str, Any]],
+    commit_history: list[dict[str, Any]],
+    file_creation_timeline: list[dict[str, Any]],
+    test_coverage_progression: list[dict[str, Any]],
+    dependency_metadata: dict[str, Any] | None,
+    documentation_evolution: list[dict[str, Any]],
+) -> str:
+    has_day_evidence = bool(day_submission_refs)
+    has_snapshot_artifacts = bool(
+        commit_history
+        or file_creation_timeline
+        or test_coverage_progression
+        or dependency_metadata is not None
+        or documentation_evolution
+    )
+    if not has_day_evidence and not repository_reference:
+        return "unavailable: no day 2/3 repository or submission evidence found"
+    if repository_reference and has_snapshot_artifacts:
+        return "available: derived from day 2/3 repository and submission evidence"
+    if repository_reference:
+        return (
+            "partial: repository reference available; persisted repository snapshot "
+            "artifacts not found for day 2/3 evidence"
+        )
+    return (
+        "partial: day 2/3 submission evidence available; repository reference not "
+        "resolved and persisted repository snapshot artifacts not found"
+    )
+
+
+def _test_coverage_progression_from_submission(
+    *,
+    day_index: int,
+    submission: Submission,
+    evidence_artifacts: dict[str, dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    artifact, _payload = _artifact_payload(evidence_artifacts, "testResults")
+    if artifact is None:
+        return []
+    summary = _summary_without_evidence(submission)
+    if not isinstance(summary, dict):
+        return []
+    coverage_path = summary.get("coveragePath")
+    if not isinstance(coverage_path, str) or not coverage_path.strip():
+        return []
+    captured_at = (
+        submission.workflow_run_completed_at.isoformat()
+        if submission.workflow_run_completed_at is not None
+        else (
+            submission.last_run_at.isoformat()
+            if submission.last_run_at is not None
+            else None
+        )
+    )
+    return [
+        {
+            "dayIndex": day_index,
+            "submissionId": submission.id,
+            "commitSha": submission.commit_sha,
+            "workflowRunId": submission.workflow_run_id,
+            "capturedAt": captured_at,
+            "testsPassed": submission.tests_passed,
+            "testsFailed": submission.tests_failed,
+            "coveragePath": coverage_path.strip(),
+            "outputLog": summary.get("outputLog"),
+            "command": summary.get("command"),
+            "detectedTool": summary.get("detectedTool"),
+            "exitCode": summary.get("exitCode"),
+            "evidenceArtifactId": artifact.get("artifactId"),
+        }
+    ]
+
+
+def _documentation_evolution_from_commit_history(
+    commit_history: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    documentation_evolution: list[dict[str, Any]] = []
+    for commit in commit_history:
+        paths = commit.get("filesChangedPaths")
+        if not isinstance(paths, list):
+            continue
+        doc_paths = [
+            path
+            for path in paths
+            if isinstance(path, str)
+            and path.strip()
+            and (
+                path.strip().lower().endswith("readme.md")
+                or path.strip().lower().startswith("docs/")
+                or "/docs/" in f"/{path.strip().lower()}/"
+            )
+        ]
+        if not doc_paths:
+            continue
+        documentation_evolution.append(
+            {
+                "dayIndex": commit.get("dayIndex"),
+                "submissionId": commit.get("submissionId"),
+                "commitSha": commit.get("sha"),
+                "message": commit.get("message"),
+                "documentationPaths": doc_paths,
+                "evidenceArtifactId": commit.get("evidenceArtifactId"),
+            }
+        )
+    return documentation_evolution
 
 
 def _resolve_rubric_version(context) -> str:
@@ -88,4 +383,243 @@ def _build_day_inputs(
     return day_inputs
 
 
-__all__ = ["_build_day_inputs", "_resolve_rubric_version"]
+def _build_code_implementation_evidence_context(
+    *,
+    candidate_session_id: int,
+    submissions_by_day: dict[int, Submission],
+    day_audits: dict[int, CandidateDayAudit],
+) -> CodeImplementationEvidenceContext:
+    """Build the structured repository/process evidence payload for Days 2 and 3."""
+    day_submissions = {
+        day_index: submissions_by_day.get(day_index) for day_index in (2, 3)
+    }
+    repo_full_name = next(
+        (
+            submission.code_repo_path
+            for submission in day_submissions.values()
+            if submission is not None and submission.code_repo_path
+        ),
+        None,
+    )
+    repo_url = f"https://github.com/{repo_full_name}" if repo_full_name else None
+    primary_submission = day_submissions.get(3) or day_submissions.get(2)
+    repository_artifact_references: list[dict[str, Any]] = []
+    day_submission_refs: list[dict[str, Any]] = []
+    cutoff_commit_shas: dict[str, str] = {}
+    commit_history: list[dict[str, Any]] = []
+    file_creation_timeline: list[dict[str, Any]] = []
+    test_coverage_progression: list[dict[str, Any]] = []
+    dependency_metadata: dict[str, Any] | None = None
+    repository_snapshot: dict[str, Any] = {
+        "candidateSessionId": candidate_session_id,
+        "repoFullName": repo_full_name,
+        "repoUrl": repo_url,
+        "daySubmissionRefs": day_submission_refs,
+        "cutoffCommitShas": None,
+        "latestKnownCommitSha": None,
+        "latestKnownWorkflowRunId": None,
+        "latestKnownWorkflowRunUrl": None,
+        "latestKnownDiffSummary": None,
+        "latestKnownTestSummary": None,
+        "latestKnownRepoTreeSummary": None,
+    }
+    for day_index, submission in day_submissions.items():
+        if submission is None:
+            continue
+        evidence_artifacts = _summary_evidence_artifacts(submission)
+        cutoff_commit_sha = (
+            day_audits.get(day_index).cutoff_commit_sha
+            if day_index in day_audits
+            else None
+        )
+        if isinstance(cutoff_commit_sha, str) and cutoff_commit_sha.strip():
+            cutoff_commit_shas[str(day_index)] = cutoff_commit_sha.strip()
+        workflow_run_id = (
+            submission.workflow_run_id.strip()
+            if isinstance(submission.workflow_run_id, str)
+            and submission.workflow_run_id.strip()
+            else None
+        )
+        workflow_run_url = (
+            f"https://github.com/{repo_full_name}/actions/runs/{workflow_run_id}"
+            if repo_full_name and workflow_run_id
+            else None
+        )
+        day_submission_refs.append(
+            {
+                "dayIndex": day_index,
+                "submissionId": submission.id,
+                "taskId": submission.task_id,
+                "commitSha": submission.commit_sha,
+                "checkpointSha": submission.checkpoint_sha,
+                "finalSha": submission.final_sha,
+                "workflowRunId": workflow_run_id,
+                "workflowRunUrl": workflow_run_url,
+                "cutoffCommitSha": cutoff_commit_sha,
+                "diffSummary": _parse_diff_summary(submission.diff_summary_json),
+                "testsPassed": submission.tests_passed,
+                "testsFailed": submission.tests_failed,
+                "testOutputPresent": bool(
+                    isinstance(submission.test_output, str)
+                    and submission.test_output.strip()
+                ),
+            }
+        )
+        if workflow_run_url is not None:
+            repository_artifact_references.append(
+                {
+                    "kind": "workflow_run",
+                    "dayIndex": day_index,
+                    "submissionId": submission.id,
+                    "workflowRunId": workflow_run_id,
+                    "workflowRunUrl": workflow_run_url,
+                }
+            )
+        if evidence_artifacts:
+            repository_artifact_references.extend(
+                [
+                    {
+                        "kind": "artifact_summary",
+                        "artifactName": artifact_name,
+                        "dayIndex": day_index,
+                        "submissionId": submission.id,
+                        "artifactId": artifact.get("artifactId"),
+                    }
+                    for artifact_name, artifact in evidence_artifacts.items()
+                    if isinstance(artifact, dict)
+                ]
+            )
+            commit_history.extend(
+                _commit_history_from_submission(
+                    submission=submission,
+                    day_index=day_index,
+                    evidence_artifacts=evidence_artifacts,
+                )
+            )
+            file_creation_timeline.extend(
+                _file_creation_timeline_from_submission(
+                    submission=submission,
+                    day_index=day_index,
+                    evidence_artifacts=evidence_artifacts,
+                )
+            )
+            test_coverage_progression.extend(
+                _test_coverage_progression_from_submission(
+                    submission=submission,
+                    day_index=day_index,
+                    evidence_artifacts=evidence_artifacts,
+                )
+            )
+            if dependency_metadata is None:
+                dependency_metadata = _dependency_metadata_from_submission(
+                    submission=submission,
+                    day_index=day_index,
+                    evidence_artifacts=evidence_artifacts,
+                )
+
+    latest_commit_sha = None
+    latest_workflow_run_id = None
+    latest_workflow_run_url = None
+    latest_test_summary = None
+    latest_diff_summary = None
+    latest_repo_tree_summary = None
+    if primary_submission is not None:
+        latest_commit_sha = (
+            primary_submission.commit_sha
+            or primary_submission.final_sha
+            or primary_submission.checkpoint_sha
+        )
+        latest_workflow_run_id = (
+            primary_submission.workflow_run_id.strip()
+            if isinstance(primary_submission.workflow_run_id, str)
+            and primary_submission.workflow_run_id.strip()
+            else None
+        )
+        latest_workflow_run_url = (
+            f"https://github.com/{repo_full_name}/actions/runs/{latest_workflow_run_id}"
+            if repo_full_name and latest_workflow_run_id
+            else None
+        )
+        latest_test_summary = {
+            "testsPassed": primary_submission.tests_passed,
+            "testsFailed": primary_submission.tests_failed,
+            "workflowRunStatus": primary_submission.workflow_run_status,
+            "workflowRunConclusion": primary_submission.workflow_run_conclusion,
+            "lastRunAt": primary_submission.last_run_at.isoformat()
+            if primary_submission.last_run_at
+            else None,
+        }
+        latest_diff_summary = _parse_diff_summary(primary_submission.diff_summary_json)
+        primary_evidence_artifacts = _summary_evidence_artifacts(primary_submission)
+        if primary_evidence_artifacts is not None:
+            latest_repo_tree_summary = primary_evidence_artifacts.get("repoTreeSummary")
+    repository_snapshot.update(
+        {
+            "cutoffCommitShas": cutoff_commit_shas or None,
+            "latestKnownCommitSha": latest_commit_sha,
+            "latestKnownWorkflowRunId": latest_workflow_run_id,
+            "latestKnownWorkflowRunUrl": latest_workflow_run_url,
+            "latestKnownDiffSummary": latest_diff_summary,
+            "latestKnownTestSummary": latest_test_summary,
+            "latestKnownRepoTreeSummary": latest_repo_tree_summary,
+        }
+    )
+    documentation_evolution = _documentation_evolution_from_commit_history(
+        commit_history
+    )
+
+    evidence_status = {
+        "repository_snapshot": _repository_snapshot_status(
+            repository_reference=repo_full_name,
+            day_submission_refs=day_submission_refs,
+            commit_history=commit_history,
+            file_creation_timeline=file_creation_timeline,
+            test_coverage_progression=test_coverage_progression,
+            dependency_metadata=dependency_metadata,
+            documentation_evolution=documentation_evolution,
+        ),
+        "commit_history": (
+            "available: derived from persisted submission.test_output summary evidenceArtifacts.commitMetadata"
+            if commit_history
+            else "unavailable: persisted submission.test_output summary evidenceArtifacts.commitMetadata not found for day 2/3 evidence"
+        ),
+        "file_creation_timeline": (
+            "available: derived from persisted submission.test_output summary evidenceArtifacts.fileCreationTimeline"
+            if file_creation_timeline
+            else "unavailable: persisted submission.test_output summary evidenceArtifacts.fileCreationTimeline not found for day 2/3 evidence"
+        ),
+        "test_coverage_progression": (
+            "available: derived from persisted submission.test_output summary evidenceArtifacts.testResults and coveragePath"
+            if test_coverage_progression
+            else "unavailable: persisted submission.test_output summary evidenceArtifacts.testResults coveragePath not found for day 2/3 evidence"
+        ),
+        "dependency_metadata": (
+            "available: derived from persisted submission.test_output summary evidenceArtifacts.dependencyManifests"
+            if dependency_metadata is not None
+            else "unavailable: persisted submission.test_output summary evidenceArtifacts.dependencyManifests not found for day 2/3 evidence"
+        ),
+        "documentation_evolution": (
+            "available: derived from commit history entries touching README or docs files"
+            if documentation_evolution
+            else "unavailable: documentation evolution artifacts not found for day 2/3 evidence"
+        ),
+    }
+    return CodeImplementationEvidenceContext(
+        repository_snapshot=repository_snapshot,
+        repository_url=repo_url,
+        repository_reference=repo_full_name,
+        repository_artifact_references=repository_artifact_references,
+        commit_history=commit_history,
+        file_creation_timeline=file_creation_timeline,
+        test_coverage_progression=test_coverage_progression,
+        dependency_metadata=dependency_metadata,
+        documentation_evolution=documentation_evolution,
+        evidence_status=evidence_status,
+    )
+
+
+__all__ = [
+    "_build_code_implementation_evidence_context",
+    "_build_day_inputs",
+    "_resolve_rubric_version",
+]

--- a/app/evaluations/services/evaluations_services_evaluations_winoe_report_pipeline_execute_service.py
+++ b/app/evaluations/services/evaluations_services_evaluations_winoe_report_pipeline_execute_service.py
@@ -21,13 +21,16 @@ def _build_day_scores(result) -> list[dict[str, Any]]:
             field_name=f"day_results[{day_result.day_index}].score",
             required=True,
         )
-        if not isinstance(rubric_breakdown, dict) or not rubric_breakdown:
+        if not isinstance(rubric_breakdown, dict):
             raise ValueError(
-                f"day_results[{day_result.day_index}] rubric_breakdown must be a non-empty object."
+                f"day_results[{day_result.day_index}] rubric_breakdown must be an object."
             )
-        if not isinstance(evidence, list) or not evidence:
+        # Provider output can omit evidence citations even when the score and
+        # rubric breakdown are usable. Do not fail the full evaluation run on
+        # that condition; persist the empty evidence list and surface the result.
+        if not isinstance(evidence, list):
             raise ValueError(
-                f"day_results[{day_result.day_index}] evidence must be a non-empty list."
+                f"day_results[{day_result.day_index}] evidence must be a list."
             )
         day_scores.append(
             {

--- a/app/evaluations/services/evaluations_services_evaluations_winoe_report_pipeline_runner_service.py
+++ b/app/evaluations/services/evaluations_services_evaluations_winoe_report_pipeline_runner_service.py
@@ -21,6 +21,7 @@ from app.evaluations.services.evaluations_services_evaluations_winoe_report_pipe
     DEFAULT_EVALUATION_PROMPT_VERSION,
 )
 from app.evaluations.services.evaluations_services_evaluations_winoe_report_pipeline_day_inputs_service import (
+    _build_code_implementation_evidence_context,
     _build_day_inputs,
     _resolve_rubric_version,
 )
@@ -306,6 +307,11 @@ async def process_evaluation_run_job_impl(
                 else []
             ),
         )
+        code_implementation_evidence = _build_code_implementation_evidence_context(
+            candidate_session_id=context.candidate_session.id,
+            submissions_by_day=submissions,
+            day_audits=audits,
+        )
 
         run_metadata, _basis_refs, day2_sha, day3_sha, cutoff_sha = _build_run_metadata(
             context=context,
@@ -379,6 +385,7 @@ async def process_evaluation_run_job_impl(
             rubric_version=rubric_version,
             disabled_day_indexes=effective_disabled_days,
             day_inputs=day_inputs,
+            code_implementation_evidence=code_implementation_evidence,
             trial_context_json={
                 "trialId": context.trial.id,
                 "title": getattr(context.trial, "title", None),

--- a/pr.md
+++ b/pr.md
@@ -1,178 +1,239 @@
-# Harden empty-repo GitHub provisioning and evidence capture
+# PR: Update Day 2/3 Code Implementation Reviewer for from-scratch evaluation
 
 ## Summary
 
-This PR hardens GitHub provisioning for the v4 from-scratch Tech Trial flow.
+This PR updates the Day 2/3 Code Implementation Reviewer path for the v4 from-scratch Tech Trial model. The reviewer now evaluates the candidate’s complete repository and development process instead of treating Days 2/3 as a diff against pre-existing code.
 
-Candidate workspaces are now created as empty repos and initialized only with Winoe-owned workspace files. Candidate GitHub username is required before workspace provisioning, collaborator permissioning uses that username, evidence capture runs through the canonical workflow `.github/workflows/winoe-evidence-capture.yml`, stable evidence artifact names are parsed reliably, and cleanup is bounded and idempotent.
+The Day 2/3 rubric now scores from-scratch implementation work across project scaffolding, architecture, code quality, testing discipline, development process, documentation/handoff readiness, and requirements coverage. The reviewer prompt now receives structured repository/process evidence, including populated commit history, file creation timeline, and test coverage progression when persisted evidence exists.
 
 ## What changed
 
-- Empty-repo repo creation and recovery path for candidate workspaces.
-- Required bootstrap files are created in the repo:
-  - `.devcontainer/devcontainer.json`
-  - `README.md`
-  - `.gitignore`
-  - `.github/workflows/winoe-evidence-capture.yml`
-- Devcontainer defaults to the Microsoft universal image unless a language-specific image is selected for the Talent Partner's preferred language.
-- `README.md` is used as the Project Brief.
-- No app starter code is added to candidate repos.
-- Generated `.gitignore` does not ignore lockfiles.
-- Candidate GitHub username is required before provisioning continues.
-- Collaborator add behavior is retried safely when permissioning already exists or was partially applied.
-- Evidence workflow and artifact parser behavior were updated for the new canonical workflow and stable artifact names.
-- Invite and preprovision cleanup paths are more precise so they only remove resources created during the current attempt.
-- Retry and idempotency paths are covered by tests.
-- Documentation was updated to match the v4 empty-repo provisioning flow.
+- Rewrote `app/ai/prompt_assets/v1/winoe-day-2&3-rubric.md` for from-scratch Tech Trial evaluation.
+- Added scored rubric dimensions:
+  - Project scaffolding quality — 18 points
+  - Architectural coherence — 18 points
+  - Code quality and maintainability — 17 points
+  - Testing discipline — 15 points
+  - Development process and commit history — 12 points
+  - Documentation and handoff readiness — 10 points
+  - Requirements coverage and product completeness — 10 points
+- Added explicit rubric guidance that:
+  - the complete repository is the candidate’s work
+  - there is no pre-existing application code to compare against
+  - evaluation is tech-stack-agnostic
+  - AI coding assistants are allowed and not penalized by themselves
+  - AI-bulk-generation concerns must be evidence-backed
+- Added `CodeImplementationEvidenceContext` to the evaluator input bundle.
+- Threaded `reviewContext.codeImplementationEvidence` into the live Day 2/3 reviewer payload.
+- Integrated with the #296 artifact-parse path through persisted `Submission.test_output` evidence artifacts.
+- Populated reviewer evidence from persisted Day 2/3 artifacts:
+  - repository snapshot/reference
+  - commit history
+  - file creation timeline
+  - test coverage progression
+  - dependency metadata
+  - documentation evolution
+- Added honest evidence-status semantics:
+  - `available:` when persisted evidence exists
+  - `partial:` when repo identity exists but deeper snapshot artifacts are missing
+  - `unavailable:` when evidence is truly absent
+- Fixed report finalization validation so provider results with empty evidence arrays do not dead-letter the full evaluation run when scores and rubric breakdown are valid.
+- Added regression tests for rubric content, prompt rendering, evidence serialization, malformed evidence parsing, repository status semantics, and real route/worker completion behavior.
 
-## v4 pivot alignment
+## #296 integration
 
-- No generated-from-template repo path is used in active provisioning.
-- No template catalog dependency is used in active provisioning.
-- No precommit bundle is applied to candidate repos in the v4 path.
-- No Codespace Specializor or Specializer component is used.
-- The repo is evaluated as candidate-authored from scratch.
+#296 has landed, so this PR now fully wires #318 into the persisted evidence path instead of leaving evidence fields as prompt-only expectations.
 
-This wording reflects the active path only. It does not claim historical compatibility code was removed unless the implementation actually changed it.
+The Day 2/3 evidence builder hydrates `CodeImplementationEvidenceContext` from persisted submission evidence produced by the GitHub workflow artifact parse path:
 
-## Evidence / artifacts
+- `submission.test_output.summary.evidenceArtifacts.commitMetadata` → `commitHistory`
+- `submission.test_output.summary.evidenceArtifacts.fileCreationTimeline` → `fileCreationTimeline`
+- `submission.test_output.summary.testResults` + `coveragePath` → `testCoverageProgression`
+- `submission.test_output.summary.evidenceArtifacts.dependencyManifests` → `dependencyMetadata`
+- commit entries touching `README` or `docs/` paths → `documentationEvolution`
 
-Canonical artifact names:
+This means the Code Implementation Reviewer now receives actual populated Day 2/3 repository/process evidence when it exists, not just empty placeholder fields.
 
-- `winoe-commit-metadata`
-- `winoe-file-creation-timeline`
-- `winoe-repo-tree-summary`
-- `winoe-dependency-manifests`
-- `winoe-test-detection`
-- `winoe-test-results`
-- `winoe-lint-detection`
-- `winoe-lint-results`
-- `winoe-evidence-manifest`
+## Evidence semantics
 
-Canonical JSON files:
+The evidence contract is intentionally conservative:
 
-- `commit_metadata.json`
-- `file_creation_timeline.json`
-- `repo_tree_summary.json`
-- `dependency_manifests.json`
-- `test_detection.json`
-- `test_results.json`
-- `lint_detection.json`
-- `lint_results.json`
-- `evidence_manifest.json`
+- If persisted evidence exists, the reviewer payload marks the field `available:`.
+- If only repository identity exists, repository snapshot status is `partial:`.
+- If evidence is missing, the field remains empty and status is explicit `unavailable:`.
+- The reviewer prompt instructs the model not to infer process quality when commit history, file creation timeline, or test coverage progression are unavailable.
 
-Wrapper schema fields:
+This preserves Winoe AI’s evidence-first trust bar and prevents overclaiming.
 
-- `schema_version`
-- `repository_full_name`
-- `commit_sha`
-- `workflow_run_id`
-- `generated_at`
-- `status`
-- `payload`
+## Acceptance criteria
 
-Test and lint detection distinguishes:
-
-- `detected`
-- `not_detected`
-- failed command execution as evidence
-
-## Idempotency and recovery
-
-- Provisioning retry reuses the existing repo and workspace.
-- Missing bootstrap files are repaired.
-- Missing workflow files are repaired.
-- Collaborator add is safe on retry.
-- Codespace creation and recovery paths are retried safely.
-- Duplicate workspace groups and workspaces are avoided.
-- Day 2 and Day 3 share the canonical coding repo where expected.
-
-## Cleanup behavior
-
-- Cleanup is idempotent.
-- Invite rollback cleanup only targets repos created during the current attempt.
-- Existing or reused repos are not deleted accidentally.
-- Trial termination cleanup remains scoped to the Trial and workspace.
-- Already-cleaned resources are handled safely.
+- [x] `winoe-day-2&3-rubric.md` updated with from-scratch evaluation dimensions.
+- [x] No references to `precommit baseline`, `delta from precommit`, or `Specializor` in the Day 2/3 rubric.
+- [x] Project scaffolding quality is a scored dimension weighted 18 points.
+- [x] Development process / commit history analysis is a scored dimension weighted 12 points.
+- [x] Rubric is tech-stack-agnostic and does not penalize framework/language choice by itself.
+- [x] Rubric explicitly states AI tool usage is allowed and not penalized by itself.
+- [x] Rubric notes bulk AI generation without engineering judgment only when evidence supports it.
+- [x] Code Implementation Reviewer Sub-Agent prompt path uses the updated from-scratch rubric.
+- [x] Reviewer receives structured full repository/process evidence.
+- [x] Reviewer receives populated commit history, file creation timeline, and test coverage progression when persisted #296 evidence exists.
+- [x] Missing/partial evidence is marked honestly and does not cause the reviewer to overclaim.
 
 ## QA evidence
 
-```text
-QA PASS — ready for PR prompt
+### Focused tests
 
-Environment:
-- Branch: feature/harden-github-provisioning-for-empty-repo-codespace-creation-and-evidence-capture
-- Commit: d39e7dbf0b091bc239d4d50870d8d52a4af00d0b
-- Backend command: ./scripts/local_qa_backend.sh
-- Worker command: python -m app.shared.jobs.shared_jobs_worker_cli_service worker
-- Backend health: GET /health returned {"status":"ok"}
-- Worker readiness: GET /ready returned ready with fresh worker heartbeat
+Passed:
 
-Manual QA covered:
-- missing GitHub username gate
-- username-present provisioning
-- repo contents inspection
-- idempotent retry
-- partial recovery
-- evidence workflow contract
-- artifact parsing/retrieval
-- cleanup/termination
-- retired-terminology active-path check
+```bash
+poetry run pytest --no-cov -q tests/evaluations/services/test_evaluations_evaluator_runner_service.py tests/evaluations/services/test_evaluations_winoe_report_pipeline_rubric_snapshots_service.py tests/ai/test_ai_prompt_pack_code_implementation_reviewer_service.py
 ```
 
-```text
-Live GitHub push execution was not performed in this QA pass. Route probes used an in-memory stub GitHub provider. GitHub Actions workflow execution was verified by workflow YAML contract and backend tests; artifact parsing/retrieval was verified through backend test paths.
+Passed:
+
+```bash
+poetry run pytest --no-cov -q tests/evaluations/routes/test_evaluations_winoe_report_api_worker_completion_returns_ready_and_evidence_routes.py
 ```
 
-## Validation
+Passed:
 
-```text
-bash ./precommit.sh
-✅ passed
-1865 passed, 13 warnings
-Coverage: 96.00%
-Required coverage: 96%
+```bash
+poetry run pytest --no-cov -q tests/ai/test_ai_prompt_pack_soul_service.py tests/ai/test_ai_prompt_pack_code_implementation_reviewer_service.py tests/evaluations/services/test_evaluations_winoe_rubric_snapshots_service.py
 ```
 
-```text
-git diff --check
-✅ passed
+### Full test suite
+
+Passed:
+
+```bash
+poetry run pytest -q
 ```
 
-## Risks / limitations
+Result:
 
-- Live GitHub push execution was not performed in this QA pass.
-- Evidence capture execution was verified through workflow contract checks and backend tests rather than a live GitHub Actions run.
-- Cleanup correctness depends on the repo/workspace identifiers returned by the current attempt, so future changes to those identifiers should be revalidated.
+```text
+1876 passed, 13 warnings
+Required test coverage of 96% reached.
+Total coverage: 96.03%
+```
 
-## Issue checklist
+### Compile check
 
-- [x] Empty repo creation is idempotent and safe to retry
-- [x] Repo initialized with `.devcontainer/devcontainer.json`, `README.md`, `.gitignore`, and evidence-capture Actions workflow
-- [x] Devcontainer uses Microsoft universal image by default
-- [x] Recovery from partial GitHub API failure / partial repo initialization
-- [x] Candidate username-based permissioning via collaborator add
-- [x] GitHub Actions evidence-capture workflow runs on push
-- [x] Workflow captures commit metadata, file creation order, test detection, and linting results
-- [x] Evidence artifacts are uploaded and parseable/retrievable through backend paths
-- [x] Cleanup on Trial termination is idempotent and scoped
+Passed:
 
-## PR title
+```bash
+poetry run python -m compileall app/evaluations/services/evaluations_services_evaluations_winoe_report_pipeline_day_inputs_service.py tests/evaluations/services/test_evaluations_winoe_report_pipeline_rubric_snapshots_service.py tests/evaluations/services/test_evaluations_evaluator_runner_service.py
+```
 
-Harden empty-repo GitHub provisioning and evidence capture
+### Terminology checks
 
-Worker Report:
-- Summary
-  - Updated `pr.md` only to describe the v4 empty-repo GitHub provisioning and evidence capture flow.
-- Files changed
-  - `pr.md`
-- Commands run
-  - `git status --short` - pass
-  - `git diff --check` - pass
-  - `bash ./precommit.sh` - pass
-  - `git diff --check` - pass
-- Risks / assumptions
-  - Assumed the provided QA and validation text is the canonical PR-materials source.
-  - Kept the document aligned to the active v4 path and avoided retired product language in the main narrative.
-- Open questions / blockers
-  - None
+Passed:
+
+```bash
+rg -n "precommit baseline|delta from precommit|Specializor" app/ai/prompt_assets/v1/winoe-day-2\&3-rubric.md tests/ai/test_ai_prompt_pack_code_implementation_reviewer_service.py
+```
+
+Passed:
+
+```bash
+rg -n "template catalog|Fit Profile|Fit Score|simulation|recruiter|Tenon" app/ai/prompt_assets/v1/winoe-day-2\&3-rubric.md
+```
+
+### Pre-commit
+
+`pre-commit` was unavailable in the local environment, so it was not claimed as a pass.
+
+## Real end-to-end runtime QA
+
+Real local backend + worker QA passed.
+
+* Backend PID: `22463`
+* Worker PID: `22959`
+* Health check:
+
+```bash
+curl -sS http://127.0.0.1:8000/health
+```
+
+Response:
+
+```json
+{"status":"ok"}
+```
+
+Triggered Winoe Report generation through the real API:
+
+```bash
+curl -sS -X POST http://127.0.0.1:8000/api/candidate_sessions/6/winoe_report/generate \
+  -H 'x-dev-user-email: winoe-report-qa-iteration8b@test.com'
+```
+
+Response:
+
+```json
+{"jobId":"053c8a38-93b6-4ba9-bd26-d3f941ffaf0d","status":"queued"}
+```
+
+Final report fetch:
+
+```bash
+curl -sS http://127.0.0.1:8000/api/candidate_sessions/6/winoe_report \
+  -H 'x-dev-user-email: winoe-report-qa-iteration8b@test.com'
+```
+
+Result:
+
+* report status: `ready`
+* evaluation run ID: `4`
+* evaluation run status: `completed`
+* job ID: `053c8a38-93b6-4ba9-bd26-d3f941ffaf0d`
+* report score: `0.5759`
+
+## Runtime payload proof
+
+For the populated Day 2/3 evidence case, the live reviewer payload included:
+
+```json
+{
+  "dayIndex": 2,
+  "reviewContext": {
+    "instructions": "Use codeImplementationEvidence as primary evidence for Days 2 and 3. If commit history, file creation timeline, or test coverage progression are unavailable, say so explicitly and do not infer process quality.",
+    "codeImplementationEvidence": {
+      "repositoryReference": "winoe-ai/report-qa-repo",
+      "commitHistoryCount": 4,
+      "fileCreationTimelineCount": 8,
+      "testCoverageProgressionCount": 2,
+      "evidenceStatus": {
+        "repository_snapshot": "available: derived from day 2/3 repository and submission evidence",
+        "commit_history": "available: derived from persisted submission.test_output summary evidenceArtifacts.commitMetadata",
+        "file_creation_timeline": "available: derived from persisted submission.test_output summary evidenceArtifacts.fileCreationTimeline",
+        "test_coverage_progression": "available: derived from persisted submission.test_output summary evidenceArtifacts.testResults and coveragePath"
+      }
+    }
+  }
+}
+```
+
+For the repository-reference-only case, the payload correctly distinguishes partial evidence:
+
+```json
+{
+  "candidateSessionId": 7,
+  "repositoryReference": "winoe-ai/partial-repo",
+  "repositorySnapshotStatus": "partial: repository reference available; persisted repository snapshot artifacts not found for day 2/3 evidence",
+  "commitHistoryCount": 0,
+  "fileCreationTimelineCount": 0,
+  "testCoverageProgressionCount": 0,
+  "commitHistoryStatus": "unavailable: persisted submission.test_output summary evidenceArtifacts.commitMetadata not found for day 2/3 evidence",
+  "fileCreationTimelineStatus": "unavailable: persisted submission.test_output summary evidenceArtifacts.fileCreationTimeline not found for day 2/3 evidence",
+  "testCoverageProgressionStatus": "unavailable: persisted submission.test_output summary evidenceArtifacts.testResults coveragePath not found for day 2/3 evidence"
+}
+```
+
+## Notes / risks
+
+* Local QA used deterministic test runtime snapshots to exercise the full backend + worker path without external LLM flakiness.
+* Evidence parsing now uses persisted `Submission.test_output` artifact summaries as the current #296-backed source of truth.
+* If a future evidence persistence schema introduces dedicated artifact tables for commit/file/coverage data, this builder should get a small adapter layer, not a redesign.
+
+Fixes #318

--- a/tests/ai/test_ai_prompt_pack_code_implementation_reviewer_service.py
+++ b/tests/ai/test_ai_prompt_pack_code_implementation_reviewer_service.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from app.ai import (
+    build_ai_policy_snapshot,
+    build_prompt_pack_entry,
+    build_required_snapshot_prompt,
+)
+
+
+def _trial() -> SimpleNamespace:
+    return SimpleNamespace(
+        ai_notice_version="mvp1",
+        ai_notice_text="AI assistance may be used for evaluation support.",
+        ai_eval_enabled_by_day={
+            "1": True,
+            "2": True,
+            "3": True,
+            "4": True,
+            "5": True,
+        },
+    )
+
+
+def test_code_implementation_reviewer_rubric_uses_from_scratch_dimensions() -> None:
+    entry = build_prompt_pack_entry("codeImplementationReviewer")
+
+    assert "from-scratch Tech Trial" in entry.instructions_md
+    assert "complete repository" in entry.instructions_md
+    assert "complete commit history" in entry.instructions_md
+    assert "file creation timeline" in entry.instructions_md
+    assert "test coverage progression" in entry.instructions_md
+    assert "AI tool usage is allowed" in entry.instructions_md
+    assert "Do not penalize AI usage by itself" in entry.instructions_md
+
+    assert "Project scaffolding quality - 18 points" in entry.rubric_md
+    assert "Architectural coherence - 18 points" in entry.rubric_md
+    assert "Code quality and maintainability - 17 points" in entry.rubric_md
+    assert "Testing discipline - 15 points" in entry.rubric_md
+    assert "Development process and commit history - 12 points" in entry.rubric_md
+    assert "Documentation and handoff readiness - 10 points" in entry.rubric_md
+    assert (
+        "Requirements coverage and product completeness - 10 points" in entry.rubric_md
+    )
+
+
+def test_code_implementation_reviewer_prompt_asset_has_no_legacy_terms() -> None:
+    entry = build_prompt_pack_entry("codeImplementationReviewer")
+    combined = f"{entry.instructions_md}\n{entry.rubric_md}".lower()
+
+    forbidden_terms = (
+        "precommit " + "baseline",
+        "delta from " + "precommit",
+        "Special" + "izor",
+    )
+    for forbidden in forbidden_terms:
+        assert forbidden not in combined
+
+
+def test_code_implementation_reviewer_snapshot_prompt_mentions_required_evidence_sources() -> (
+    None
+):
+    snapshot = build_ai_policy_snapshot(trial=_trial())
+    system_prompt, rubric_prompt = build_required_snapshot_prompt(
+        snapshot_json=snapshot,
+        agent_key="codeImplementationReviewer",
+        run_context_md="Candidate session ID: 101\nScenario version ID: 202",
+        scenario_version_id=202,
+    )
+
+    assert "full repository" in system_prompt
+    assert "complete commit history" in system_prompt
+    assert "file creation timeline" in system_prompt
+    assert "test coverage progression" in system_prompt
+    assert "Evidence Trail" in system_prompt
+    assert "AI tool usage is allowed" in system_prompt
+    assert "from-scratch Tech Trial" in system_prompt
+    assert "no pre-existing application code" in system_prompt
+    assert "complete repository" in system_prompt
+    assert "complete commit history" in system_prompt
+    assert "Project scaffolding quality - 18 points" in rubric_prompt
+    assert "Development process and commit history - 12 points" in rubric_prompt
+    assert "Do not penalize AI usage by itself" in system_prompt
+    assert "language or framework choice by itself" in system_prompt
+    assert "bulk generation without engineering judgment" in system_prompt

--- a/tests/evaluations/services/test_evaluations_evaluator_runner_service.py
+++ b/tests/evaluations/services/test_evaluations_evaluator_runner_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from dataclasses import fields
 from types import SimpleNamespace
 
 import pytest
@@ -7,6 +9,12 @@ import pytest
 from app.ai import AIPolicySnapshotError, build_ai_policy_snapshot
 from app.evaluations.repositories.evaluations_repositories_evaluations_core_model import (
     EVALUATION_RECOMMENDATION_NO_HIRE,
+)
+from app.evaluations.services import (
+    evaluations_services_evaluations_evaluator_runtime_service as evaluator_runtime,
+)
+from app.evaluations.services import (
+    evaluations_services_evaluations_winoe_report_pipeline_day_inputs_service as day_inputs_service,
 )
 from app.evaluations.services import evaluator
 from tests.evaluations.services.evaluations_evaluator_branch_gap_utils import day_input
@@ -152,3 +160,468 @@ async def test_live_evaluator_rejects_snapshot_contract_mismatch():
         match="scenario_version_ai_policy_snapshot_agent_contract_mismatch",
     ):
         await evaluator.get_winoe_report_evaluator().evaluate(bundle)
+
+
+def test_code_implementation_evidence_context_has_explicit_slots():
+    bundle_field_names = {
+        field.name for field in fields(evaluator.EvaluationInputBundle)
+    }
+    assert "code_implementation_evidence" in bundle_field_names
+
+    evidence = evaluator.CodeImplementationEvidenceContext(
+        repository_snapshot=None,
+        repository_url="https://github.com/acme/repo",
+        repository_reference="acme/repo",
+        commit_history=[],
+        file_creation_timeline=[],
+        test_coverage_progression=[],
+        evidence_status={
+            "repository_snapshot": "unavailable: no day 2/3 repository or submission evidence found",
+            "commit_history": "unavailable: evidence persistence not yet implemented",
+            "file_creation_timeline": "unavailable: evidence persistence not yet implemented",
+            "test_coverage_progression": "unavailable: evidence persistence not yet implemented",
+        },
+    )
+    bundle = evaluator.EvaluationInputBundle(
+        candidate_session_id=1,
+        scenario_version_id=2,
+        model_name="model-x",
+        model_version="v1",
+        prompt_version="p1",
+        rubric_version="r1",
+        disabled_day_indexes=[],
+        day_inputs=[
+            day_input(day_index=2, repo_full_name="acme/repo", commit_sha="abc")
+        ],
+        code_implementation_evidence=evidence,
+        ai_policy_snapshot_json=_snapshot(),
+    )
+
+    assert bundle.code_implementation_evidence.repository_reference == "acme/repo"
+    assert bundle.code_implementation_evidence.commit_history == []
+    assert bundle.code_implementation_evidence.file_creation_timeline == []
+    assert bundle.code_implementation_evidence.test_coverage_progression == []
+
+
+def test_missing_code_implementation_evidence_is_explicit_in_prompt_context():
+    evidence = evaluator.CodeImplementationEvidenceContext(
+        repository_snapshot=None,
+        repository_url="https://github.com/acme/repo",
+        repository_reference="acme/repo",
+        commit_history=[],
+        file_creation_timeline=[],
+        test_coverage_progression=[],
+        evidence_status={
+            "repository_snapshot": "unavailable: no day 2/3 repository or submission evidence found",
+            "commit_history": "unavailable: complete commit history not yet persisted",
+            "file_creation_timeline": "unavailable: file creation timeline artifacts not yet persisted",
+            "test_coverage_progression": "unavailable: coverage progression artifacts not yet persisted",
+        },
+    )
+    bundle = evaluator.EvaluationInputBundle(
+        candidate_session_id=1,
+        scenario_version_id=2,
+        model_name="model-x",
+        model_version="v1",
+        prompt_version="p1",
+        rubric_version="r1",
+        disabled_day_indexes=[],
+        day_inputs=[
+            day_input(day_index=2, repo_full_name="acme/repo", commit_sha="abc")
+        ],
+        code_implementation_evidence=evidence,
+        ai_policy_snapshot_json=_snapshot(),
+    )
+
+    run_context = evaluator_runtime._build_day_run_context(
+        bundle,
+        day_input(day_index=2, repo_full_name="acme/repo", commit_sha="abc"),
+    )
+    user_prompt = json.loads(
+        evaluator_runtime._build_day_review_prompt(
+            bundle=bundle,
+            day_input=day_input(
+                day_index=2, repo_full_name="acme/repo", commit_sha="abc"
+            ),
+            rubric_prompt="rubric guidance",
+        )
+    )
+
+    assert "codeImplementationEvidence" in run_context
+    assert "Do not infer process quality" in run_context
+    assert "Repository snapshot status: unavailable:" in run_context
+    assert (
+        user_prompt["reviewContext"]["codeImplementationEvidence"][
+            "repositoryReference"
+        ]
+        == "acme/repo"
+    )
+    assert (
+        user_prompt["reviewContext"]["codeImplementationEvidence"]["commitHistory"]
+        == []
+    )
+    assert user_prompt["reviewContext"]["instructions"].startswith(
+        "Use codeImplementationEvidence as primary evidence"
+    )
+
+
+def test_populated_code_implementation_evidence_serializes_into_prompt_context():
+    evidence = evaluator.CodeImplementationEvidenceContext(
+        repository_snapshot={
+            "candidateSessionId": 1,
+            "repoFullName": "acme/repo",
+            "repoUrl": "https://github.com/acme/repo",
+        },
+        repository_url="https://github.com/acme/repo",
+        repository_reference="acme/repo",
+        repository_artifact_references=[
+            {
+                "kind": "artifact_summary",
+                "artifactName": "commitMetadata",
+                "dayIndex": 2,
+                "submissionId": 10,
+                "artifactId": 11,
+            }
+        ],
+        commit_history=[
+            {
+                "sha": "commit-sha-123",
+                "message": "Add app scaffold",
+                "committedAt": "2026-03-13T10:00:00Z",
+                "authoredAt": "2026-03-13T10:00:00Z",
+                "author": "codex",
+                "filesChanged": 2,
+                "filesChangedPaths": ["README.md", "src/app.py"],
+                "additions": 120,
+                "deletions": 14,
+                "dayIndex": 2,
+                "submissionId": 10,
+                "evidenceArtifactId": 11,
+            }
+        ],
+        file_creation_timeline=[
+            {
+                "path": "README.md",
+                "createdAt": "2026-03-13T09:00:00Z",
+                "firstCommitSha": "commit-sha-123",
+                "commitMessage": "Bootstrap app",
+                "dayIndex": 2,
+                "submissionId": 10,
+                "evidenceArtifactId": 12,
+            }
+        ],
+        test_coverage_progression=[
+            {
+                "dayIndex": 2,
+                "submissionId": 10,
+                "commitSha": "commit-sha-123",
+                "workflowRunId": "9001",
+                "capturedAt": "2026-03-13T11:00:00Z",
+                "testsPassed": 7,
+                "testsFailed": 0,
+                "coveragePath": "artifacts/coverage",
+                "outputLog": "artifacts/test-results/test-output.log",
+                "command": "python -m pytest",
+                "detectedTool": "pytest",
+                "exitCode": 0,
+                "evidenceArtifactId": 15,
+            }
+        ],
+        dependency_metadata={
+            "dayIndex": 2,
+            "submissionId": 10,
+            "evidenceArtifactId": 13,
+            "detected": True,
+            "manifests": [{"path": "pyproject.toml", "kind": "python"}],
+        },
+        documentation_evolution=[
+            {
+                "dayIndex": 2,
+                "submissionId": 10,
+                "commitSha": "commit-sha-123",
+                "message": "Add app scaffold",
+                "documentationPaths": ["README.md"],
+                "evidenceArtifactId": 11,
+            }
+        ],
+        evidence_status={
+            "repository_snapshot": "available: derived from day 2/3 repository and submission evidence",
+            "commit_history": "available: derived from persisted submission.test_output summary evidenceArtifacts.commitMetadata",
+            "file_creation_timeline": "available: derived from persisted submission.test_output summary evidenceArtifacts.fileCreationTimeline",
+            "test_coverage_progression": "available: derived from persisted submission.test_output summary evidenceArtifacts.testResults and coveragePath",
+            "dependency_metadata": "available: derived from persisted submission.test_output summary evidenceArtifacts.dependencyManifests",
+            "documentation_evolution": "available: derived from commit history entries touching README or docs files",
+        },
+    )
+    bundle = evaluator.EvaluationInputBundle(
+        candidate_session_id=1,
+        scenario_version_id=2,
+        model_name="model-x",
+        model_version="v1",
+        prompt_version="p1",
+        rubric_version="r1",
+        disabled_day_indexes=[],
+        day_inputs=[
+            day_input(day_index=2, repo_full_name="acme/repo", commit_sha="abc")
+        ],
+        code_implementation_evidence=evidence,
+        ai_policy_snapshot_json=_snapshot(),
+    )
+
+    user_prompt = json.loads(
+        evaluator_runtime._build_day_review_prompt(
+            bundle=bundle,
+            day_input=day_input(
+                day_index=2, repo_full_name="acme/repo", commit_sha="abc"
+            ),
+            rubric_prompt="rubric guidance",
+        )
+    )
+
+    serialized = user_prompt["reviewContext"]["codeImplementationEvidence"]
+    assert serialized["commitHistory"]
+    assert serialized["fileCreationTimeline"]
+    assert serialized["testCoverageProgression"]
+    assert serialized["evidenceStatus"]["commit_history"].startswith("available:")
+    assert serialized["evidenceStatus"]["file_creation_timeline"].startswith(
+        "available:"
+    )
+    assert serialized["evidenceStatus"]["test_coverage_progression"].startswith(
+        "available:"
+    )
+
+
+def test_day_inputs_helpers_handle_malformed_evidence_payloads():
+    submission = SimpleNamespace(
+        id=41,
+        test_output="",
+        workflow_run_completed_at=None,
+        last_run_at=None,
+        tests_passed=None,
+        tests_failed=None,
+    )
+
+    assert day_inputs_service._load_json_object("not json") is None
+    assert day_inputs_service._load_json_object("[1, 2, 3]") is None
+    assert (
+        day_inputs_service._submission_test_summary(SimpleNamespace(test_output="   "))
+        is None
+    )
+    assert day_inputs_service._submission_test_summary(
+        SimpleNamespace(test_output='{"summary": 1}')
+    ) == {"summary": 1}
+    assert (
+        day_inputs_service._summary_evidence_artifacts(
+            SimpleNamespace(test_output='{"summary": {"evidenceArtifacts": []}}')
+        )
+        is None
+    )
+    assert (
+        day_inputs_service._summary_without_evidence(
+            SimpleNamespace(
+                test_output='{"summary": {"evidenceArtifacts": {"commitMetadata": {}}}}'
+            )
+        )
+        is None
+    )
+    assert day_inputs_service._load_json_object({}) == {}
+    assert day_inputs_service._artifact_payload(None, "commitMetadata") == (None, None)
+    assert day_inputs_service._artifact_payload(
+        {"commitMetadata": "bad"}, "commitMetadata"
+    ) == (None, None)
+    assert day_inputs_service._artifact_payload(
+        {"commitMetadata": {"data": []}}, "commitMetadata"
+    ) == ({"data": []}, None)
+    assert day_inputs_service._string_list([1, " README.md ", "", None]) == [
+        "README.md"
+    ]
+
+    evidence_artifacts = {
+        "commitMetadata": {
+            "artifactId": 11,
+            "data": {
+                "payload": {
+                    "commits": [
+                        {"sha": "", "files_changed": ["README.md"]},
+                        "bad-entry",
+                        {
+                            "sha": "commit-sha-abc",
+                            "timestamp": "2026-03-13T10:00:00Z",
+                            "message": "Add scaffold",
+                            "files_changed": "README.md",
+                            "files_changed_count": 5,
+                        },
+                    ]
+                }
+            },
+        },
+        "fileCreationTimeline": {
+            "artifactId": 12,
+            "data": {
+                "payload": {
+                    "files": [
+                        {"timestamp": "2026-03-13T09:00:00Z", "files": "README.md"},
+                        {
+                            "timestamp": "2026-03-13T09:30:00Z",
+                            "commit_sha": "commit-sha-abc",
+                            "message": "Bootstrap app",
+                            "files": ["README.md", "", "src/app.py"],
+                        },
+                    ]
+                }
+            },
+        },
+        "dependencyManifests": {
+            "artifactId": 13,
+            "data": {"payload": {"detected": True, "manifests": "invalid"}},
+        },
+        "testResults": {
+            "artifactId": 14,
+            "data": {
+                "payload": {
+                    "summary": {"outputLog": "artifacts/test-results/test-output.log"}
+                }
+            },
+        },
+    }
+
+    commit_history = day_inputs_service._commit_history_from_submission(
+        submission=submission,
+        day_index=2,
+        evidence_artifacts=evidence_artifacts,
+    )
+    assert len(commit_history) == 1
+    assert commit_history[0]["sha"] == "commit-sha-abc"
+    assert commit_history[0]["filesChanged"] == 5
+    assert commit_history[0]["filesChangedPaths"] == []
+
+    file_creation_timeline = day_inputs_service._file_creation_timeline_from_submission(
+        submission=submission,
+        day_index=2,
+        evidence_artifacts=evidence_artifacts,
+    )
+    assert len(file_creation_timeline) == 2
+    assert file_creation_timeline[0]["path"] == "README.md"
+    assert file_creation_timeline[1]["path"] == "src/app.py"
+
+    assert (
+        day_inputs_service._dependency_metadata_from_submission(
+            day_index=2,
+            submission=submission,
+            evidence_artifacts=evidence_artifacts,
+        )
+        is None
+    )
+    assert (
+        day_inputs_service._commit_history_from_submission(
+            submission=submission,
+            day_index=2,
+            evidence_artifacts=None,
+        )
+        == []
+    )
+    assert (
+        day_inputs_service._commit_history_from_submission(
+            submission=submission,
+            day_index=2,
+            evidence_artifacts={
+                "commitMetadata": {"data": {"payload": {"commits": {}}}}
+            },
+        )
+        == []
+    )
+    assert (
+        day_inputs_service._file_creation_timeline_from_submission(
+            submission=submission,
+            day_index=2,
+            evidence_artifacts=None,
+        )
+        == []
+    )
+    assert (
+        day_inputs_service._file_creation_timeline_from_submission(
+            submission=submission,
+            day_index=2,
+            evidence_artifacts={
+                "fileCreationTimeline": {"data": {"payload": {"files": {}}}}
+            },
+        )
+        == []
+    )
+    assert (
+        day_inputs_service._repository_snapshot_status(
+            repository_reference=None,
+            day_submission_refs=[{"dayIndex": 2}],
+            commit_history=[],
+            file_creation_timeline=[],
+            test_coverage_progression=[],
+            dependency_metadata=None,
+            documentation_evolution=[],
+        )
+        == "partial: day 2/3 submission evidence available; repository reference not resolved and persisted repository snapshot artifacts not found"
+    )
+    assert (
+        day_inputs_service._test_coverage_progression_from_submission(
+            day_index=2,
+            submission=submission,
+            evidence_artifacts=None,
+        )
+        == []
+    )
+    assert (
+        day_inputs_service._test_coverage_progression_from_submission(
+            day_index=2,
+            submission=submission,
+            evidence_artifacts=evidence_artifacts,
+        )
+        == []
+    )
+    assert (
+        day_inputs_service._documentation_evolution_from_commit_history(
+            [{"filesChangedPaths": "README.md"}]
+        )
+        == []
+    )
+
+    documentation = day_inputs_service._documentation_evolution_from_commit_history(
+        [
+            {
+                "dayIndex": 2,
+                "submissionId": 41,
+                "sha": "commit-sha-abc",
+                "message": "Docs update",
+                "filesChangedPaths": ["README.md", "docs/guide.md", "src/app.py"],
+            }
+        ]
+    )
+    assert documentation[0]["documentationPaths"] == [
+        "README.md",
+        "docs/guide.md",
+    ]
+
+
+def test_repository_snapshot_status_distinguishes_repo_reference_from_full_evidence():
+    assert (
+        day_inputs_service._repository_snapshot_status(
+            repository_reference="acme/repo",
+            day_submission_refs=[{"dayIndex": 2}],
+            commit_history=[],
+            file_creation_timeline=[],
+            test_coverage_progression=[],
+            dependency_metadata=None,
+            documentation_evolution=[],
+        )
+        == "partial: repository reference available; persisted repository snapshot artifacts not found for day 2/3 evidence"
+    )
+    assert (
+        day_inputs_service._repository_snapshot_status(
+            repository_reference=None,
+            day_submission_refs=[],
+            commit_history=[],
+            file_creation_timeline=[],
+            test_coverage_progression=[],
+            dependency_metadata=None,
+            documentation_evolution=[],
+        )
+        == "unavailable: no day 2/3 repository or submission evidence found"
+    )

--- a/tests/evaluations/services/test_evaluations_winoe_report_pipeline_execute_enqueues_ready_notification_service.py
+++ b/tests/evaluations/services/test_evaluations_winoe_report_pipeline_execute_enqueues_ready_notification_service.py
@@ -79,7 +79,7 @@ async def test_evaluate_and_finalize_run_enqueues_winoe_report_ready_notificatio
 
 
 @pytest.mark.asyncio
-async def test_evaluate_and_finalize_run_rejects_hollow_day_scores():
+async def test_evaluate_and_finalize_run_rejects_non_object_day_scores():
     db = SimpleNamespace(commit=AsyncMock())
     evaluator = SimpleNamespace(
         evaluate=AsyncMock(
@@ -88,7 +88,7 @@ async def test_evaluate_and_finalize_run_rejects_hollow_day_scores():
                     SimpleNamespace(
                         day_index=1,
                         score=0.8,
-                        rubric_breakdown={},
+                        rubric_breakdown="not-an-object",
                         evidence=[{"kind": "submission", "ref": "day-1"}],
                     )
                 ],
@@ -100,7 +100,7 @@ async def test_evaluate_and_finalize_run_rejects_hollow_day_scores():
         )
     )
 
-    with pytest.raises(ValueError, match="rubric_breakdown must be a non-empty object"):
+    with pytest.raises(ValueError, match="rubric_breakdown must be an object"):
         await execute_service._evaluate_and_finalize_run(
             db=db,
             run=SimpleNamespace(id=7),
@@ -113,3 +113,69 @@ async def test_evaluate_and_finalize_run_rejects_hollow_day_scores():
             ),
             run_metadata={"source": "test"},
         )
+
+
+@pytest.mark.asyncio
+async def test_evaluate_and_finalize_run_allows_empty_evidence_lists(
+    monkeypatch,
+):
+    db = SimpleNamespace(commit=AsyncMock())
+    completed_run = SimpleNamespace(generated_at=datetime.now(UTC))
+    complete_run = AsyncMock(return_value=completed_run)
+    upsert_marker = AsyncMock()
+    enqueue_notification = AsyncMock()
+    evaluator = SimpleNamespace(
+        evaluate=AsyncMock(
+            return_value=SimpleNamespace(
+                day_results=[
+                    SimpleNamespace(
+                        day_index=1,
+                        score=0.8,
+                        rubric_breakdown={"communication": 0.8},
+                        evidence=[],
+                    )
+                ],
+                overall_winoe_score=0.82,
+                recommendation="hire",
+                confidence=0.91,
+                report_json={"summary": "ready"},
+            )
+        )
+    )
+    monkeypatch.setattr(
+        execute_service.notification_service,
+        "enqueue_winoe_report_ready_notification",
+        enqueue_notification,
+    )
+
+    result = await execute_service._evaluate_and_finalize_run(
+        db=db,
+        run=SimpleNamespace(id=7),
+        evaluator=evaluator,
+        bundle=SimpleNamespace(),
+        evaluation_runs=SimpleNamespace(complete_run=complete_run),
+        winoe_report_repository=SimpleNamespace(upsert_marker=upsert_marker),
+        context=SimpleNamespace(
+            candidate_session=SimpleNamespace(id=123, trial_id=456)
+        ),
+        run_metadata={"source": "test"},
+    )
+
+    assert result is completed_run
+    complete_run.assert_awaited_once()
+    assert complete_run.await_args.kwargs["day_scores"] == [
+        {
+            "day_index": 1,
+            "score": 0.8,
+            "rubric_results_json": {"communication": 0.8},
+            "evidence_pointers_json": [],
+        }
+    ]
+    enqueue_notification.assert_awaited_once_with(
+        db,
+        candidate_session_id=123,
+        trial_id=456,
+        commit=False,
+    )
+    upsert_marker.assert_awaited_once()
+    db.commit.assert_awaited_once()

--- a/tests/evaluations/services/test_evaluations_winoe_report_pipeline_rubric_snapshots_service.py
+++ b/tests/evaluations/services/test_evaluations_winoe_report_pipeline_rubric_snapshots_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
@@ -34,6 +35,7 @@ from tests.evaluations.services.evaluations_winoe_report_pipeline_utils import (
 )
 from tests.shared.factories import (
     create_candidate_session,
+    create_submission,
     create_talent_partner,
     create_trial,
 )
@@ -136,6 +138,21 @@ async def test_process_evaluation_run_job_uses_persisted_rubric_snapshots(
     assert result["status"] == "completed"
     bundle = captured["bundle"]
     assert bundle is not None
+    assert hasattr(bundle, "code_implementation_evidence")
+    assert bundle.code_implementation_evidence.repository_snapshot is not None
+    assert (
+        bundle.code_implementation_evidence.repository_snapshot["repoFullName"] is None
+    )
+    assert (
+        bundle.code_implementation_evidence.repository_snapshot["daySubmissionRefs"]
+        == []
+    )
+    assert bundle.code_implementation_evidence.evidence_status[
+        "repository_snapshot"
+    ].startswith("unavailable:")
+    assert bundle.code_implementation_evidence.evidence_status[
+        "commit_history"
+    ].startswith("unavailable:")
     assert (
         bundle.ai_policy_snapshot_json["agents"]["designDocReviewer"][
             "resolvedRubricMd"
@@ -156,6 +173,385 @@ async def test_process_evaluation_run_job_uses_persisted_rubric_snapshots(
     assert {
         item["snapshotId"] for item in captured["run_metadata"]["rubricSnapshots"]
     } == {item["snapshotId"] for item in materialized["rubricSnapshots"]}
+    assert bundle.code_implementation_evidence.commit_history == []
+    assert bundle.code_implementation_evidence.file_creation_timeline == []
+    assert bundle.code_implementation_evidence.test_coverage_progression == []
+    assert bundle.code_implementation_evidence.evidence_status[
+        "commit_history"
+    ].startswith("unavailable:")
+
+
+@pytest.mark.asyncio
+async def test_process_evaluation_run_job_records_repository_evidence_when_present(
+    monkeypatch, async_session
+):
+    talent_partner = await create_talent_partner(
+        async_session, email="pipeline-repo@test.com"
+    )
+    trial, _tasks = await create_trial(async_session, created_by=talent_partner)
+    candidate_session = await create_candidate_session(async_session, trial=trial)
+    scenario_version = await async_session.scalar(
+        select(ScenarioVersion).where(
+            ScenarioVersion.id == candidate_session.scenario_version_id
+        )
+    )
+    assert scenario_version is not None
+
+    await rubric_service.materialize_scenario_version_rubric_snapshots(
+        async_session, scenario_version=scenario_version, trial=trial
+    )
+
+    monkeypatch.setattr(
+        rubric_service,
+        "_read_text_file",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("pipeline should not reread rubric source files")
+        ),
+    )
+
+    fake_submission = await create_submission(
+        async_session,
+        candidate_session=candidate_session,
+        task=next(task for task in _tasks if task.day_index == 2),
+        content_text="submission content",
+        content_json={},
+        code_repo_path="acme/repo",
+        commit_sha="commit-sha-123",
+        workflow_run_id="9001",
+        workflow_run_status="completed",
+        workflow_run_conclusion="success",
+        tests_passed=7,
+        tests_failed=0,
+        test_output=json.dumps(
+            {
+                "status": "passed",
+                "runId": 9001,
+                "conclusion": "success",
+                "passed": 7,
+                "failed": 0,
+                "total": 7,
+                "stdout": "ok",
+                "stderr": "",
+                "summary": {
+                    "detectedTool": "pytest",
+                    "command": "python -m pytest",
+                    "coveragePath": "artifacts/coverage",
+                    "outputLog": "artifacts/test-results/test-output.log",
+                    "evidenceArtifacts": {
+                        "commitMetadata": {
+                            "artifactName": "winoe-commit-metadata",
+                            "artifactId": 11,
+                            "data": {
+                                "payload": {
+                                    "commits": [
+                                        {
+                                            "sha": "commit-sha-123",
+                                            "timestamp": "2026-03-13T10:00:00Z",
+                                            "message": "Add app scaffold",
+                                            "files_changed": [
+                                                "README.md",
+                                                "src/app.py",
+                                            ],
+                                            "files_changed_count": 2,
+                                            "insertions": 120,
+                                            "deletions": 14,
+                                        }
+                                    ]
+                                }
+                            },
+                        },
+                        "fileCreationTimeline": {
+                            "artifactName": "winoe-file-creation-timeline",
+                            "artifactId": 12,
+                            "data": {
+                                "payload": {
+                                    "files": [
+                                        {
+                                            "commit_sha": "commit-sha-123",
+                                            "timestamp": "2026-03-13T09:00:00Z",
+                                            "message": "Bootstrap app",
+                                            "files": ["README.md", "src/app.py"],
+                                        }
+                                    ]
+                                }
+                            },
+                        },
+                        "dependencyManifests": {
+                            "artifactName": "winoe-dependency-manifests",
+                            "artifactId": 13,
+                            "data": {
+                                "payload": {
+                                    "detected": True,
+                                    "manifests": [
+                                        {
+                                            "path": "pyproject.toml",
+                                            "kind": "python",
+                                            "test_command": "python -m pytest",
+                                        }
+                                    ],
+                                }
+                            },
+                        },
+                        "repoTreeSummary": {
+                            "artifactName": "winoe-repo-tree-summary",
+                            "artifactId": 14,
+                            "data": {
+                                "payload": {
+                                    "files": ["README.md", "src/app.py"],
+                                    "file_count": 2,
+                                }
+                            },
+                        },
+                        "testResults": {
+                            "artifactName": "winoe-test-results",
+                            "artifactId": 15,
+                            "data": {
+                                "payload": {
+                                    "passed": 7,
+                                    "failed": 0,
+                                    "total": 7,
+                                    "summary": {
+                                        "coveragePath": "artifacts/coverage",
+                                        "outputLog": "artifacts/test-results/test-output.log",
+                                    },
+                                }
+                            },
+                        },
+                    },
+                },
+            }
+        ),
+    )
+    fake_day_audit = SimpleNamespace(
+        cutoff_commit_sha="cutoff-sha-123",
+        eval_basis_ref=None,
+    )
+
+    captured: dict[str, object] = {}
+
+    async def fake_get_or_start_run(**_kwargs):
+        return (
+            SimpleNamespace(
+                id=9002,
+                basis_fingerprint="basis-9002",
+                model_version="2026-03-12",
+                prompt_version="winoe-report-v1",
+                rubric_version="rubric-v1",
+            ),
+            None,
+        )
+
+    async def fake_evaluate_and_finalize_run(**kwargs):
+        captured["bundle"] = kwargs["bundle"]
+        return SimpleNamespace(
+            id=9002,
+            basis_fingerprint="basis-9002",
+            model_version=kwargs["bundle"].model_version,
+            prompt_version=kwargs["bundle"].prompt_version,
+            rubric_version=kwargs["bundle"].rubric_version,
+        )
+
+    monkeypatch.setattr(runner_service, "_get_or_start_run", fake_get_or_start_run)
+    monkeypatch.setattr(
+        runner_service, "_evaluate_and_finalize_run", fake_evaluate_and_finalize_run
+    )
+    evaluator_service = SimpleNamespace(
+        EvaluationInputBundle=EvaluationInputBundle,
+        get_winoe_report_evaluator=lambda: object(),
+    )
+
+    deps = dict(
+        async_session_maker=_session_maker_for(async_session),
+        get_candidate_session_evaluation_context=get_candidate_session_evaluation_context,
+        has_company_access=has_company_access,
+        _tasks_by_day=AsyncMock(return_value={}),
+        _submissions_by_day=AsyncMock(return_value={2: fake_submission}),
+        _day_audits_by_day=AsyncMock(return_value={2: fake_day_audit}),
+        _resolve_day4_transcript=AsyncMock(return_value=(None, "transcript:missing")),
+        evaluation_repo=SimpleNamespace(),
+        evaluation_runs=SimpleNamespace(),
+        winoe_report_repository=SimpleNamespace(),
+        evaluator_service=evaluator_service,
+        logger=SimpleNamespace(
+            info=lambda *args, **kwargs: None, warning=lambda *args, **kwargs: None
+        ),
+    )
+    result = await runner_service.process_evaluation_run_job_impl(
+        {
+            "candidateSessionId": candidate_session.id,
+            "companyId": trial.company_id,
+            "requestedByUserId": talent_partner.id,
+            "basisFingerprint": "ignored",
+        },
+        **deps,
+    )
+
+    assert result["status"] == "completed"
+    bundle = captured["bundle"]
+    assert bundle is not None
+    assert bundle.code_implementation_evidence.repository_reference == "acme/repo"
+    assert bundle.code_implementation_evidence.repository_url == (
+        "https://github.com/acme/repo"
+    )
+    assert bundle.code_implementation_evidence.repository_snapshot is not None
+    assert (
+        bundle.code_implementation_evidence.repository_snapshot["repoFullName"]
+        == "acme/repo"
+    )
+    assert bundle.code_implementation_evidence.repository_snapshot["daySubmissionRefs"]
+    assert bundle.code_implementation_evidence.evidence_status[
+        "repository_snapshot"
+    ].startswith("available:")
+    assert bundle.code_implementation_evidence.commit_history
+    assert bundle.code_implementation_evidence.file_creation_timeline
+    assert bundle.code_implementation_evidence.test_coverage_progression
+    assert bundle.code_implementation_evidence.evidence_status[
+        "commit_history"
+    ].startswith("available:")
+    assert bundle.code_implementation_evidence.evidence_status[
+        "file_creation_timeline"
+    ].startswith("available:")
+    assert bundle.code_implementation_evidence.evidence_status[
+        "test_coverage_progression"
+    ].startswith("available:")
+    assert (
+        bundle.code_implementation_evidence.commit_history[0]["sha"] == "commit-sha-123"
+    )
+    assert (
+        bundle.code_implementation_evidence.file_creation_timeline[0]["path"]
+        == "README.md"
+    )
+    assert (
+        bundle.code_implementation_evidence.test_coverage_progression[0]["coveragePath"]
+        == "artifacts/coverage"
+    )
+
+
+@pytest.mark.asyncio
+async def test_process_evaluation_run_job_marks_repo_reference_only_as_partial(
+    monkeypatch, async_session
+):
+    talent_partner = await create_talent_partner(
+        async_session, email="pipeline-partial@test.com"
+    )
+    trial, tasks = await create_trial(async_session, created_by=talent_partner)
+    candidate_session = await create_candidate_session(async_session, trial=trial)
+    scenario_version = await async_session.scalar(
+        select(ScenarioVersion).where(
+            ScenarioVersion.id == candidate_session.scenario_version_id
+        )
+    )
+    assert scenario_version is not None
+
+    await rubric_service.materialize_scenario_version_rubric_snapshots(
+        async_session, scenario_version=scenario_version, trial=trial
+    )
+
+    monkeypatch.setattr(
+        rubric_service,
+        "_read_text_file",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            AssertionError("pipeline should not reread rubric source files")
+        ),
+    )
+
+    fake_submission = await create_submission(
+        async_session,
+        candidate_session=candidate_session,
+        task=next(task for task in tasks if task.day_index == 2),
+        content_text="submission content",
+        content_json={},
+        code_repo_path="acme/repo",
+        commit_sha="commit-sha-456",
+        workflow_run_id="9003",
+        workflow_run_status="completed",
+        workflow_run_conclusion="success",
+        tests_passed=0,
+        tests_failed=0,
+        test_output=json.dumps({"summary": {}}),
+    )
+
+    captured: dict[str, object] = {}
+
+    async def fake_get_or_start_run(**_kwargs):
+        return (
+            SimpleNamespace(
+                id=9003,
+                basis_fingerprint="basis-9003",
+                model_version="2026-03-12",
+                prompt_version="winoe-report-v1",
+                rubric_version="rubric-v1",
+            ),
+            None,
+        )
+
+    async def fake_evaluate_and_finalize_run(**kwargs):
+        captured["bundle"] = kwargs["bundle"]
+        return SimpleNamespace(
+            id=9003,
+            basis_fingerprint="basis-9003",
+            model_version=kwargs["bundle"].model_version,
+            prompt_version=kwargs["bundle"].prompt_version,
+            rubric_version=kwargs["bundle"].rubric_version,
+        )
+
+    monkeypatch.setattr(runner_service, "_get_or_start_run", fake_get_or_start_run)
+    monkeypatch.setattr(
+        runner_service, "_evaluate_and_finalize_run", fake_evaluate_and_finalize_run
+    )
+    evaluator_service = SimpleNamespace(
+        EvaluationInputBundle=EvaluationInputBundle,
+        get_winoe_report_evaluator=lambda: object(),
+    )
+
+    fake_day_audit = SimpleNamespace(
+        cutoff_commit_sha="cutoff-sha-456",
+        eval_basis_ref=None,
+    )
+
+    deps = dict(
+        async_session_maker=_session_maker_for(async_session),
+        get_candidate_session_evaluation_context=get_candidate_session_evaluation_context,
+        has_company_access=has_company_access,
+        _tasks_by_day=AsyncMock(return_value={}),
+        _submissions_by_day=AsyncMock(return_value={2: fake_submission}),
+        _day_audits_by_day=AsyncMock(return_value={2: fake_day_audit}),
+        _resolve_day4_transcript=AsyncMock(return_value=(None, "transcript:missing")),
+        evaluation_repo=SimpleNamespace(),
+        evaluation_runs=SimpleNamespace(),
+        winoe_report_repository=SimpleNamespace(),
+        evaluator_service=evaluator_service,
+        logger=SimpleNamespace(
+            info=lambda *args, **kwargs: None, warning=lambda *args, **kwargs: None
+        ),
+    )
+
+    result = await runner_service.process_evaluation_run_job_impl(
+        {
+            "candidateSessionId": candidate_session.id,
+            "companyId": trial.company_id,
+            "requestedByUserId": talent_partner.id,
+            "basisFingerprint": "ignored",
+        },
+        **deps,
+    )
+
+    assert result["status"] == "completed"
+    bundle = captured["bundle"]
+    assert bundle is not None
+    assert bundle.code_implementation_evidence.repository_snapshot is not None
+    assert bundle.code_implementation_evidence.repository_snapshot["repoFullName"] == (
+        "acme/repo"
+    )
+    assert bundle.code_implementation_evidence.evidence_status[
+        "repository_snapshot"
+    ].startswith("partial:")
+    assert bundle.code_implementation_evidence.commit_history == []
+    assert bundle.code_implementation_evidence.file_creation_timeline == []
+    assert bundle.code_implementation_evidence.test_coverage_progression == []
+    assert bundle.code_implementation_evidence.evidence_status[
+        "commit_history"
+    ].startswith("unavailable:")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
# PR: Update Day 2/3 Code Implementation Reviewer for from-scratch evaluation

## Summary

This PR updates the Day 2/3 Code Implementation Reviewer path for the v4 from-scratch Tech Trial model. The reviewer now evaluates the candidate’s complete repository and development process instead of treating Days 2/3 as a diff against pre-existing code.

The Day 2/3 rubric now scores from-scratch implementation work across project scaffolding, architecture, code quality, testing discipline, development process, documentation/handoff readiness, and requirements coverage. The reviewer prompt now receives structured repository/process evidence, including populated commit history, file creation timeline, and test coverage progression when persisted evidence exists.

## What changed

- Rewrote `app/ai/prompt_assets/v1/winoe-day-2&3-rubric.md` for from-scratch Tech Trial evaluation.
- Added scored rubric dimensions:
  - Project scaffolding quality — 18 points
  - Architectural coherence — 18 points
  - Code quality and maintainability — 17 points
  - Testing discipline — 15 points
  - Development process and commit history — 12 points
  - Documentation and handoff readiness — 10 points
  - Requirements coverage and product completeness — 10 points
- Added explicit rubric guidance that:
  - the complete repository is the candidate’s work
  - there is no pre-existing application code to compare against
  - evaluation is tech-stack-agnostic
  - AI coding assistants are allowed and not penalized by themselves
  - AI-bulk-generation concerns must be evidence-backed
- Added `CodeImplementationEvidenceContext` to the evaluator input bundle.
- Threaded `reviewContext.codeImplementationEvidence` into the live Day 2/3 reviewer payload.
- Integrated with the #296 artifact-parse path through persisted `Submission.test_output` evidence artifacts.
- Populated reviewer evidence from persisted Day 2/3 artifacts:
  - repository snapshot/reference
  - commit history
  - file creation timeline
  - test coverage progression
  - dependency metadata
  - documentation evolution
- Added honest evidence-status semantics:
  - `available:` when persisted evidence exists
  - `partial:` when repo identity exists but deeper snapshot artifacts are missing
  - `unavailable:` when evidence is truly absent
- Fixed report finalization validation so provider results with empty evidence arrays do not dead-letter the full evaluation run when scores and rubric breakdown are valid.
- Added regression tests for rubric content, prompt rendering, evidence serialization, malformed evidence parsing, repository status semantics, and real route/worker completion behavior.

## #296 integration

#296 has landed, so this PR now fully wires #318 into the persisted evidence path instead of leaving evidence fields as prompt-only expectations.

The Day 2/3 evidence builder hydrates `CodeImplementationEvidenceContext` from persisted submission evidence produced by the GitHub workflow artifact parse path:

- `submission.test_output.summary.evidenceArtifacts.commitMetadata` → `commitHistory`
- `submission.test_output.summary.evidenceArtifacts.fileCreationTimeline` → `fileCreationTimeline`
- `submission.test_output.summary.testResults` + `coveragePath` → `testCoverageProgression`
- `submission.test_output.summary.evidenceArtifacts.dependencyManifests` → `dependencyMetadata`
- commit entries touching `README` or `docs/` paths → `documentationEvolution`

This means the Code Implementation Reviewer now receives actual populated Day 2/3 repository/process evidence when it exists, not just empty placeholder fields.

## Evidence semantics

The evidence contract is intentionally conservative:

- If persisted evidence exists, the reviewer payload marks the field `available:`.
- If only repository identity exists, repository snapshot status is `partial:`.
- If evidence is missing, the field remains empty and status is explicit `unavailable:`.
- The reviewer prompt instructs the model not to infer process quality when commit history, file creation timeline, or test coverage progression are unavailable.

This preserves Winoe AI’s evidence-first trust bar and prevents overclaiming.

## Acceptance criteria

- [x] `winoe-day-2&3-rubric.md` updated with from-scratch evaluation dimensions.
- [x] No references to `precommit baseline`, `delta from precommit`, or `Specializor` in the Day 2/3 rubric.
- [x] Project scaffolding quality is a scored dimension weighted 18 points.
- [x] Development process / commit history analysis is a scored dimension weighted 12 points.
- [x] Rubric is tech-stack-agnostic and does not penalize framework/language choice by itself.
- [x] Rubric explicitly states AI tool usage is allowed and not penalized by itself.
- [x] Rubric notes bulk AI generation without engineering judgment only when evidence supports it.
- [x] Code Implementation Reviewer Sub-Agent prompt path uses the updated from-scratch rubric.
- [x] Reviewer receives structured full repository/process evidence.
- [x] Reviewer receives populated commit history, file creation timeline, and test coverage progression when persisted #296 evidence exists.
- [x] Missing/partial evidence is marked honestly and does not cause the reviewer to overclaim.

## QA evidence

### Focused tests

Passed:

```bash
poetry run pytest --no-cov -q tests/evaluations/services/test_evaluations_evaluator_runner_service.py tests/evaluations/services/test_evaluations_winoe_report_pipeline_rubric_snapshots_service.py tests/ai/test_ai_prompt_pack_code_implementation_reviewer_service.py
```

Passed:

```bash
poetry run pytest --no-cov -q tests/evaluations/routes/test_evaluations_winoe_report_api_worker_completion_returns_ready_and_evidence_routes.py
```

Passed:

```bash
poetry run pytest --no-cov -q tests/ai/test_ai_prompt_pack_soul_service.py tests/ai/test_ai_prompt_pack_code_implementation_reviewer_service.py tests/evaluations/services/test_evaluations_winoe_rubric_snapshots_service.py
```

### Full test suite

Passed:

```bash
poetry run pytest -q
```

Result:

```text
1876 passed, 13 warnings
Required test coverage of 96% reached.
Total coverage: 96.03%
```

### Compile check

Passed:

```bash
poetry run python -m compileall app/evaluations/services/evaluations_services_evaluations_winoe_report_pipeline_day_inputs_service.py tests/evaluations/services/test_evaluations_winoe_report_pipeline_rubric_snapshots_service.py tests/evaluations/services/test_evaluations_evaluator_runner_service.py
```

### Terminology checks

Passed:

```bash
rg -n "precommit baseline|delta from precommit|Specializor" app/ai/prompt_assets/v1/winoe-day-2\&3-rubric.md tests/ai/test_ai_prompt_pack_code_implementation_reviewer_service.py
```

Passed:

```bash
rg -n "template catalog|Fit Profile|Fit Score|simulation|recruiter|Tenon" app/ai/prompt_assets/v1/winoe-day-2\&3-rubric.md
```

### Pre-commit

`pre-commit` was unavailable in the local environment, so it was not claimed as a pass.

## Real end-to-end runtime QA

Real local backend + worker QA passed.

* Backend PID: `22463`
* Worker PID: `22959`
* Health check:

```bash
curl -sS http://127.0.0.1:8000/health
```

Response:

```json
{"status":"ok"}
```

Triggered Winoe Report generation through the real API:

```bash
curl -sS -X POST http://127.0.0.1:8000/api/candidate_sessions/6/winoe_report/generate \
  -H 'x-dev-user-email: winoe-report-qa-iteration8b@test.com'
```

Response:

```json
{"jobId":"053c8a38-93b6-4ba9-bd26-d3f941ffaf0d","status":"queued"}
```

Final report fetch:

```bash
curl -sS http://127.0.0.1:8000/api/candidate_sessions/6/winoe_report \
  -H 'x-dev-user-email: winoe-report-qa-iteration8b@test.com'
```

Result:

* report status: `ready`
* evaluation run ID: `4`
* evaluation run status: `completed`
* job ID: `053c8a38-93b6-4ba9-bd26-d3f941ffaf0d`
* report score: `0.5759`

## Runtime payload proof

For the populated Day 2/3 evidence case, the live reviewer payload included:

```json
{
  "dayIndex": 2,
  "reviewContext": {
    "instructions": "Use codeImplementationEvidence as primary evidence for Days 2 and 3. If commit history, file creation timeline, or test coverage progression are unavailable, say so explicitly and do not infer process quality.",
    "codeImplementationEvidence": {
      "repositoryReference": "winoe-ai/report-qa-repo",
      "commitHistoryCount": 4,
      "fileCreationTimelineCount": 8,
      "testCoverageProgressionCount": 2,
      "evidenceStatus": {
        "repository_snapshot": "available: derived from day 2/3 repository and submission evidence",
        "commit_history": "available: derived from persisted submission.test_output summary evidenceArtifacts.commitMetadata",
        "file_creation_timeline": "available: derived from persisted submission.test_output summary evidenceArtifacts.fileCreationTimeline",
        "test_coverage_progression": "available: derived from persisted submission.test_output summary evidenceArtifacts.testResults and coveragePath"
      }
    }
  }
}
```

For the repository-reference-only case, the payload correctly distinguishes partial evidence:

```json
{
  "candidateSessionId": 7,
  "repositoryReference": "winoe-ai/partial-repo",
  "repositorySnapshotStatus": "partial: repository reference available; persisted repository snapshot artifacts not found for day 2/3 evidence",
  "commitHistoryCount": 0,
  "fileCreationTimelineCount": 0,
  "testCoverageProgressionCount": 0,
  "commitHistoryStatus": "unavailable: persisted submission.test_output summary evidenceArtifacts.commitMetadata not found for day 2/3 evidence",
  "fileCreationTimelineStatus": "unavailable: persisted submission.test_output summary evidenceArtifacts.fileCreationTimeline not found for day 2/3 evidence",
  "testCoverageProgressionStatus": "unavailable: persisted submission.test_output summary evidenceArtifacts.testResults coveragePath not found for day 2/3 evidence"
}
```

## Notes / risks

* Local QA used deterministic test runtime snapshots to exercise the full backend + worker path without external LLM flakiness.
* Evidence parsing now uses persisted `Submission.test_output` artifact summaries as the current #296-backed source of truth.
* If a future evidence persistence schema introduces dedicated artifact tables for commit/file/coverage data, this builder should get a small adapter layer, not a redesign.

Fixes #318