### PR TITLE
Normalize Candidate Trial routes and storage keys to Winoe terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 # Winoe Backend
 
-FastAPI + PostgreSQL backend for Winoe's async trial platform. Talent Partners create and manage trials, candidates complete session tasks, and GitHub-native workflows capture code/debug execution artifacts for talent_partner review.
+FastAPI + PostgreSQL backend for Winoe's async trial platform. Talent Partners create and manage Trials, candidates complete Candidate Trial tasks, and GitHub-native workflows capture code/debug execution artifacts for Talent Partner review.
 
 ## Overview
 
-- Domain modules: trials, candidate sessions, tasks, submissions, evaluations, media, notifications, talent_partners/admin, and shared runtime infrastructure.
+- Domain modules: Trials, Candidate Trials, tasks, submissions, evaluations, media, notifications, talent_partners/admin, and shared runtime infrastructure.
 - GitHub-native flow: empty-repo workspace provisioning, Codespaces init/status, Actions evidence capture, artifact parsing, and persisted run/test metadata.
 - Auth model: bearer-token principal model with talent_partner/candidate permission gates, plus admin key and demo admin dependency paths.
-- Current API surface: 57 HTTP endpoints (generated from live OpenAPI).
+- Current API surface: 62 HTTP endpoints (generated from live OpenAPI).
 
 ## Stack (Poetry Constraints)
 
@@ -157,8 +157,8 @@ Canonical env keys are summarized below by primary group.
 
 ### Admin Templates / Demo Admin Ops
 
-- `POST /api/admin/candidate_sessions/{candidate_session_id}/day_windows/control`
-- `POST /api/admin/candidate_sessions/{candidate_session_id}/reset`
+- `POST /api/admin/candidate_trials/{candidate_trial_id}/day_windows/control`
+- `POST /api/admin/candidate_trials/{candidate_trial_id}/reset`
 - `POST /api/admin/jobs/{job_id}/requeue`
 - `POST /api/admin/trials/{trial_id}/scenario/use_fallback`
 - `POST /api/admin/media/purge`
@@ -181,18 +181,31 @@ Canonical env keys are summarized below by primary group.
 - `PATCH /api/trials/{trial_id}/scenario/{scenario_version_id}`
 - `GET /api/submissions`
 - `GET /api/submissions/{submission_id}`
-- `GET /api/candidate_sessions/{candidate_session_id}/winoe_report`
-- `POST /api/candidate_sessions/{candidate_session_id}/winoe_report/generate`
+- `GET /api/candidate_trials/{candidate_trial_id}/winoe_report`
+- `POST /api/candidate_trials/{candidate_trial_id}/winoe_report/generate`
 
-### Candidate Session APIs
+### Candidate Trial APIs
 
+- `GET /api/candidate/trials/{token}`
+- `POST /api/candidate/trials/{token}/claim`
+- `POST /api/candidate/trials/{token}/schedule`
+- `GET /api/candidate/trials/{token}/review`
+- `GET /api/candidate/trials/{candidate_trial_id}/current_task`
+- `GET /api/candidate/invites`
+- `POST /api/candidate/trials/{candidate_trial_id}/privacy/consent`
+
+### Deprecated Candidate Trial Compatibility APIs
+
+- `POST /api/admin/candidate_sessions/{candidate_trial_id}/day_windows/control`
+- `POST /api/admin/candidate_sessions/{candidate_trial_id}/reset`
 - `GET /api/candidate/session/{token}`
 - `POST /api/candidate/session/{token}/claim`
 - `POST /api/candidate/session/{token}/schedule`
 - `GET /api/candidate/session/{token}/review`
-- `GET /api/candidate/session/{candidate_session_id}/current_task`
-- `GET /api/candidate/invites`
-- `POST /api/candidate/session/{candidate_session_id}/privacy/consent`
+- `GET /api/candidate/session/{candidate_trial_id}/current_task`
+- `POST /api/candidate/session/{candidate_trial_id}/privacy/consent`
+- `GET /api/candidate_sessions/{candidate_trial_id}/winoe_report`
+- `POST /api/candidate_sessions/{candidate_trial_id}/winoe_report/generate`
 
 ### Company Config / Media Storage
 

--- a/app/candidates/routes/candidate_sessions_routes/candidates_routes_candidate_sessions_routes_candidates_candidate_sessions_routes_current_task_logic_routes.py
+++ b/app/candidates/routes/candidate_sessions_routes/candidates_routes_candidate_sessions_routes_candidates_candidate_sessions_routes_current_task_logic_routes.py
@@ -21,7 +21,16 @@ from app.submissions.services import (
 
 
 def _require_candidate_session_header_match(candidate_session_id: int, request) -> None:
-    header_value = (request.headers.get("x-candidate-session-id") or "").strip()
+    canonical_header = (request.headers.get("x-candidate-trial-id") or "").strip()
+    legacy_header = (request.headers.get("x-candidate-session-id") or "").strip()
+    if canonical_header and legacy_header and canonical_header != legacy_header:
+        raise ApiError(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Candidate Trial headers do not match",
+            error_code="CANDIDATE_SESSION_HEADER_MISMATCH",
+            retryable=False,
+        )
+    header_value = canonical_header or legacy_header
     if not header_value:
         raise ApiError(
             status_code=status.HTTP_401_UNAUTHORIZED,
@@ -45,7 +54,7 @@ def _require_candidate_session_header_match(candidate_session_id: int, request) 
     if header_session_id != candidate_session_id:
         raise ApiError(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Candidate session header does not match requested session.",
+            detail="Candidate Trial header does not match requested Trial.",
             error_code="CANDIDATE_SESSION_HEADER_MISMATCH",
             retryable=False,
         )

--- a/app/candidates/routes/candidate_sessions_routes/candidates_routes_candidate_sessions_routes_candidates_candidate_sessions_routes_current_task_routes.py
+++ b/app/candidates/routes/candidate_sessions_routes/candidates_routes_candidate_sessions_routes_candidates_candidate_sessions_routes_current_task_routes.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Path, Request
+from fastapi import APIRouter, Depends, Path, Request, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.candidates.routes.candidate_sessions_routes.candidates_routes_candidate_sessions_routes_candidates_candidate_sessions_routes_current_task_logic_routes import (
@@ -16,18 +16,32 @@ from app.shared.auth.shared_auth_candidate_access_utils import (
     require_candidate_principal,
 )
 from app.shared.database import get_session
+from app.shared.http.shared_http_deprecation_headers import (
+    mark_legacy_candidate_session_route,
+)
 
 router = APIRouter()
 
 
 @router.get(
-    "/session/{candidate_session_id}/current_task", response_model=CurrentTaskResponse
+    "/trials/{candidate_trial_id}/current_task", response_model=CurrentTaskResponse
+)
+@router.get(
+    "/session/{candidate_trial_id}/current_task",
+    response_model=CurrentTaskResponse,
+    deprecated=True,
 )
 async def get_current_task(
-    candidate_session_id: Annotated[int, Path(..., ge=1)],
+    candidate_trial_id: Annotated[int, Path(..., ge=1)],
     request: Request,
+    response: Response,
     principal: Annotated[Principal, Depends(require_candidate_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> CurrentTaskResponse:
-    """Return the current task for a candidate session."""
-    return await build_current_task_view(candidate_session_id, request, principal, db)
+    """Return the current task for a Candidate Trial."""
+    mark_legacy_candidate_session_route(
+        request,
+        response,
+        canonical_path=f"/api/candidate/trials/{candidate_trial_id}/current_task",
+    )
+    return await build_current_task_view(candidate_trial_id, request, principal, db)

--- a/app/candidates/routes/candidate_sessions_routes/candidates_routes_candidate_sessions_routes_candidates_candidate_sessions_routes_privacy_routes.py
+++ b/app/candidates/routes/candidate_sessions_routes/candidates_routes_candidate_sessions_routes_candidates_candidate_sessions_routes_privacy_routes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Path, status
+from fastapi import APIRouter, Depends, Path, Request, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.candidates.candidate_sessions import services as cs_service
@@ -20,38 +20,62 @@ from app.shared.auth.shared_auth_candidate_access_utils import (
     require_candidate_principal,
 )
 from app.shared.database import get_session
+from app.shared.http.shared_http_deprecation_headers import (
+    mark_legacy_candidate_session_route,
+)
 from app.shared.time.shared_time_now_service import utcnow
 
 router = APIRouter()
 
 
 @router.post(
-    "/session/{candidate_session_id}/privacy/consent",
+    "/trials/{candidate_trial_id}/privacy/consent",
     response_model=CandidatePrivacyConsentResponse,
     status_code=status.HTTP_200_OK,
     summary="Record Candidate Privacy Consent",
     description=(
         "Persist candidate consent acknowledgements for recording/privacy notices"
-        " tied to a claimed session."
+        " tied to a claimed Candidate Trial."
     ),
     responses={
         status.HTTP_401_UNAUTHORIZED: {
             "description": "Candidate authentication required."
         },
-        status.HTTP_403_FORBIDDEN: {"description": "Candidate does not own session."},
-        status.HTTP_404_NOT_FOUND: {"description": "Candidate session not found."},
+        status.HTTP_403_FORBIDDEN: {"description": "Candidate does not own Trial."},
+        status.HTTP_404_NOT_FOUND: {"description": "Candidate Trial not found."},
+    },
+)
+@router.post(
+    "/session/{candidate_trial_id}/privacy/consent",
+    response_model=CandidatePrivacyConsentResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Record Candidate Privacy Consent Legacy Route",
+    deprecated=True,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Candidate authentication required."
+        },
+        status.HTTP_403_FORBIDDEN: {"description": "Candidate does not own Trial."},
+        status.HTTP_404_NOT_FOUND: {"description": "Candidate Trial not found."},
     },
 )
 async def record_candidate_privacy_consent(
-    candidate_session_id: Annotated[int, Path(..., ge=1)],
+    candidate_trial_id: Annotated[int, Path(..., ge=1)],
     payload: CandidatePrivacyConsentRequest,
+    request: Request,
+    response: Response,
     principal: Annotated[Principal, Depends(require_candidate_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> CandidatePrivacyConsentResponse:
     """Record candidate privacy consent."""
+    mark_legacy_candidate_session_route(
+        request,
+        response,
+        canonical_path=f"/api/candidate/trials/{candidate_trial_id}/privacy/consent",
+    )
     candidate_session = await cs_service.fetch_owned_session(
         db,
-        candidate_session_id,
+        candidate_trial_id,
         principal,
         now=utcnow(),
     )

--- a/app/candidates/routes/candidate_sessions_routes/candidates_routes_candidate_sessions_routes_candidates_candidate_sessions_routes_resolve_routes.py
+++ b/app/candidates/routes/candidate_sessions_routes/candidates_routes_candidate_sessions_routes_candidates_candidate_sessions_routes_resolve_routes.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Path, Request, status
+from fastapi import APIRouter, Depends, Path, Request, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.candidates.routes.candidate_sessions_routes.candidates_routes_candidate_sessions_routes_candidates_candidate_sessions_routes_claim_logic_routes import (
@@ -19,31 +19,60 @@ from app.shared.auth.shared_auth_candidate_access_utils import (
     require_candidate_principal,
 )
 from app.shared.database import get_session
+from app.shared.http.shared_http_deprecation_headers import (
+    mark_legacy_candidate_session_route,
+)
 
 router = APIRouter()
 
 
-@router.get("/session/{token}", response_model=CandidateSessionResolveResponse)
+@router.get(
+    "/trials/{token}",
+    response_model=CandidateSessionResolveResponse,
+    summary="Resolve Candidate Trial",
+)
+@router.get(
+    "/session/{token}",
+    response_model=CandidateSessionResolveResponse,
+    summary="Resolve Candidate Trial Legacy Route",
+    deprecated=True,
+)
 async def resolve_candidate_session(
     token: Annotated[str, Path(..., min_length=20, max_length=255)],
     request: Request,
+    response: Response,
     principal: Annotated[Principal, Depends(require_candidate_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> CandidateSessionResolveResponse:
-    """Claim an invite token for the authenticated candidate."""
+    """Resolve a candidate Trial token for the authenticated candidate."""
+    mark_legacy_candidate_session_route(
+        request, response, canonical_path=f"/api/candidate/trials/{token}"
+    )
     return render_claim_response(await claim_token(token, request, principal, db))
 
 
 @router.post(
+    "/trials/{token}/claim",
+    response_model=CandidateSessionResolveResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Claim Candidate Trial",
+)
+@router.post(
     "/session/{token}/claim",
     response_model=CandidateSessionResolveResponse,
     status_code=status.HTTP_200_OK,
+    summary="Claim Candidate Trial Legacy Route",
+    deprecated=True,
 )
 async def claim_candidate_session(
     token: Annotated[str, Path(..., min_length=20, max_length=255)],
     request: Request,
+    response: Response,
     db: Annotated[AsyncSession, Depends(get_session)],
     principal: Annotated[Principal, Depends(require_candidate_principal)],
 ) -> CandidateSessionResolveResponse:
     """Idempotent claim endpoint for authenticated candidates (no email body required)."""
+    mark_legacy_candidate_session_route(
+        request, response, canonical_path=f"/api/candidate/trials/{token}/claim"
+    )
     return render_claim_response(await claim_token(token, request, principal, db))

--- a/app/candidates/routes/candidate_sessions_routes/candidates_routes_candidate_sessions_routes_candidates_candidate_sessions_routes_review_routes.py
+++ b/app/candidates/routes/candidate_sessions_routes/candidates_routes_candidate_sessions_routes_candidates_candidate_sessions_routes_review_routes.py
@@ -2,7 +2,7 @@
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Path
+from fastapi import APIRouter, Depends, Path, Request, Response
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.candidates.candidate_sessions.services.candidates_candidate_sessions_services_candidates_candidate_sessions_review_service import (
@@ -19,20 +19,35 @@ from app.shared.auth.shared_auth_candidate_access_utils import (
     require_candidate_principal,
 )
 from app.shared.database import get_session
+from app.shared.http.shared_http_deprecation_headers import (
+    mark_legacy_candidate_session_route,
+)
 
 router = APIRouter()
 
 
 @router.get(
+    "/trials/{token}/review",
+    response_model=CandidateCompletedReviewResponse,
+    summary="Review Candidate Trial",
+)
+@router.get(
     "/session/{token}/review",
     response_model=CandidateCompletedReviewResponse,
+    summary="Review Candidate Trial Legacy Route",
+    deprecated=True,
 )
 async def review_candidate_session(
     token: Annotated[str, Path(..., min_length=20, max_length=255)],
+    request: Request,
+    response: Response,
     principal: Annotated[Principal, Depends(require_candidate_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> CandidateCompletedReviewResponse:
-    """Return a read-only review payload for a completed candidate session."""
+    """Return a read-only review payload for a completed Candidate Trial."""
+    mark_legacy_candidate_session_route(
+        request, response, canonical_path=f"/api/candidate/trials/{token}/review"
+    )
     return await build_candidate_completed_review(
         db,
         token=token,

--- a/app/candidates/routes/candidate_sessions_routes/candidates_routes_candidate_sessions_routes_candidates_candidate_sessions_routes_schedule_routes.py
+++ b/app/candidates/routes/candidate_sessions_routes/candidates_routes_candidate_sessions_routes_candidates_candidate_sessions_routes_schedule_routes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Path, Request, status
+from fastapi import APIRouter, Depends, Path, Request, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.candidates.candidate_sessions import services as cs_service
@@ -26,24 +26,45 @@ from app.shared.database import get_session
 from app.shared.http.dependencies.shared_http_dependencies_notifications_utils import (
     get_email_service,
 )
+from app.shared.http.shared_http_deprecation_headers import (
+    mark_legacy_candidate_session_route,
+)
 
 router = APIRouter()
 
 
 @router.post(
-    "/session/{token}/schedule",
+    "/trials/{token}/schedule",
     response_model=CandidateSessionScheduleResponse,
-    summary="Schedule Candidate Session",
+    summary="Schedule Candidate Trial",
     description=(
         "Persist candidate-proposed schedule details and send confirmation"
-        " notifications for the session token."
+        " notifications for the Trial token."
     ),
     responses={
         status.HTTP_401_UNAUTHORIZED: {
             "description": "Candidate authentication required."
         },
         status.HTTP_403_FORBIDDEN: {"description": "Token does not match principal."},
-        status.HTTP_404_NOT_FOUND: {"description": "Candidate session not found."},
+        status.HTTP_404_NOT_FOUND: {"description": "Candidate Trial not found."},
+        status.HTTP_410_GONE: {"description": "Candidate invite token is expired."},
+    },
+)
+@router.post(
+    "/session/{token}/schedule",
+    response_model=CandidateSessionScheduleResponse,
+    summary="Schedule Candidate Trial Legacy Route",
+    description=(
+        "Persist candidate-proposed schedule details and send confirmation"
+        " notifications for the Trial token."
+    ),
+    deprecated=True,
+    responses={
+        status.HTTP_401_UNAUTHORIZED: {
+            "description": "Candidate authentication required."
+        },
+        status.HTTP_403_FORBIDDEN: {"description": "Token does not match principal."},
+        status.HTTP_404_NOT_FOUND: {"description": "Candidate Trial not found."},
         status.HTTP_410_GONE: {"description": "Candidate invite token is expired."},
     },
 )
@@ -51,11 +72,15 @@ async def schedule_candidate_session(
     token: Annotated[str, Path(..., min_length=20, max_length=255)],
     payload: CandidateSessionScheduleRequest,
     request: Request,
+    response: Response,
     principal: Annotated[Principal, Depends(require_candidate_principal)],
     db: Annotated[AsyncSession, Depends(get_session)],
     email_service: Annotated[EmailService, Depends(get_email_service)],
 ) -> CandidateSessionScheduleResponse:
-    """Schedule candidate session."""
+    """Schedule Candidate Trial."""
+    mark_legacy_candidate_session_route(
+        request, response, canonical_path=f"/api/candidate/trials/{token}/schedule"
+    )
     correlation_id = (
         request.headers.get("x-correlation-id")
         or request.headers.get("x-request-id")

--- a/app/evaluations/routes/evaluations_routes_evaluations_winoe_report_routes.py
+++ b/app/evaluations/routes/evaluations_routes_evaluations_winoe_report_routes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Path, status
+from fastapi import APIRouter, Depends, Path, Request, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.evaluations.schemas.evaluations_schemas_evaluations_winoe_report_schema import (
@@ -18,64 +18,104 @@ from app.shared.auth.shared_auth_current_user_utils import get_current_user
 from app.shared.auth.shared_auth_roles_utils import ensure_talent_partner
 from app.shared.database import get_session
 from app.shared.database.shared_database_models_model import User
+from app.shared.http.shared_http_deprecation_headers import (
+    mark_legacy_candidate_session_route,
+)
 
-router = APIRouter(prefix="/candidate_sessions", tags=["winoe_report"])
+router = APIRouter(tags=["winoe_report"])
 
 
 @router.post(
-    "/{candidate_session_id}/winoe_report/generate",
+    "/candidate_trials/{candidate_trial_id}/winoe_report/generate",
     response_model=WinoeReportGenerateResponse,
     status_code=status.HTTP_202_ACCEPTED,
-    summary="Generate Winoe Report Route",
+    summary="Generate Winoe Report",
     description=(
-        "Queue or compute winoe-report artifacts for a candidate session visible"
+        "Queue or compute Winoe Report artifacts for a Candidate Trial visible"
         " to the authenticated Talent Partner."
     ),
     responses={
         status.HTTP_403_FORBIDDEN: {"description": "Talent Partner access required."},
-        status.HTTP_404_NOT_FOUND: {"description": "Candidate session not found."},
+        status.HTTP_404_NOT_FOUND: {"description": "Candidate Trial not found."},
+    },
+)
+@router.post(
+    "/candidate_sessions/{candidate_trial_id}/winoe_report/generate",
+    response_model=WinoeReportGenerateResponse,
+    status_code=status.HTTP_202_ACCEPTED,
+    summary="Generate Winoe Report Legacy Route",
+    deprecated=True,
+    responses={
+        status.HTTP_403_FORBIDDEN: {"description": "Talent Partner access required."},
+        status.HTTP_404_NOT_FOUND: {"description": "Candidate Trial not found."},
     },
 )
 async def generate_winoe_report_route(
-    candidate_session_id: Annotated[int, Path(..., ge=1)],
+    candidate_trial_id: Annotated[int, Path(..., ge=1)],
+    request: Request,
+    response: Response,
     db: Annotated[AsyncSession, Depends(get_session)],
     user: Annotated[User, Depends(get_current_user)],
 ) -> WinoeReportGenerateResponse:
     """Handle the generate winoe report API route."""
+    mark_legacy_candidate_session_route(
+        request,
+        response,
+        canonical_path=f"/api/candidate_trials/{candidate_trial_id}/winoe_report/generate",
+    )
     ensure_talent_partner(user)
     payload = await winoe_report_api.generate_winoe_report(
         db,
-        candidate_session_id=candidate_session_id,
+        candidate_session_id=candidate_trial_id,
         user=user,
     )
     return WinoeReportGenerateResponse(**payload)
 
 
 @router.get(
-    "/{candidate_session_id}/winoe_report",
+    "/candidate_trials/{candidate_trial_id}/winoe_report",
     response_model=WinoeReportStatusResponse,
     response_model_exclude_unset=True,
     status_code=status.HTTP_200_OK,
-    summary="Get Winoe Report Route",
+    summary="Get Winoe Report",
     description=(
-        "Return winoe-report generation status and latest report payload for a"
-        " Talent Partner-visible candidate session."
+        "Return Winoe Report generation status and latest report payload for a"
+        " Talent Partner-visible Candidate Trial."
     ),
     responses={
         status.HTTP_403_FORBIDDEN: {"description": "Talent Partner access required."},
-        status.HTTP_404_NOT_FOUND: {"description": "Candidate session not found."},
+        status.HTTP_404_NOT_FOUND: {"description": "Candidate Trial not found."},
+    },
+)
+@router.get(
+    "/candidate_sessions/{candidate_trial_id}/winoe_report",
+    response_model=WinoeReportStatusResponse,
+    response_model_exclude_unset=True,
+    status_code=status.HTTP_200_OK,
+    summary="Get Winoe Report Legacy Route",
+    deprecated=True,
+    responses={
+        status.HTTP_403_FORBIDDEN: {"description": "Talent Partner access required."},
+        status.HTTP_404_NOT_FOUND: {"description": "Candidate Trial not found."},
     },
 )
 async def get_winoe_report_route(
-    candidate_session_id: Annotated[int, Path(..., ge=1)],
+    candidate_trial_id: Annotated[int, Path(..., ge=1)],
+    request: Request,
+    response: Response,
     db: Annotated[AsyncSession, Depends(get_session)],
     user: Annotated[User, Depends(get_current_user)],
 ) -> WinoeReportStatusResponse:
     """Handle the get winoe report API route."""
+    mark_legacy_candidate_session_route(
+        request,
+        response,
+        canonical_path=f"/api/candidate_trials/{candidate_trial_id}/winoe_report",
+    )
     ensure_talent_partner(user)
     payload = await winoe_report_api.fetch_winoe_report(
         db,
-        candidate_session_id=candidate_session_id,
+        candidate_session_id=candidate_trial_id,
         user=user,
     )
     return WinoeReportStatusResponse(**payload)

--- a/app/evaluations/services/evaluations_services_evaluations_winoe_report_api_service.py
+++ b/app/evaluations/services/evaluations_services_evaluations_winoe_report_api_service.py
@@ -88,7 +88,7 @@ async def require_talent_partner_candidate_session_context(
     ):
         raise HTTPException(
             status_code=status.HTTP_403_FORBIDDEN,
-            detail="Candidate session access forbidden",
+            detail="Candidate Trial access forbidden",
         )
     return context
 

--- a/app/media/routes/media_routes_media_recordings_routes.py
+++ b/app/media/routes/media_routes_media_recordings_routes.py
@@ -39,13 +39,15 @@ router.include_router(fake_storage_router)
     summary="Delete Recording Route",
     description=(
         "Soft-delete a recording asset owned by the authenticated candidate"
-        " session and revoke access links."
+        " Trial and revoke access links."
     ),
     responses={
         status.HTTP_401_UNAUTHORIZED: {
             "description": "Candidate authentication required."
         },
-        status.HTTP_403_FORBIDDEN: {"description": "Candidate does not own session."},
+        status.HTTP_403_FORBIDDEN: {
+            "description": "Candidate does not own Candidate Trial."
+        },
         status.HTTP_404_NOT_FOUND: {"description": "Recording asset not found."},
     },
 )

--- a/app/media/services/media_services_media_keys_service.py
+++ b/app/media/services/media_services_media_keys_service.py
@@ -57,7 +57,7 @@ def build_recording_storage_key(
     ext = normalize_extension(extension)
     opaque = recording_uuid or uuid.uuid4().hex
     key = (
-        f"candidate-sessions/{candidate_session_id}/tasks/{task_id}/"
+        f"candidate-trials/{candidate_session_id}/tasks/{task_id}/"
         f"recordings/{opaque}.{ext}"
     )
     return ensure_safe_storage_key(key)

--- a/app/notifications/services/notifications_services_notifications_talent_partner_updates_service.py
+++ b/app/notifications/services/notifications_services_notifications_talent_partner_updates_service.py
@@ -118,7 +118,7 @@ async def enqueue_candidate_completed_notification(
     trial_id: int,
     commit: bool = True,
 ) -> Job:
-    """Queue a Talent Partner email for completed candidate sessions."""
+    """Queue a Talent Partner email for completed Candidate Trials."""
     return await _enqueue_talent_partner_notification_job(
         db,
         job_type=CANDIDATE_COMPLETED_NOTIFICATION_JOB_TYPE,

--- a/app/shared/http/dependencies/shared_http_dependencies_candidate_sessions_utils.py
+++ b/app/shared/http/dependencies/shared_http_dependencies_candidate_sessions_utils.py
@@ -20,18 +20,32 @@ from app.shared.utils.shared_utils_errors_utils import ApiError
 
 async def candidate_session_from_headers(
     principal: Annotated[Principal, Depends(require_candidate_principal)],
+    x_candidate_trial_id: Annotated[
+        int | None, Header(alias="x-candidate-trial-id", ge=1)
+    ] = None,
     x_candidate_session_id: Annotated[
         int | None, Header(alias="x-candidate-session-id", ge=1)
     ] = None,
     db: Annotated[AsyncSession, Depends(get_session)] = None,
 ) -> CandidateSession:
     """Load a candidate session for the authenticated candidate."""
-    if x_candidate_session_id is None:
+    if (
+        x_candidate_trial_id is not None
+        and x_candidate_session_id is not None
+        and int(x_candidate_trial_id) != int(x_candidate_session_id)
+    ):
+        raise ApiError(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Candidate Trial headers do not match",
+            error_code="CANDIDATE_SESSION_HEADER_MISMATCH",
+        )
+    candidate_trial_id = x_candidate_trial_id or x_candidate_session_id
+    if candidate_trial_id is None:
         raise ApiError(
             status_code=status.HTTP_401_UNAUTHORIZED,
             detail="Missing candidate session headers",
             error_code="CANDIDATE_SESSION_HEADER_REQUIRED",
         )
     return await cs_service.fetch_owned_session(
-        db, int(x_candidate_session_id), principal, now=shared_utcnow()
+        db, int(candidate_trial_id), principal, now=shared_utcnow()
     )

--- a/app/shared/http/shared_http_app_builder_service.py
+++ b/app/shared/http/shared_http_app_builder_service.py
@@ -14,6 +14,7 @@ from app.shared.http.shared_http_middleware import (
     configure_core_logging,
     configure_cors,
     configure_csrf_protection,
+    configure_legacy_candidate_trial_compatibility_headers,
     configure_perf_logging,
     configure_proxy_headers,
     configure_request_limits,
@@ -39,6 +40,7 @@ def create_app() -> FastAPI:
     configure_csrf_protection(app)
     configure_cors(app)
     configure_security_headers(app)
+    configure_legacy_candidate_trial_compatibility_headers(app)
     register_routers(app)
     register_error_handlers(app)
     return app

--- a/app/shared/http/shared_http_deprecation_headers.py
+++ b/app/shared/http/shared_http_deprecation_headers.py
@@ -1,0 +1,114 @@
+"""Helpers for legacy API compatibility headers."""
+
+from __future__ import annotations
+
+import re
+
+from fastapi import Request, Response
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.responses import Response as StarletteResponse
+
+LEGACY_CANDIDATE_SESSIONS_RESOURCE = "candidate_sessions"
+LEGACY_CANDIDATE_SESSION_PATH = "/candidate/session/"
+LEGACY_CANDIDATE_SESSIONS_PATH = "/candidate_sessions/"
+LEGACY_ADMIN_CANDIDATE_SESSIONS_PATH = "/admin/candidate_sessions/"
+
+_LEGACY_CANDIDATE_TRIAL_ROUTE_PATTERNS: tuple[tuple[re.Pattern[str], str], ...] = (
+    (
+        re.compile(r"^/api/candidate/session/(?P<id>[1-9]\d*)/current_task$"),
+        "/api/candidate/trials/{id}/current_task",
+    ),
+    (
+        re.compile(r"^/api/candidate/session/(?P<id>[1-9]\d*)/privacy/consent$"),
+        "/api/candidate/trials/{id}/privacy/consent",
+    ),
+    (
+        re.compile(r"^/api/candidate/session/(?P<token>[^/]+)$"),
+        "/api/candidate/trials/{token}",
+    ),
+    (
+        re.compile(r"^/api/candidate/session/(?P<token>[^/]+)/claim$"),
+        "/api/candidate/trials/{token}/claim",
+    ),
+    (
+        re.compile(r"^/api/candidate/session/(?P<token>[^/]+)/schedule$"),
+        "/api/candidate/trials/{token}/schedule",
+    ),
+    (
+        re.compile(r"^/api/candidate/session/(?P<token>[^/]+)/review$"),
+        "/api/candidate/trials/{token}/review",
+    ),
+    (
+        re.compile(r"^/api/candidate_sessions/(?P<id>[1-9]\d*)/winoe_report$"),
+        "/api/candidate_trials/{id}/winoe_report",
+    ),
+    (
+        re.compile(r"^/api/candidate_sessions/(?P<id>[1-9]\d*)/winoe_report/generate$"),
+        "/api/candidate_trials/{id}/winoe_report/generate",
+    ),
+    (
+        re.compile(r"^/api/admin/candidate_sessions/(?P<id>[1-9]\d*)/reset$"),
+        "/api/admin/candidate_trials/{id}/reset",
+    ),
+    (
+        re.compile(
+            r"^/api/admin/candidate_sessions/(?P<id>[1-9]\d*)/day_windows/control$"
+        ),
+        "/api/admin/candidate_trials/{id}/day_windows/control",
+    ),
+)
+
+
+def canonical_candidate_trial_successor_path(path: str) -> str | None:
+    """Return the canonical successor path for supported legacy Trial routes."""
+    for pattern, canonical_template in _LEGACY_CANDIDATE_TRIAL_ROUTE_PATTERNS:
+        match = pattern.fullmatch(path)
+        if match is None:
+            continue
+        return canonical_template.format(**match.groupdict())
+    return None
+
+
+def apply_legacy_candidate_trial_headers(
+    response: Response | StarletteResponse,
+    *,
+    canonical_path: str,
+) -> None:
+    """Attach legacy Candidate Trial compatibility headers idempotently."""
+    response.headers["Deprecation"] = "true"
+    response.headers["Link"] = f'<{canonical_path}>; rel="successor-version"'
+    response.headers["X-Winoe-Canonical-Resource"] = "candidate_trials"
+
+
+def mark_legacy_candidate_session_route(
+    request: Request,
+    response: Response,
+    *,
+    canonical_path: str,
+) -> None:
+    """Attach compatibility headers when a legacy candidate-session route is used."""
+    path = getattr(getattr(request, "url", None), "path", "")
+    if canonical_candidate_trial_successor_path(path) != canonical_path:
+        return
+    apply_legacy_candidate_trial_headers(response, canonical_path=canonical_path)
+
+
+class LegacyCandidateTrialCompatibilityHeadersMiddleware(BaseHTTPMiddleware):
+    """Attach compatibility headers to all responses from legacy Trial routes."""
+
+    async def dispatch(self, request, call_next):
+        response = await call_next(request)
+        canonical_path = canonical_candidate_trial_successor_path(request.url.path)
+        if canonical_path is not None:
+            apply_legacy_candidate_trial_headers(
+                response, canonical_path=canonical_path
+            )
+        return response
+
+
+__all__ = [
+    "LegacyCandidateTrialCompatibilityHeadersMiddleware",
+    "apply_legacy_candidate_trial_headers",
+    "canonical_candidate_trial_successor_path",
+    "mark_legacy_candidate_session_route",
+]

--- a/app/shared/http/shared_http_middleware.py
+++ b/app/shared/http/shared_http_middleware.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from app.shared.http.shared_http_middleware_http_middleware import (
     configure_cors,
     configure_csrf_protection,
+    configure_legacy_candidate_trial_compatibility_headers,
     configure_proxy_headers,
     configure_request_limits,
     configure_security_headers,
@@ -16,6 +17,7 @@ __all__ = [
     "configure_core_logging",
     "configure_csrf_protection",
     "configure_cors",
+    "configure_legacy_candidate_trial_compatibility_headers",
     "configure_perf_logging",
     "configure_proxy_headers",
     "configure_request_limits",

--- a/app/shared/http/shared_http_middleware_http_middleware.py
+++ b/app/shared/http/shared_http_middleware_http_middleware.py
@@ -21,6 +21,7 @@ from .shared_http_middleware_http_request_middleware import (
 from .shared_http_middleware_http_setup_middleware import (
     configure_cors,
     configure_csrf_protection,
+    configure_legacy_candidate_trial_compatibility_headers,
     configure_proxy_headers,
     configure_request_limits,
     configure_security_headers,
@@ -29,6 +30,7 @@ from .shared_http_middleware_http_setup_middleware import (
 __all__ = [
     "CsrfOriginEnforcementMiddleware",
     "configure_csrf_protection",
+    "configure_legacy_candidate_trial_compatibility_headers",
     "configure_proxy_headers",
     "configure_request_limits",
     "configure_cors",

--- a/app/shared/http/shared_http_middleware_http_setup_middleware.py
+++ b/app/shared/http/shared_http_middleware_http_setup_middleware.py
@@ -17,6 +17,9 @@ from app.shared.utils.shared_utils_request_limits_utils import (
     RequestSizeLimitMiddleware,
 )
 
+from .shared_http_deprecation_headers import (
+    LegacyCandidateTrialCompatibilityHeadersMiddleware,
+)
 from .shared_http_middleware_http_config import (
     _cors_config,
     _csrf_allowed_origins,
@@ -102,3 +105,8 @@ def _media_allowed_origins() -> set[str]:
 def configure_security_headers(app: FastAPI) -> None:
     """Execute configure security headers."""
     app.add_middleware(SecurityHeadersMiddleware)
+
+
+def configure_legacy_candidate_trial_compatibility_headers(app: FastAPI) -> None:
+    """Attach legacy Candidate Trial headers after route and error handling."""
+    app.add_middleware(LegacyCandidateTrialCompatibilityHeadersMiddleware)

--- a/app/submissions/repositories/submissions_repositories_submissions_winoe_report_model.py
+++ b/app/submissions/repositories/submissions_repositories_submissions_winoe_report_model.py
@@ -11,7 +11,7 @@ from app.shared.database.shared_database_base_model import Base
 
 
 class WinoeReport(Base):
-    """Model for storing winoe reports for candidate sessions."""
+    """Model for storing Winoe Reports for Candidate Trials."""
 
     __tablename__ = "winoe_reports"
     __table_args__ = (

--- a/app/talent_partners/routes/admin_routes/talent_partners_routes_admin_routes_talent_partners_admin_routes_demo_ops_routes.py
+++ b/app/talent_partners/routes/admin_routes/talent_partners_routes_admin_routes_talent_partners_admin_routes_demo_ops_routes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Path, status
+from fastapi import APIRouter, Depends, Path, Request, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.integrations.storage_media import StorageMediaProvider
@@ -18,6 +18,9 @@ from app.shared.http.dependencies.shared_http_dependencies_admin_demo_utils impo
 )
 from app.shared.http.dependencies.shared_http_dependencies_storage_media_utils import (
     get_media_storage_provider,
+)
+from app.shared.http.shared_http_deprecation_headers import (
+    mark_legacy_candidate_session_route,
 )
 from app.talent_partners.routes.admin_routes.talent_partners_routes_admin_routes_talent_partners_admin_routes_demo_ops_responses_routes import (
     build_fallback_response,
@@ -43,33 +46,56 @@ router = APIRouter()
 
 
 @router.post(
-    "/candidate_sessions/{candidate_session_id}/reset",
+    "/candidate_trials/{candidate_trial_id}/reset",
     response_model=CandidateSessionResetResponse,
     status_code=status.HTTP_200_OK,
-    summary="Reset Candidate Session",
+    summary="Reset Candidate Trial",
+    operation_id="reset_candidate_trial",
     description=(
-        "Reset a candidate session state during demo-mode operations for controlled QA"
+        "Reset a Candidate Trial state during demo-mode operations for controlled QA"
         " or replay flows."
     ),
     responses={
         status.HTTP_400_BAD_REQUEST: {"description": "Invalid reset request payload."},
         status.HTTP_403_FORBIDDEN: {"description": "Admin access required."},
         status.HTTP_404_NOT_FOUND: {
-            "description": "Demo mode disabled or target session not found."
+            "description": "Demo mode disabled or target Trial not found."
+        },
+    },
+)
+@router.post(
+    "/candidate_sessions/{candidate_trial_id}/reset",
+    response_model=CandidateSessionResetResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Reset Candidate Trial Legacy Route",
+    operation_id="reset_candidate_trial_legacy",
+    deprecated=True,
+    responses={
+        status.HTTP_400_BAD_REQUEST: {"description": "Invalid reset request payload."},
+        status.HTTP_403_FORBIDDEN: {"description": "Admin access required."},
+        status.HTTP_404_NOT_FOUND: {
+            "description": "Demo mode disabled or target Trial not found."
         },
     },
 )
 async def reset_candidate_session(
-    candidate_session_id: Annotated[int, Path(..., gt=0)],
+    candidate_trial_id: Annotated[int, Path(..., gt=0)],
     payload: CandidateSessionResetRequest,
+    request: Request,
+    response: Response,
     db: Annotated[AsyncSession, Depends(get_session)],
     actor: Annotated[DemoAdminActor, Depends(require_demo_mode_admin)],
 ) -> CandidateSessionResetResponse:
-    """Reset candidate session."""
+    """Reset Candidate Trial."""
+    mark_legacy_candidate_session_route(
+        request,
+        response,
+        canonical_path=f"/api/admin/candidate_trials/{candidate_trial_id}/reset",
+    )
     result = await admin_ops_service.reset_candidate_session(
         db,
         actor=actor,
-        candidate_session_id=candidate_session_id,
+        candidate_session_id=candidate_trial_id,
         target_state=payload.targetState,
         reason=payload.reason,
         override_if_evaluated=payload.overrideIfEvaluated,

--- a/app/talent_partners/routes/admin_routes/talent_partners_routes_admin_routes_talent_partners_admin_routes_dev_session_controls_routes.py
+++ b/app/talent_partners/routes/admin_routes/talent_partners_routes_admin_routes_talent_partners_admin_routes_dev_session_controls_routes.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Depends, Path, status
+from fastapi import APIRouter, Depends, Path, Request, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.candidates.schemas.candidates_schemas_candidates_candidate_sessions_windows_schema import (
@@ -13,6 +13,9 @@ from app.candidates.schemas.candidates_schemas_candidates_candidate_sessions_win
 )
 from app.shared.auth.shared_auth_admin_api_key_utils import require_admin_key
 from app.shared.database import get_session
+from app.shared.http.shared_http_deprecation_headers import (
+    mark_legacy_candidate_session_route,
+)
 from app.talent_partners.schemas.talent_partners_schemas_talent_partners_admin_ops_schema import (
     CandidateSessionDayWindowControlRequest,
     CandidateSessionDayWindowControlResponse,
@@ -36,12 +39,13 @@ def _build_current_day_window(payload: dict | None) -> CurrentDayWindow | None:
 
 
 @router.post(
-    "/candidate_sessions/{candidate_session_id}/day_windows/control",
+    "/candidate_trials/{candidate_trial_id}/day_windows/control",
     response_model=CandidateSessionDayWindowControlResponse,
     status_code=status.HTTP_200_OK,
-    summary="Control Candidate Session Day Windows",
+    summary="Control Candidate Trial Day Windows",
+    operation_id="control_candidate_trial_day_windows",
     description=(
-        "Local/test-only admin-keyed control that retimes a candidate session so a"
+        "Local/test-only admin-keyed control that retimes a Candidate Trial so a"
         " chosen day window is immediately usable for end-to-end validation."
     ),
     responses={
@@ -51,16 +55,39 @@ def _build_current_day_window(payload: dict | None) -> CurrentDayWindow | None:
         },
     },
 )
+@router.post(
+    "/candidate_sessions/{candidate_trial_id}/day_windows/control",
+    response_model=CandidateSessionDayWindowControlResponse,
+    status_code=status.HTTP_200_OK,
+    summary="Control Candidate Trial Day Windows Legacy Route",
+    operation_id="control_candidate_trial_day_windows_legacy",
+    deprecated=True,
+    responses={
+        status.HTTP_404_NOT_FOUND: {"description": "Admin access required."},
+        status.HTTP_422_UNPROCESSABLE_ENTITY: {
+            "description": "The requested day-window control payload is invalid."
+        },
+    },
+)
 async def control_candidate_session_day_windows(
-    candidate_session_id: Annotated[int, Path(..., gt=0)],
+    candidate_trial_id: Annotated[int, Path(..., gt=0)],
     payload: CandidateSessionDayWindowControlRequest,
+    request: Request,
+    response: Response,
     db: Annotated[AsyncSession, Depends(get_session)],
     _admin_key: Annotated[None, Depends(require_admin_key)],
 ) -> CandidateSessionDayWindowControlResponse:
-    """Control candidate-session day windows for local/test validation."""
+    """Control Candidate Trial day windows for local/test validation."""
+    mark_legacy_candidate_session_route(
+        request,
+        response,
+        canonical_path=(
+            f"/api/admin/candidate_trials/{candidate_trial_id}/day_windows/control"
+        ),
+    )
     result = await admin_ops_service.set_candidate_session_day_window(
         db,
-        candidate_session_id=candidate_session_id,
+        candidate_session_id=candidate_trial_id,
         target_day_index=payload.targetDayIndex,
         reason=payload.reason,
         candidate_timezone=payload.candidateTimezone,

--- a/app/tasks/routes/tasks/tasks_routes_tasks_tasks_handoff_upload_routes.py
+++ b/app/tasks/routes/tasks/tasks_routes_tasks_tasks_handoff_upload_routes.py
@@ -65,9 +65,9 @@ logger = logging.getLogger(__name__)
         " instructions."
     ),
     responses={
-        status.HTTP_403_FORBIDDEN: {"description": "Candidate session access denied."},
+        status.HTTP_403_FORBIDDEN: {"description": "Candidate Trial access denied."},
         status.HTTP_404_NOT_FOUND: {
-            "description": "Task or candidate session not found."
+            "description": "Task or Candidate Trial not found."
         },
     },
 )
@@ -104,7 +104,7 @@ async def init_handoff_upload_route(
         " metadata to the submission."
     ),
     responses={
-        status.HTTP_403_FORBIDDEN: {"description": "Candidate session access denied."},
+        status.HTTP_403_FORBIDDEN: {"description": "Candidate Trial access denied."},
         status.HTTP_404_NOT_FOUND: {"description": "Task or upload record not found."},
     },
 )
@@ -138,10 +138,10 @@ async def complete_handoff_upload_route(
     summary="Handoff Status Route",
     description=(
         "Return the current recording/transcript status for handoff tasks in"
-        " the candidate session."
+        " the Candidate Trial."
     ),
     responses={
-        status.HTTP_403_FORBIDDEN: {"description": "Candidate session access denied."},
+        status.HTTP_403_FORBIDDEN: {"description": "Candidate Trial access denied."},
         status.HTTP_404_NOT_FOUND: {
             "description": "Task or handoff recording not found."
         },

--- a/app/trials/routes/trials_routes/trials_routes_trials_routes_trials_routes_candidates_routes.py
+++ b/app/trials/routes/trials_routes/trials_routes_trials_routes_trials_routes_candidates_routes.py
@@ -36,7 +36,7 @@ async def list_trial_candidates(
     user: Annotated[Any, Depends(get_current_user)],
     includeTerminated: bool = False,
 ):
-    """List candidate sessions for a trial (Talent Partner-only)."""
+    """List Candidate Trials for a trial (Talent Partner-only)."""
     ensure_talent_partner_or_none(user)
     await trial_service.require_owned_trial(
         db,

--- a/app/trials/routes/trials_routes/trials_routes_trials_routes_trials_routes_invite_create_routes.py
+++ b/app/trials/routes/trials_routes/trials_routes_trials_routes_trials_routes_invite_create_routes.py
@@ -47,7 +47,7 @@ async def create_candidate_invite(
     email_service: Annotated[EmailService, Depends(get_email_service)],
     github_client: Annotated[GithubClient, Depends(get_github_client)],
 ):
-    """Create a candidate_session invite token for a trial (Talent Partner-only)."""
+    """Create a Candidate Trial invite token for a Trial (Talent Partner-only)."""
     ensure_talent_partner_or_none(user)
     return await create_invite_response(
         db,

--- a/app/trials/routes/trials_routes/trials_routes_trials_routes_trials_routes_invite_resend_routes.py
+++ b/app/trials/routes/trials_routes/trials_routes_trials_routes_trials_routes_invite_resend_routes.py
@@ -32,12 +32,12 @@ router = APIRouter()
     summary="Resend Candidate Invite",
     description=(
         "Resend an existing candidate invite email for a Talent Partner-owned"
-        " trial session."
+        " Candidate Trial."
     ),
     responses={
         status.HTTP_403_FORBIDDEN: {"description": "Talent Partner access required."},
         status.HTTP_404_NOT_FOUND: {
-            "description": "Trial or candidate session not found."
+            "description": "Trial or Candidate Trial not found."
         },
     },
 )

--- a/docs/ai_evaluation_jobs_integration.md
+++ b/docs/ai_evaluation_jobs_integration.md
@@ -4,11 +4,13 @@ This document describes how winoe-report generation uses durable jobs and evalua
 
 ## Entry Points
 
-- API trigger: `POST /api/candidate_sessions/{candidate_session_id}/winoe_report/generate`
+- API trigger: `POST /api/candidate_trials/{candidate_trial_id}/winoe_report/generate`
   - route: `app/evaluations/routes/evaluations_routes_evaluations_winoe_report_routes.py`
   - service: `generate_winoe_report` in `app/evaluations/services/evaluations_services_evaluations_winoe_report_api_service.py`
-- API status/read: `GET /api/candidate_sessions/{candidate_session_id}/winoe_report`
+- API status/read: `GET /api/candidate_trials/{candidate_trial_id}/winoe_report`
   - service: `fetch_winoe_report` in the same module
+- Legacy `/api/candidate_sessions/...` report routes remain as deprecated compatibility
+  aliases during the migration window.
 
 ## Job Enqueue Path
 
@@ -27,7 +29,7 @@ This document describes how winoe-report generation uses durable jobs and evalua
 
 - `evaluation_runs` stores run lifecycle, model metadata, basis fingerprint, and final report fields.
 - `evaluation_day_scores` stores per-day score/rubric/evidence payloads.
-- `winoe_reports` stores generated marker rows per candidate session.
+- `winoe_reports` stores generated marker rows per Candidate Trial.
 - `jobs` tracks queue/runtime state and serialized payload/result/error for polling/debugging.
 
 ## Read Model Behavior
@@ -41,8 +43,8 @@ This document describes how winoe-report generation uses durable jobs and evalua
 
 ## Access and Safety Controls
 
-- Talent Partner/company ownership enforcement via candidate-session evaluation context lookup.
-- Candidate session not found -> 404.
+- Talent Partner/company ownership enforcement via Candidate Trial evaluation context lookup.
+- Candidate Trial not found -> 404.
 - Unauthorized company access -> 403.
 - Job payload includes candidate/company/requesting user IDs for auditability.
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -2,29 +2,37 @@
 
 Generated from FastAPI OpenAPI plus dependency-based auth mapping.
 Generated at: deterministic
-Total endpoints: 54
+Total endpoints: 62
 
 ## Endpoint Index
 
-- `POST /api/admin/candidate_sessions/{candidate_session_id}/day_windows/control`: Control Candidate Session Day Windows
-- `POST /api/admin/candidate_sessions/{candidate_session_id}/reset`: Reset Candidate Session
+- `POST /api/admin/candidate_sessions/{candidate_trial_id}/day_windows/control`: Control Candidate Trial Day Windows Legacy Route
+- `POST /api/admin/candidate_sessions/{candidate_trial_id}/reset`: Reset Candidate Trial Legacy Route
+- `POST /api/admin/candidate_trials/{candidate_trial_id}/day_windows/control`: Control Candidate Trial Day Windows
+- `POST /api/admin/candidate_trials/{candidate_trial_id}/reset`: Reset Candidate Trial
 - `POST /api/admin/jobs/{job_id}/requeue`: Requeue Job
 - `POST /api/admin/media/purge`: Purge Media Retention
-- `GET /api/admin/templates/health`: Get Template Health
-- `POST /api/admin/templates/health/run`: Run Template Health
 - `POST /api/admin/trials/{trial_id}/scenario/use_fallback`: Use Trial Fallback
 - `POST /api/auth/logout`: Logout
 - `GET /api/auth/me`: Read Me
 - `POST /api/auth/talent-partner-onboarding`: Complete TalentPartner Onboarding
 - `GET /api/candidate/invites`: List Candidate Invites
-- `GET /api/candidate/session/{candidate_session_id}/current_task`: Get Current Task
-- `POST /api/candidate/session/{candidate_session_id}/privacy/consent`: Record Candidate Privacy Consent
-- `GET /api/candidate/session/{token}`: Resolve Candidate Session
-- `POST /api/candidate/session/{token}/claim`: Claim Candidate Session
-- `GET /api/candidate/session/{token}/review`: Review Candidate Session
-- `POST /api/candidate/session/{token}/schedule`: Schedule Candidate Session
-- `GET /api/candidate_sessions/{candidate_session_id}/winoe_report`: Get Winoe Report Route
-- `POST /api/candidate_sessions/{candidate_session_id}/winoe_report/generate`: Generate Winoe Report Route
+- `GET /api/candidate/session/{candidate_trial_id}/current_task`: Get Current Task
+- `POST /api/candidate/session/{candidate_trial_id}/privacy/consent`: Record Candidate Privacy Consent Legacy Route
+- `GET /api/candidate/session/{token}`: Resolve Candidate Trial Legacy Route
+- `POST /api/candidate/session/{token}/claim`: Claim Candidate Trial Legacy Route
+- `GET /api/candidate/session/{token}/review`: Review Candidate Trial Legacy Route
+- `POST /api/candidate/session/{token}/schedule`: Schedule Candidate Trial Legacy Route
+- `GET /api/candidate/trials/{candidate_trial_id}/current_task`: Get Current Task
+- `POST /api/candidate/trials/{candidate_trial_id}/privacy/consent`: Record Candidate Privacy Consent
+- `GET /api/candidate/trials/{token}`: Resolve Candidate Trial
+- `POST /api/candidate/trials/{token}/claim`: Claim Candidate Trial
+- `GET /api/candidate/trials/{token}/review`: Review Candidate Trial
+- `POST /api/candidate/trials/{token}/schedule`: Schedule Candidate Trial
+- `GET /api/candidate_sessions/{candidate_trial_id}/winoe_report`: Get Winoe Report Legacy Route
+- `POST /api/candidate_sessions/{candidate_trial_id}/winoe_report/generate`: Generate Winoe Report Legacy Route
+- `GET /api/candidate_trials/{candidate_trial_id}/winoe_report`: Get Winoe Report
+- `POST /api/candidate_trials/{candidate_trial_id}/winoe_report/generate`: Generate Winoe Report
 - `GET /api/companies/me/ai-config`: Read TalentPartner Company AI Config
 - `PUT /api/companies/me/ai-config`: Update TalentPartner Company AI Config
 - `POST /api/github/webhooks`: Receive Github Webhook
@@ -63,19 +71,19 @@ Total endpoints: 54
 
 ## Endpoint Details
 
-### `POST /api/admin/candidate_sessions/{candidate_session_id}/day_windows/control`
-- Summary: Control Candidate Session Day Windows
-- Description: Local/test-only admin-keyed control that retimes a candidate session so a chosen day window is immediately usable for end-to-end validation.
+### `POST /api/admin/candidate_sessions/{candidate_trial_id}/day_windows/control`
+- Summary: Control Candidate Trial Day Windows Legacy Route
+- Description: Control Candidate Trial day windows for local/test validation.
 - Auth: Admin API key via `X-Admin-Key` header
-- Operation ID: `control_candidate_session_day_windows_api_admin_candidate_sessions__candidate_session_id__day_windows_control_post`
+- Operation ID: `control_candidate_trial_day_windows_legacy`
 - Dependency auth signals: `app.shared.auth.shared_auth_admin_api_key_utils.require_admin_key`, `app.shared.database.get_session`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
-  - | `candidate_session_id` | yes | `integer` | `-` | - |
-- Query params: 
+  - | `candidate_trial_id` | yes | `integer` | `-` | - |
+- Query params:
   - None
-- Header params: 
+- Header params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `X-Admin-Key` | no | `X-Admin-Key` | `-` | - |
@@ -112,19 +120,19 @@ Total endpoints: 54
 }
 ```
 
-### `POST /api/admin/candidate_sessions/{candidate_session_id}/reset`
-- Summary: Reset Candidate Session
-- Description: Reset a candidate session state during demo-mode operations for controlled QA or replay flows.
+### `POST /api/admin/candidate_sessions/{candidate_trial_id}/reset`
+- Summary: Reset Candidate Trial Legacy Route
+- Description: Reset Candidate Trial.
 - Auth: Bearer token for demo admin allowlist (requires `WINOE_DEMO_MODE=true`)
-- Operation ID: `reset_candidate_session_api_admin_candidate_sessions__candidate_session_id__reset_post`
+- Operation ID: `reset_candidate_trial_legacy`
 - Dependency auth signals: `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_admin_demo_utils.require_demo_mode_admin`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
-  - | `candidate_session_id` | yes | `integer` | `-` | - |
-- Query params: 
+  - | `candidate_trial_id` | yes | `integer` | `-` | - |
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: `CandidateSessionResetRequest`
 - Request example:
@@ -139,7 +147,94 @@ Total endpoints: 54
 - Error responses:
   - `400`: Invalid reset request payload. (schema: `-`)
   - `403`: Admin access required. (schema: `-`)
-  - `404`: Demo mode disabled or target session not found. (schema: `-`)
+  - `404`: Demo mode disabled or target Trial not found. (schema: `-`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "candidateSessionId": 1,
+  "status": "ok",
+  "resetTo": "not_started"
+}
+```
+
+### `POST /api/admin/candidate_trials/{candidate_trial_id}/day_windows/control`
+- Summary: Control Candidate Trial Day Windows
+- Description: Local/test-only admin-keyed control that retimes a Candidate Trial so a chosen day window is immediately usable for end-to-end validation.
+- Auth: Admin API key via `X-Admin-Key` header
+- Operation ID: `control_candidate_trial_day_windows`
+- Dependency auth signals: `app.shared.auth.shared_auth_admin_api_key_utils.require_admin_key`, `app.shared.database.get_session`
+- Path params:
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `candidate_trial_id` | yes | `integer` | `-` | - |
+- Query params:
+  - None
+- Header params:
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `X-Admin-Key` | no | `X-Admin-Key` | `-` | - |
+- Request schema: `CandidateSessionDayWindowControlRequest`
+- Request example:
+```json
+{
+  "targetDayIndex": 1,
+  "reason": "example"
+}
+```
+- Success responses:
+  - `200`: Successful Response (schema: `CandidateSessionDayWindowControlResponse`)
+- Error responses:
+  - `404`: Admin access required. (schema: `-`)
+  - `422`: The requested day-window control payload is invalid. (schema: `-`)
+- Success example (`200`):
+```json
+{
+  "candidateSessionId": 1,
+  "candidateStatus": "example",
+  "status": "ok",
+  "targetDayIndex": 1,
+  "candidateTimezone": "example",
+  "scheduledStartAt": "2026-01-01T00:00:00Z",
+  "scheduleLockedAt": "2026-01-01T00:00:00Z",
+  "dayWindows": [
+    {
+      "dayIndex": 1,
+      "windowStartAt": "2026-01-01T00:00:00Z",
+      "windowEndAt": "2026-01-01T00:00:00Z"
+    }
+  ]
+}
+```
+
+### `POST /api/admin/candidate_trials/{candidate_trial_id}/reset`
+- Summary: Reset Candidate Trial
+- Description: Reset a Candidate Trial state during demo-mode operations for controlled QA or replay flows.
+- Auth: Bearer token for demo admin allowlist (requires `WINOE_DEMO_MODE=true`)
+- Operation ID: `reset_candidate_trial`
+- Dependency auth signals: `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_admin_demo_utils.require_demo_mode_admin`, `fastapi.security.http.unknown`
+- Path params:
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `candidate_trial_id` | yes | `integer` | `-` | - |
+- Query params:
+  - None
+- Header params:
+  - None
+- Request schema: `CandidateSessionResetRequest`
+- Request example:
+```json
+{
+  "targetState": "not_started",
+  "reason": "example"
+}
+```
+- Success responses:
+  - `200`: Successful Response (schema: `CandidateSessionResetResponse`)
+- Error responses:
+  - `400`: Invalid reset request payload. (schema: `-`)
+  - `403`: Admin access required. (schema: `-`)
+  - `404`: Demo mode disabled or target Trial not found. (schema: `-`)
   - `422`: Validation Error (schema: `HTTPValidationError`)
 - Success example (`200`):
 ```json
@@ -156,13 +251,13 @@ Total endpoints: 54
 - Auth: Bearer token for demo admin allowlist (requires `WINOE_DEMO_MODE=true`)
 - Operation ID: `requeue_job_api_admin_jobs__job_id__requeue_post`
 - Dependency auth signals: `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_admin_demo_utils.require_demo_mode_admin`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `job_id` | yes | `string` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: `JobRequeueRequest`
 - Request example:
@@ -194,11 +289,11 @@ Total endpoints: 54
 - Auth: Bearer token for demo admin allowlist (requires `WINOE_DEMO_MODE=true`)
 - Operation ID: `purge_media_retention_api_admin_media_purge_post`
 - Dependency auth signals: `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_admin_demo_utils.require_demo_mode_admin`, `app.shared.http.dependencies.shared_http_dependencies_storage_media_utils.get_media_storage_provider`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - None
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: `MediaRetentionPurgeRequest`
 - Request example:
@@ -228,20 +323,19 @@ Total endpoints: 54
 }
 ```
 
-
 ### `POST /api/admin/trials/{trial_id}/scenario/use_fallback`
 - Summary: Use Trial Fallback
 - Description: Apply a fallback scenario version to a trial when generated content must be overridden in demo mode.
 - Auth: Bearer token for demo admin allowlist (requires `WINOE_DEMO_MODE=true`)
 - Operation ID: `use_trial_fallback_api_admin_trials__trial_id__scenario_use_fallback_post`
 - Dependency auth signals: `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_admin_demo_utils.require_demo_mode_admin`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: `TrialFallbackRequest`
 - Request example:
@@ -273,11 +367,11 @@ Total endpoints: 54
 - Auth: None
 - Operation ID: `logout_api_auth_logout_post`
 - Dependency auth signals: None
-- Path params: 
+- Path params:
   - None
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -291,11 +385,11 @@ Total endpoints: 54
 - Auth: TalentPartner bearer token
 - Operation ID: `read_me_api_auth_me_get`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_authenticated_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - None
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -319,11 +413,11 @@ Total endpoints: 54
 - Auth: Bearer token
 - Operation ID: `complete_talent_partner_onboarding_api_auth_talent_partner_onboarding_post`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - None
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: `TalentPartnerOnboardingWrite`
 - Request example:
@@ -355,13 +449,13 @@ Total endpoints: 54
 - Auth: Candidate bearer token with `candidate:access`
 - Operation ID: `list_candidate_invites_api_candidate_invites_get`
 - Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - None
-- Query params: 
+- Query params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `includeTerminated` | no | `boolean` | `False` | - |
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -390,19 +484,19 @@ Total endpoints: 54
 ]
 ```
 
-### `GET /api/candidate/session/{candidate_session_id}/current_task`
+### `GET /api/candidate/session/{candidate_trial_id}/current_task`
 - Summary: Get Current Task
-- Description: Return the current task for a candidate session.
+- Description: Return the current task for a Candidate Trial.
 - Auth: Candidate bearer token with `candidate:access`
-- Operation ID: `get_current_task_api_candidate_session__candidate_session_id__current_task_get`
+- Operation ID: `get_current_task_api_candidate_session__candidate_trial_id__current_task_get`
 - Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
-  - | `candidate_session_id` | yes | `integer` | `-` | - |
-- Query params: 
+  - | `candidate_trial_id` | yes | `integer` | `-` | - |
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -433,19 +527,19 @@ Total endpoints: 54
 }
 ```
 
-### `POST /api/candidate/session/{candidate_session_id}/privacy/consent`
-- Summary: Record Candidate Privacy Consent
-- Description: Persist candidate consent acknowledgements for recording/privacy notices tied to a claimed session.
+### `POST /api/candidate/session/{candidate_trial_id}/privacy/consent`
+- Summary: Record Candidate Privacy Consent Legacy Route
+- Description: Record candidate privacy consent.
 - Auth: Candidate bearer token with `candidate:access`
-- Operation ID: `record_candidate_privacy_consent_api_candidate_session__candidate_session_id__privacy_consent_post`
+- Operation ID: `record_candidate_privacy_consent_api_candidate_session__candidate_trial_id__privacy_consent_post`
 - Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
-  - | `candidate_session_id` | yes | `integer` | `-` | - |
-- Query params: 
+  - | `candidate_trial_id` | yes | `integer` | `-` | - |
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: `CandidatePrivacyConsentRequest`
 - Request example:
@@ -458,8 +552,8 @@ Total endpoints: 54
   - `200`: Successful Response (schema: `CandidatePrivacyConsentResponse`)
 - Error responses:
   - `401`: Candidate authentication required. (schema: `-`)
-  - `403`: Candidate does not own session. (schema: `-`)
-  - `404`: Candidate session not found. (schema: `-`)
+  - `403`: Candidate does not own Trial. (schema: `-`)
+  - `404`: Candidate Trial not found. (schema: `-`)
   - `422`: Validation Error (schema: `HTTPValidationError`)
 - Success example (`200`):
 ```json
@@ -469,18 +563,18 @@ Total endpoints: 54
 ```
 
 ### `GET /api/candidate/session/{token}`
-- Summary: Resolve Candidate Session
-- Description: Claim an invite token for the authenticated candidate.
+- Summary: Resolve Candidate Trial Legacy Route
+- Description: Resolve a candidate Trial token for the authenticated candidate.
 - Auth: Candidate bearer token with `candidate:access`
 - Operation ID: `resolve_candidate_session_api_candidate_session__token__get`
 - Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `token` | yes | `string` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -510,18 +604,18 @@ Total endpoints: 54
 ```
 
 ### `POST /api/candidate/session/{token}/claim`
-- Summary: Claim Candidate Session
+- Summary: Claim Candidate Trial Legacy Route
 - Description: Idempotent claim endpoint for authenticated candidates (no email body required).
 - Auth: Candidate bearer token with `candidate:access`
 - Operation ID: `claim_candidate_session_api_candidate_session__token__claim_post`
 - Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `token` | yes | `string` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -551,18 +645,18 @@ Total endpoints: 54
 ```
 
 ### `GET /api/candidate/session/{token}/review`
-- Summary: Review Candidate Session
-- Description: Return a read-only review payload for a completed candidate session.
+- Summary: Review Candidate Trial Legacy Route
+- Description: Return a read-only review payload for a completed Candidate Trial.
 - Auth: Candidate bearer token with `candidate:access`
 - Operation ID: `review_candidate_session_api_candidate_session__token__review_get`
 - Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `token` | yes | `string` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -584,25 +678,26 @@ Total endpoints: 54
 ```
 
 ### `POST /api/candidate/session/{token}/schedule`
-- Summary: Schedule Candidate Session
-- Description: Persist candidate-proposed schedule details and send confirmation notifications for the session token.
+- Summary: Schedule Candidate Trial Legacy Route
+- Description: Persist candidate-proposed schedule details and send confirmation notifications for the Trial token.
 - Auth: Candidate bearer token with `candidate:access`
 - Operation ID: `schedule_candidate_session_api_candidate_session__token__schedule_post`
 - Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_notifications_utils.get_email_service`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `token` | yes | `string` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: `CandidateSessionScheduleRequest`
 - Request example:
 ```json
 {
   "scheduledStartAt": "2026-01-01T00:00:00Z",
-  "candidateTimezone": "example"
+  "candidateTimezone": "example",
+  "githubUsername": "example"
 }
 ```
 - Success responses:
@@ -610,7 +705,7 @@ Total endpoints: 54
 - Error responses:
   - `401`: Candidate authentication required. (schema: `-`)
   - `403`: Token does not match principal. (schema: `-`)
-  - `404`: Candidate session not found. (schema: `-`)
+  - `404`: Candidate Trial not found. (schema: `-`)
   - `410`: Candidate invite token is expired. (schema: `-`)
   - `422`: Validation Error (schema: `HTTPValidationError`)
 - Success example (`200`):
@@ -630,26 +725,267 @@ Total endpoints: 54
 }
 ```
 
-### `GET /api/candidate_sessions/{candidate_session_id}/winoe_report`
-- Summary: Get Winoe Report Route
-- Description: Return winoe-report generation status and latest report payload for a Talent Partner-visible candidate session.
-- Auth: TalentPartner bearer token
-- Operation ID: `get_winoe_report_route_api_candidate_sessions__candidate_session_id__winoe_report_get`
-- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+### `GET /api/candidate/trials/{candidate_trial_id}/current_task`
+- Summary: Get Current Task
+- Description: Return the current task for a Candidate Trial.
+- Auth: Candidate bearer token with `candidate:access`
+- Operation ID: `get_current_task_api_candidate_trials__candidate_trial_id__current_task_get`
+- Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
-  - | `candidate_session_id` | yes | `integer` | `-` | - |
-- Query params: 
+  - | `candidate_trial_id` | yes | `integer` | `-` | - |
+- Query params:
   - None
-- Header params: 
+- Header params:
+  - None
+- Request schema: None
+- Success responses:
+  - `200`: Successful Response (schema: `CurrentTaskResponse`)
+- Error responses:
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "candidateSessionId": 1,
+  "status": "not_started",
+  "currentDayIndex": 1,
+  "currentTask": {
+    "id": 1,
+    "dayIndex": 1,
+    "title": "example",
+    "type": "example",
+    "description": "example"
+  },
+  "completedTaskIds": [
+    1
+  ],
+  "progress": {
+    "completed": 1,
+    "total": 1
+  },
+  "isComplete": true
+}
+```
+
+### `POST /api/candidate/trials/{candidate_trial_id}/privacy/consent`
+- Summary: Record Candidate Privacy Consent
+- Description: Persist candidate consent acknowledgements for recording/privacy notices tied to a claimed Candidate Trial.
+- Auth: Candidate bearer token with `candidate:access`
+- Operation ID: `record_candidate_privacy_consent_api_candidate_trials__candidate_trial_id__privacy_consent_post`
+- Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params:
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `candidate_trial_id` | yes | `integer` | `-` | - |
+- Query params:
+  - None
+- Header params:
+  - None
+- Request schema: `CandidatePrivacyConsentRequest`
+- Request example:
+```json
+{
+  "noticeVersion": "example"
+}
+```
+- Success responses:
+  - `200`: Successful Response (schema: `CandidatePrivacyConsentResponse`)
+- Error responses:
+  - `401`: Candidate authentication required. (schema: `-`)
+  - `403`: Candidate does not own Trial. (schema: `-`)
+  - `404`: Candidate Trial not found. (schema: `-`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "status": "example"
+}
+```
+
+### `GET /api/candidate/trials/{token}`
+- Summary: Resolve Candidate Trial
+- Description: Resolve a candidate Trial token for the authenticated candidate.
+- Auth: Candidate bearer token with `candidate:access`
+- Operation ID: `resolve_candidate_session_api_candidate_trials__token__get`
+- Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params:
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `token` | yes | `string` | `-` | - |
+- Query params:
+  - None
+- Header params:
+  - None
+- Request schema: None
+- Success responses:
+  - `200`: Successful Response (schema: `CandidateSessionResolveResponse`)
+- Error responses:
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "candidateSessionId": 1,
+  "status": "not_started",
+  "claimedAt": "2026-01-01T00:00:00Z",
+  "startedAt": "2026-01-01T00:00:00Z",
+  "completedAt": "2026-01-01T00:00:00Z",
+  "candidateName": "example",
+  "trial": {
+    "id": 1,
+    "title": "example",
+    "role": "example"
+  },
+  "aiNoticeText": "example",
+  "aiNoticeVersion": "example",
+  "evalEnabledByDay": {
+    "key": true
+  }
+}
+```
+
+### `POST /api/candidate/trials/{token}/claim`
+- Summary: Claim Candidate Trial
+- Description: Idempotent claim endpoint for authenticated candidates (no email body required).
+- Auth: Candidate bearer token with `candidate:access`
+- Operation ID: `claim_candidate_session_api_candidate_trials__token__claim_post`
+- Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params:
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `token` | yes | `string` | `-` | - |
+- Query params:
+  - None
+- Header params:
+  - None
+- Request schema: None
+- Success responses:
+  - `200`: Successful Response (schema: `CandidateSessionResolveResponse`)
+- Error responses:
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "candidateSessionId": 1,
+  "status": "not_started",
+  "claimedAt": "2026-01-01T00:00:00Z",
+  "startedAt": "2026-01-01T00:00:00Z",
+  "completedAt": "2026-01-01T00:00:00Z",
+  "candidateName": "example",
+  "trial": {
+    "id": 1,
+    "title": "example",
+    "role": "example"
+  },
+  "aiNoticeText": "example",
+  "aiNoticeVersion": "example",
+  "evalEnabledByDay": {
+    "key": true
+  }
+}
+```
+
+### `GET /api/candidate/trials/{token}/review`
+- Summary: Review Candidate Trial
+- Description: Return a read-only review payload for a completed Candidate Trial.
+- Auth: Candidate bearer token with `candidate:access`
+- Operation ID: `review_candidate_session_api_candidate_trials__token__review_get`
+- Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params:
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `token` | yes | `string` | `-` | - |
+- Query params:
+  - None
+- Header params:
+  - None
+- Request schema: None
+- Success responses:
+  - `200`: Successful Response (schema: `CandidateCompletedReviewResponse`)
+- Error responses:
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "candidateSessionId": 1,
+  "status": "not_started",
+  "completedAt": "2026-01-01T00:00:00Z",
+  "trial": {
+    "id": 1,
+    "title": "example",
+    "role": "example"
+  }
+}
+```
+
+### `POST /api/candidate/trials/{token}/schedule`
+- Summary: Schedule Candidate Trial
+- Description: Persist candidate-proposed schedule details and send confirmation notifications for the Trial token.
+- Auth: Candidate bearer token with `candidate:access`
+- Operation ID: `schedule_candidate_session_api_candidate_trials__token__schedule_post`
+- Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_notifications_utils.get_email_service`, `fastapi.security.http.unknown`
+- Path params:
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `token` | yes | `string` | `-` | - |
+- Query params:
+  - None
+- Header params:
+  - None
+- Request schema: `CandidateSessionScheduleRequest`
+- Request example:
+```json
+{
+  "scheduledStartAt": "2026-01-01T00:00:00Z",
+  "candidateTimezone": "example",
+  "githubUsername": "example"
+}
+```
+- Success responses:
+  - `200`: Successful Response (schema: `CandidateSessionScheduleResponse`)
+- Error responses:
+  - `401`: Candidate authentication required. (schema: `-`)
+  - `403`: Token does not match principal. (schema: `-`)
+  - `404`: Candidate Trial not found. (schema: `-`)
+  - `410`: Candidate invite token is expired. (schema: `-`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "candidateSessionId": 1,
+  "scheduledStartAt": "2026-01-01T00:00:00Z",
+  "candidateTimezone": "example",
+  "dayWindows": [
+    {
+      "dayIndex": 1,
+      "windowStartAt": "2026-01-01T00:00:00Z",
+      "windowEndAt": "2026-01-01T00:00:00Z"
+    }
+  ],
+  "scheduleLockedAt": "2026-01-01T00:00:00Z"
+}
+```
+
+### `GET /api/candidate_sessions/{candidate_trial_id}/winoe_report`
+- Summary: Get Winoe Report Legacy Route
+- Description: Handle the get winoe report API route.
+- Auth: TalentPartner bearer token
+- Operation ID: `get_winoe_report_route_api_candidate_sessions__candidate_trial_id__winoe_report_get`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params:
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `candidate_trial_id` | yes | `integer` | `-` | - |
+- Query params:
+  - None
+- Header params:
   - None
 - Request schema: None
 - Success responses:
   - `200`: Successful Response (schema: `WinoeReportStatusResponse`)
 - Error responses:
   - `403`: Talent Partner access required. (schema: `-`)
-  - `404`: Candidate session not found. (schema: `-`)
+  - `404`: Candidate Trial not found. (schema: `-`)
   - `422`: Validation Error (schema: `HTTPValidationError`)
 - Success example (`200`):
 ```json
@@ -658,26 +994,83 @@ Total endpoints: 54
 }
 ```
 
-### `POST /api/candidate_sessions/{candidate_session_id}/winoe_report/generate`
-- Summary: Generate Winoe Report Route
-- Description: Queue or compute winoe-report artifacts for a candidate session visible to the authenticated Talent Partner.
+### `POST /api/candidate_sessions/{candidate_trial_id}/winoe_report/generate`
+- Summary: Generate Winoe Report Legacy Route
+- Description: Handle the generate winoe report API route.
 - Auth: TalentPartner bearer token
-- Operation ID: `generate_winoe_report_route_api_candidate_sessions__candidate_session_id__winoe_report_generate_post`
+- Operation ID: `generate_winoe_report_route_api_candidate_sessions__candidate_trial_id__winoe_report_generate_post`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
-  - | `candidate_session_id` | yes | `integer` | `-` | - |
-- Query params: 
+  - | `candidate_trial_id` | yes | `integer` | `-` | - |
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
   - `202`: Successful Response (schema: `WinoeReportGenerateResponse`)
 - Error responses:
   - `403`: Talent Partner access required. (schema: `-`)
-  - `404`: Candidate session not found. (schema: `-`)
+  - `404`: Candidate Trial not found. (schema: `-`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`202`):
+```json
+{
+  "jobId": "example",
+  "status": "example"
+}
+```
+
+### `GET /api/candidate_trials/{candidate_trial_id}/winoe_report`
+- Summary: Get Winoe Report
+- Description: Return Winoe Report generation status and latest report payload for a Talent Partner-visible Candidate Trial.
+- Auth: Bearer token
+- Operation ID: `get_winoe_report_route_api_candidate_trials__candidate_trial_id__winoe_report_get`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params:
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `candidate_trial_id` | yes | `integer` | `-` | - |
+- Query params:
+  - None
+- Header params:
+  - None
+- Request schema: None
+- Success responses:
+  - `200`: Successful Response (schema: `WinoeReportStatusResponse`)
+- Error responses:
+  - `403`: Talent Partner access required. (schema: `-`)
+  - `404`: Candidate Trial not found. (schema: `-`)
+  - `422`: Validation Error (schema: `HTTPValidationError`)
+- Success example (`200`):
+```json
+{
+  "status": "not_started"
+}
+```
+
+### `POST /api/candidate_trials/{candidate_trial_id}/winoe_report/generate`
+- Summary: Generate Winoe Report
+- Description: Queue or compute Winoe Report artifacts for a Candidate Trial visible to the authenticated Talent Partner.
+- Auth: Bearer token
+- Operation ID: `generate_winoe_report_route_api_candidate_trials__candidate_trial_id__winoe_report_generate_post`
+- Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
+- Path params:
+  - | Name | Required | Type | Default | Description |
+  - |---|---:|---|---|---|
+  - | `candidate_trial_id` | yes | `integer` | `-` | - |
+- Query params:
+  - None
+- Header params:
+  - None
+- Request schema: None
+- Success responses:
+  - `202`: Successful Response (schema: `WinoeReportGenerateResponse`)
+- Error responses:
+  - `403`: Talent Partner access required. (schema: `-`)
+  - `404`: Candidate Trial not found. (schema: `-`)
   - `422`: Validation Error (schema: `HTTPValidationError`)
 - Success example (`202`):
 ```json
@@ -693,11 +1086,11 @@ Total endpoints: 54
 - Auth: Bearer token
 - Operation ID: `read_company_ai_config_api_companies_me_ai_config_get`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - None
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -719,11 +1112,11 @@ Total endpoints: 54
 - Auth: Bearer token
 - Operation ID: `update_company_ai_config_api_companies_me_ai_config_put`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - None
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: `CompanyAIConfigWrite`
 - Request example:
@@ -738,7 +1131,7 @@ Total endpoints: 54
       "instructionsMd": null,
       "rubricMd": null
     },
-    "day1": {
+    "designDocReviewer": {
       "instructionsMd": null,
       "rubricMd": null
     }
@@ -764,11 +1157,11 @@ Total endpoints: 54
 - Auth: GitHub webhook signature (`X-Hub-Signature-256`) when configured
 - Operation ID: `receive_github_webhook_api_github_webhooks_post`
 - Dependency auth signals: `app.shared.database.get_session`
-- Path params: 
+- Path params:
   - None
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -790,13 +1183,13 @@ Total endpoints: 54
 - Auth: Bearer token (principal-scoped access)
 - Operation ID: `get_job_status_api_jobs__job_id__get`
 - Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `job_id` | yes | `string` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -823,15 +1216,15 @@ Total endpoints: 54
 - Auth: None
 - Operation ID: `fake_storage_download_route_api_recordings_storage_fake_download_get`
 - Dependency auth signals: `app.shared.http.dependencies.shared_http_dependencies_storage_media_utils.get_media_storage_provider`
-- Path params: 
+- Path params:
   - None
-- Query params: 
+- Query params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `key` | yes | `string` | `-` | - |
   - | `expiresAt` | yes | `integer` | `-` | - |
   - | `sig` | yes | `string` | `-` | - |
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -851,9 +1244,9 @@ Total endpoints: 54
 - Auth: None
 - Operation ID: `fake_storage_upload_route_api_recordings_storage_fake_upload_put`
 - Dependency auth signals: `app.shared.http.dependencies.shared_http_dependencies_storage_media_utils.get_media_storage_provider`
-- Path params: 
+- Path params:
   - None
-- Query params: 
+- Query params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `key` | yes | `string` | `-` | - |
@@ -861,7 +1254,8 @@ Total endpoints: 54
   - | `sizeBytes` | yes | `integer` | `-` | - |
   - | `expiresAt` | yes | `integer` | `-` | - |
   - | `sig` | yes | `string` | `-` | - |
-- Header params: 
+  - | `durationSeconds` | no | `Durationseconds` | `-` | - |
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -873,24 +1267,24 @@ Total endpoints: 54
 
 ### `POST /api/recordings/{recording_id}/delete`
 - Summary: Delete Recording Route
-- Description: Soft-delete a recording asset owned by the authenticated candidate session and revoke access links.
+- Description: Soft-delete a recording asset owned by the authenticated candidate Trial and revoke access links.
 - Auth: Candidate bearer token with `candidate:access`
 - Operation ID: `delete_recording_route_api_recordings__recording_id__delete_post`
 - Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `recording_id` | yes | `string` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
   - `200`: Successful Response (schema: `RecordingDeleteResponse`)
 - Error responses:
   - `401`: Candidate authentication required. (schema: `-`)
-  - `403`: Candidate does not own session. (schema: `-`)
+  - `403`: Candidate does not own Candidate Trial. (schema: `-`)
   - `404`: Recording asset not found. (schema: `-`)
   - `422`: Validation Error (schema: `HTTPValidationError`)
 - Success example (`200`):
@@ -906,16 +1300,16 @@ Total endpoints: 54
 - Auth: TalentPartner bearer token
 - Operation ID: `list_submissions_route_api_submissions_get`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - None
-- Query params: 
+- Query params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `candidateSessionId` | no | `Candidatesessionid` | `-` | - |
   - | `taskId` | no | `Taskid` | `-` | - |
   - | `limit` | no | `Limit` | `-` | - |
   - | `offset` | no | `integer` | `0` | - |
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -944,13 +1338,13 @@ Total endpoints: 54
 - Auth: TalentPartner bearer token
 - Operation ID: `get_submission_detail_route_api_submissions__submission_id__get`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `submission_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -974,18 +1368,19 @@ Total endpoints: 54
 ### `POST /api/tasks/{task_id}/codespace/init`
 - Summary: Init Codespace Route
 - Description: Provision or return a GitHub Codespace workspace for a task.
-- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-session-id`
+- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-trial-id`; legacy `x-candidate-session-id` is accepted during the compatibility window.
 - Operation ID: `init_codespace_route_api_tasks__task_id__codespace_init_post`
 - Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_candidate_sessions_utils.candidate_session_from_headers`, `app.shared.http.dependencies.shared_http_dependencies_github_native_utils.get_github_client`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `task_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
+  - | `x-candidate-trial-id` | no | `X-Candidate-Trial-Id` | `-` | - |
   - | `x-candidate-session-id` | no | `X-Candidate-Session-Id` | `-` | - |
 - Request schema: `CodespaceInitRequest`
 - Request example:
@@ -1010,18 +1405,19 @@ Total endpoints: 54
 ### `GET /api/tasks/{task_id}/codespace/status`
 - Summary: Codespace Status Route
 - Description: Return Codespace details and last known test status for a task.
-- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-session-id`
+- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-trial-id`; legacy `x-candidate-session-id` is accepted during the compatibility window.
 - Operation ID: `codespace_status_route_api_tasks__task_id__codespace_status_get`
-- Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_candidate_sessions_utils.candidate_session_from_headers`, `fastapi.security.http.unknown`
-- Path params: 
+- Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_candidate_sessions_utils.candidate_session_from_headers`, `app.shared.http.dependencies.shared_http_dependencies_github_native_utils.get_github_client`, `fastapi.security.http.unknown`
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `task_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
+  - | `x-candidate-trial-id` | no | `X-Candidate-Trial-Id` | `-` | - |
   - | `x-candidate-session-id` | no | `X-Candidate-Session-Id` | `-` | - |
 - Request schema: None
 - Success responses:
@@ -1039,18 +1435,19 @@ Total endpoints: 54
 ### `GET /api/tasks/{task_id}/draft`
 - Summary: Get Task Draft Route
 - Description: Return the saved draft payload for a candidate task in the current session context.
-- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-session-id`
+- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-trial-id`; legacy `x-candidate-session-id` is accepted during the compatibility window.
 - Operation ID: `get_task_draft_route_api_tasks__task_id__draft_get`
 - Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_candidate_sessions_utils.candidate_session_from_headers`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `task_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
+  - | `x-candidate-trial-id` | no | `X-Candidate-Trial-Id` | `-` | - |
   - | `x-candidate-session-id` | no | `X-Candidate-Session-Id` | `-` | - |
 - Request schema: None
 - Success responses:
@@ -1070,18 +1467,19 @@ Total endpoints: 54
 ### `PUT /api/tasks/{task_id}/draft`
 - Summary: Put Task Draft Route
 - Description: Create or update a candidate task draft while enforcing active-window and finalization constraints.
-- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-session-id`
+- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-trial-id`; legacy `x-candidate-session-id` is accepted during the compatibility window.
 - Operation ID: `put_task_draft_route_api_tasks__task_id__draft_put`
 - Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_candidate_sessions_utils.candidate_session_from_headers`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `task_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
+  - | `x-candidate-trial-id` | no | `X-Candidate-Trial-Id` | `-` | - |
   - | `x-candidate-session-id` | no | `X-Candidate-Session-Id` | `-` | - |
 - Request schema: `TaskDraftUpsertRequest`
 - Request example:
@@ -1107,25 +1505,26 @@ Total endpoints: 54
 
 ### `GET /api/tasks/{task_id}/handoff/status`
 - Summary: Handoff Status Route
-- Description: Return the current recording/transcript status for handoff tasks in the candidate session.
-- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-session-id`
+- Description: Return the current recording/transcript status for handoff tasks in the Candidate Trial.
+- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-trial-id`; legacy `x-candidate-session-id` is accepted during the compatibility window.
 - Operation ID: `handoff_status_route_api_tasks__task_id__handoff_status_get`
 - Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_candidate_sessions_utils.candidate_session_from_headers`, `app.shared.http.dependencies.shared_http_dependencies_storage_media_utils.get_media_storage_provider`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `task_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
+  - | `x-candidate-trial-id` | no | `X-Candidate-Trial-Id` | `-` | - |
   - | `x-candidate-session-id` | no | `X-Candidate-Session-Id` | `-` | - |
 - Request schema: None
 - Success responses:
   - `200`: Successful Response (schema: `HandoffStatusResponse`)
 - Error responses:
-  - `403`: Candidate session access denied. (schema: `-`)
+  - `403`: Candidate Trial access denied. (schema: `-`)
   - `404`: Task or handoff recording not found. (schema: `-`)
   - `422`: Validation Error (schema: `HTTPValidationError`)
 - Success example (`200`):
@@ -1135,7 +1534,12 @@ Total endpoints: 54
     "recordingId": "example",
     "status": "example"
   },
-  "supplementalMaterials": [],
+  "supplementalMaterials": [
+    {
+      "recordingId": "example",
+      "status": "example"
+    }
+  ],
   "transcript": {
     "status": "example"
   }
@@ -1145,18 +1549,19 @@ Total endpoints: 54
 ### `POST /api/tasks/{task_id}/handoff/upload/complete`
 - Summary: Complete Handoff Upload Route
 - Description: Finalize a previously initialized handoff upload and bind recording metadata to the submission.
-- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-session-id`
+- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-trial-id`; legacy `x-candidate-session-id` is accepted during the compatibility window.
 - Operation ID: `complete_handoff_upload_route_api_tasks__task_id__handoff_upload_complete_post`
 - Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_candidate_sessions_utils.candidate_session_from_headers`, `app.shared.http.dependencies.shared_http_dependencies_storage_media_utils.get_media_storage_provider`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `task_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
+  - | `x-candidate-trial-id` | no | `X-Candidate-Trial-Id` | `-` | - |
   - | `x-candidate-session-id` | no | `X-Candidate-Session-Id` | `-` | - |
 - Request schema: `HandoffUploadCompleteRequest`
 - Request example:
@@ -1168,7 +1573,7 @@ Total endpoints: 54
 - Success responses:
   - `200`: Successful Response (schema: `HandoffUploadCompleteResponse`)
 - Error responses:
-  - `403`: Candidate session access denied. (schema: `-`)
+  - `403`: Candidate Trial access denied. (schema: `-`)
   - `404`: Task or upload record not found. (schema: `-`)
   - `422`: Validation Error (schema: `HTTPValidationError`)
 - Success example (`200`):
@@ -1182,34 +1587,33 @@ Total endpoints: 54
 ### `POST /api/tasks/{task_id}/handoff/upload/init`
 - Summary: Init Handoff Upload Route
 - Description: Initialize candidate handoff recording upload and return signed upload instructions.
-- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-session-id`
+- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-trial-id`; legacy `x-candidate-session-id` is accepted during the compatibility window.
 - Operation ID: `init_handoff_upload_route_api_tasks__task_id__handoff_upload_init_post`
 - Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_candidate_sessions_utils.candidate_session_from_headers`, `app.shared.http.dependencies.shared_http_dependencies_storage_media_utils.get_media_storage_provider`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `task_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
+  - | `x-candidate-trial-id` | no | `X-Candidate-Trial-Id` | `-` | - |
   - | `x-candidate-session-id` | no | `X-Candidate-Session-Id` | `-` | - |
 - Request schema: `HandoffUploadInitRequest`
 - Request example:
 ```json
 {
   "contentType": "example",
-  "sizeBytes": 1,
-  "assetType": "recording",
-  "durationSeconds": 600
+  "sizeBytes": 1
 }
 ```
 - Success responses:
   - `200`: Successful Response (schema: `HandoffUploadInitResponse`)
 - Error responses:
-  - `403`: Candidate session access denied. (schema: `-`)
-  - `404`: Task or candidate session not found. (schema: `-`)
+  - `403`: Candidate Trial access denied. (schema: `-`)
+  - `404`: Task or Candidate Trial not found. (schema: `-`)
   - `422`: Validation Error (schema: `HTTPValidationError`)
 - Success example (`200`):
 ```json
@@ -1223,18 +1627,19 @@ Total endpoints: 54
 ### `POST /api/tasks/{task_id}/run`
 - Summary: Run Task Tests Route
 - Description: Dispatch GitHub Actions tests for a candidate task.
-- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-session-id`
+- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-trial-id`; legacy `x-candidate-session-id` is accepted during the compatibility window.
 - Operation ID: `run_task_tests_route_api_tasks__task_id__run_post`
 - Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_candidate_sessions_utils.candidate_session_from_headers`, `app.shared.http.dependencies.shared_http_dependencies_github_native_utils.get_actions_runner`, `app.shared.http.dependencies.shared_http_dependencies_github_native_utils.get_github_client`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `task_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
+  - | `x-candidate-trial-id` | no | `X-Candidate-Trial-Id` | `-` | - |
   - | `x-candidate-session-id` | no | `X-Candidate-Session-Id` | `-` | - |
 - Request schema: `RunTestsRequest`
 - Request example:
@@ -1258,19 +1663,20 @@ Total endpoints: 54
 ### `GET /api/tasks/{task_id}/run/{run_id}`
 - Summary: Get Run Result Route
 - Description: Poll a previously-triggered workflow run.
-- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-session-id`
+- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-trial-id`; legacy `x-candidate-session-id` is accepted during the compatibility window.
 - Operation ID: `get_run_result_route_api_tasks__task_id__run__run_id__get`
 - Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_candidate_sessions_utils.candidate_session_from_headers`, `app.shared.http.dependencies.shared_http_dependencies_github_native_utils.get_actions_runner`, `app.shared.http.dependencies.shared_http_dependencies_github_native_utils.get_github_client`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `task_id` | yes | `integer` | `-` | - |
   - | `run_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
+  - | `x-candidate-trial-id` | no | `X-Candidate-Trial-Id` | `-` | - |
   - | `x-candidate-session-id` | no | `X-Candidate-Session-Id` | `-` | - |
 - Request schema: None
 - Success responses:
@@ -1286,19 +1692,20 @@ Total endpoints: 54
 
 ### `POST /api/tasks/{task_id}/submit`
 - Summary: Submit Task Route
-- Description: Submit a task, optionally running GitHub tests for code/debug types.
-- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-session-id`
+- Description: Submit a task, optionally running GitHub tests for code tasks.
+- Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-trial-id`; legacy `x-candidate-session-id` is accepted during the compatibility window.
 - Operation ID: `submit_task_route_api_tasks__task_id__submit_post`
 - Dependency auth signals: `app.shared.auth.principal.shared_auth_principal_dependencies_utils.get_principal`, `app.shared.auth.shared_auth_candidate_access_utils.require_candidate_principal`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_candidate_sessions_utils.candidate_session_from_headers`, `app.shared.http.dependencies.shared_http_dependencies_github_native_utils.get_actions_runner`, `app.shared.http.dependencies.shared_http_dependencies_github_native_utils.get_github_client`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `task_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
+  - | `x-candidate-trial-id` | no | `X-Candidate-Trial-Id` | `-` | - |
   - | `x-candidate-session-id` | no | `X-Candidate-Session-Id` | `-` | - |
 - Request schema: `SubmissionCreateRequest`
 - Request example:
@@ -1334,13 +1741,13 @@ Total endpoints: 54
 - Auth: TalentPartner bearer token
 - Operation ID: `list_trials_api_trials_get`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - None
-- Query params: 
+- Query params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `includeTerminated` | no | `boolean` | `False` | - |
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -1354,8 +1761,6 @@ Total endpoints: 54
     "id": 1,
     "title": "example",
     "role": "example",
-    "techStack": "example",
-    "templateKey": "example",
     "status": "draft",
     "createdAt": "2026-01-01T00:00:00Z",
     "numCandidates": 1
@@ -1369,11 +1774,11 @@ Total endpoints: 54
 - Auth: TalentPartner bearer token
 - Operation ID: `create_trial_api_trials_post`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - None
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: `TrialCreate`
 - Request example:
@@ -1381,9 +1786,7 @@ Total endpoints: 54
 {
   "title": "example",
   "role": "example",
-  "techStack": "example",
-  "seniority": "example",
-  "focus": "example"
+  "seniority": "example"
 }
 ```
 - Success responses:
@@ -1396,10 +1799,8 @@ Total endpoints: 54
   "id": 1,
   "title": "example",
   "role": "example",
-  "techStack": "example",
   "seniority": "example",
   "focus": "example",
-  "templateKey": "example",
   "status": "draft",
   "scenarioGenerationJobId": "example",
   "tasks": [
@@ -1419,13 +1820,13 @@ Total endpoints: 54
 - Auth: TalentPartner bearer token
 - Operation ID: `get_trial_detail_api_trials__trial_id__get`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -1451,13 +1852,13 @@ Total endpoints: 54
 - Auth: TalentPartner bearer token
 - Operation ID: `update_trial_api_trials__trial_id__put`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: `TrialUpdate`
 - Request example:
@@ -1495,13 +1896,13 @@ Total endpoints: 54
 - Auth: TalentPartner bearer token
 - Operation ID: `activate_trial_api_trials__trial_id__activate_post`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: `TrialLifecycleRequest`
 - Request example:
@@ -1527,19 +1928,19 @@ Total endpoints: 54
 
 ### `GET /api/trials/{trial_id}/candidates`
 - Summary: List Trial Candidates
-- Description: List candidate sessions for a trial (Talent Partner-only).
+- Description: List Candidate Trials for a trial (Talent Partner-only).
 - Auth: TalentPartner bearer token
 - Operation ID: `list_trial_candidates_api_trials__trial_id__candidates_get`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `includeTerminated` | no | `boolean` | `False` | - |
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -1563,17 +1964,17 @@ Total endpoints: 54
 
 ### `GET /api/trials/{trial_id}/candidates/compare`
 - Summary: List Trial Candidates Compare
-- Description: Return side-by-side candidate progress and scoring signals for a Talent Partner-owned trial.
+- Description: Return side-by-side candidate progress and public evidence-backed signals for a Talent Partner-owned trial. Winoe does not decide who to hire.
 - Auth: TalentPartner bearer token
 - Operation ID: `list_trial_candidates_compare_api_trials__trial_id__candidates_compare_get`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -1591,25 +1992,25 @@ Total endpoints: 54
 
 ### `POST /api/trials/{trial_id}/candidates/{candidate_session_id}/invite/resend`
 - Summary: Resend Candidate Invite
-- Description: Resend an existing candidate invite email for a Talent Partner-owned trial session.
+- Description: Resend an existing candidate invite email for a Talent Partner-owned Candidate Trial.
 - Auth: TalentPartner bearer token
 - Operation ID: `resend_candidate_invite_api_trials__trial_id__candidates__candidate_session_id__invite_resend_post`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_notifications_utils.get_email_service`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `trial_id` | yes | `integer` | `-` | - |
   - | `candidate_session_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
   - `200`: Successful Response (schema: `-`)
 - Error responses:
   - `403`: Talent Partner access required. (schema: `-`)
-  - `404`: Trial or candidate session not found. (schema: `-`)
+  - `404`: Trial or Candidate Trial not found. (schema: `-`)
   - `422`: Validation Error (schema: `HTTPValidationError`)
 - Success example (`200`):
 ```json
@@ -1618,17 +2019,17 @@ Total endpoints: 54
 
 ### `POST /api/trials/{trial_id}/invite`
 - Summary: Create Candidate Invite
-- Description: Create a candidate_session invite token for a trial (Talent Partner-only).
+- Description: Create a Candidate Trial invite token for a Trial (Talent Partner-only).
 - Auth: TalentPartner bearer token
 - Operation ID: `create_candidate_invite_api_trials__trial_id__invite_post`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `app.shared.http.dependencies.shared_http_dependencies_github_native_utils.get_github_client`, `app.shared.http.dependencies.shared_http_dependencies_notifications_utils.get_email_service`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: `CandidateInviteRequest`
 - Request example:
@@ -1659,13 +2060,13 @@ Total endpoints: 54
 - Auth: TalentPartner bearer token
 - Operation ID: `update_active_scenario_version_api_trials__trial_id__scenario_active_patch`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: `ScenarioActiveUpdateRequest`
 - Request example:
@@ -1700,13 +2101,13 @@ Total endpoints: 54
 - Auth: TalentPartner bearer token
 - Operation ID: `regenerate_scenario_version_api_trials__trial_id__scenario_regenerate_post`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -1731,14 +2132,14 @@ Total endpoints: 54
 - Auth: TalentPartner bearer token
 - Operation ID: `patch_scenario_version_api_trials__trial_id__scenario__scenario_version_id__patch`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `trial_id` | yes | `integer` | `-` | - |
   - | `scenario_version_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: `ScenarioVersionPatchRequest`
 - Request example:
@@ -1775,14 +2176,14 @@ Total endpoints: 54
 - Auth: TalentPartner bearer token
 - Operation ID: `approve_scenario_version_api_trials__trial_id__scenario__scenario_version_id__approve_post`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `trial_id` | yes | `integer` | `-` | - |
   - | `scenario_version_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -1811,13 +2212,13 @@ Total endpoints: 54
 - Auth: TalentPartner bearer token
 - Operation ID: `terminate_trial_api_trials__trial_id__terminate_post`
 - Dependency auth signals: `app.shared.auth.dependencies.shared_auth_dependencies_current_user_utils.get_current_user`, `app.shared.database.get_session`, `fastapi.security.http.unknown`
-- Path params: 
+- Path params:
   - | Name | Required | Type | Default | Description |
   - |---|---:|---|---|---|
   - | `trial_id` | yes | `integer` | `-` | - |
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: `TrialLifecycleRequest`
 - Request example:
@@ -1847,11 +2248,11 @@ Total endpoints: 54
 - Auth: None
 - Operation ID: `health_check_health_get`
 - Dependency auth signals: None
-- Path params: 
+- Path params:
   - None
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:
@@ -1869,11 +2270,11 @@ Total endpoints: 54
 - Auth: None
 - Operation ID: `readiness_check_ready_get`
 - Dependency auth signals: None
-- Path params: 
+- Path params:
   - None
-- Query params: 
+- Query params:
   - None
-- Header params: 
+- Header params:
   - None
 - Request schema: None
 - Success responses:

--- a/docs/mvp1/evidence_traceability.md
+++ b/docs/mvp1/evidence_traceability.md
@@ -74,12 +74,15 @@ Day 4 transcript data is persisted in `transcripts` (`text`, `segments_json`, `m
 
 ## 5. Winoe Report materialization model
 
-`winoe_reports` is a marker table (`candidate_session_id`, `generated_at`).
+`winoe_reports` is a marker table keyed to the Candidate Trial persistence row
+(`candidate_session_id`, `generated_at`).
 
 - Full winoe-report report content is composed from `evaluation_runs` + `evaluation_day_scores` (plus run metadata and report JSON), not from a large blob in `winoe_reports`.
 - API endpoints:
-  - `POST /api/candidate_sessions/{candidate_session_id}/winoe_report/generate`
-  - `GET /api/candidate_sessions/{candidate_session_id}/winoe_report`
+  - `POST /api/candidate_trials/{candidate_trial_id}/winoe_report/generate`
+  - `GET /api/candidate_trials/{candidate_trial_id}/winoe_report`
+  - Deprecated compatibility aliases remain available at the legacy
+    `candidate_sessions` route prefix.
 
 ## 6. Mapping to issue tracks
 

--- a/docs/mvp1/operator_checklist.md
+++ b/docs/mvp1/operator_checklist.md
@@ -22,22 +22,23 @@ Use this checklist before invites, during active evaluations, and before sharing
 
 ## C. Day 4 consent and media controls
 
-- [ ] Confirm candidate consent was recorded before handoff upload completion:
-  - `candidate_sessions.consent_version`
-  - `candidate_sessions.consent_timestamp`
-  - `candidate_sessions.ai_notice_version`
+- [ ] Confirm candidate consent was recorded before handoff upload completion
+      (stored on the Candidate Trial persistence row):
+  - `CandidateSession.consent_version`
+  - `CandidateSession.consent_timestamp`
+  - `CandidateSession.ai_notice_version`
 - [ ] Confirm retention/deletion policy matches environment settings:
   - `MEDIA_RETENTION_DAYS`
   - `MEDIA_DELETE_ENABLED`
 
 ## D. Re-run triggers
 
-- [ ] Re-run evaluation (`POST /api/candidate_sessions/{candidate_session_id}/winoe_report/generate`) after any scenario-version change that should affect scoring context.
+- [ ] Re-run evaluation (`POST /api/candidate_trials/{candidate_trial_id}/winoe_report/generate`) after any scenario-version change that should affect scoring context.
 - [ ] Re-run evaluation after any change that affects cutoff basis for day 2/3.
-- [ ] Confirm the latest run is the one used for review (`GET /api/candidate_sessions/{candidate_session_id}/winoe_report`).
+- [ ] Confirm the latest run is the one used for review (`GET /api/candidate_trials/{candidate_trial_id}/winoe_report`).
 
 ## E. Manual override and audit controls
 
-- [ ] Do not perform manual override/reset actions for evaluated sessions without explicit override intent (`overrideIfEvaluated`) and a documented reason.
-- [ ] For admin demo-ops actions that use the audit pipeline (session reset, job requeue, scenario fallback), confirm response `auditId` values have matching `admin_action_audits` records.
+- [ ] Do not perform manual override/reset actions for evaluated Candidate Trials without explicit override intent (`overrideIfEvaluated`) and a documented reason.
+- [ ] For admin demo-ops actions that use the audit pipeline (Candidate Trial reset, job requeue, scenario fallback), confirm response `auditId` values have matching `admin_action_audits` records.
 - [ ] Confirm no out-of-band manual data edits were made without a corresponding audit trail entry.

--- a/pr.md
+++ b/pr.md
@@ -1,93 +1,162 @@
-## Title
-
-Support contract-live Day 2/3 verification for Codespace-only candidate QA
+# PR: Normalize Candidate Trial routes and storage keys to Winoe terminology
 
 ## Summary
 
-This backend patch stays narrow for frontend issue #194 contract-live support.
+This PR adds canonical Candidate Trial route/resource naming while preserving legacy `candidate_sessions` / `candidate/session` compatibility aliases. It adds legacy deprecation headers for both success and error responses, supports canonical `x-candidate-trial-id` while preserving legacy `x-candidate-session-id`, and migrates new media upload keys from `candidate-sessions/...` to `candidate-trials/...`.
 
-It does two things:
+Legacy persisted media keys remain readable/deletable, Winoe Report ownership copy now uses Candidate Trial terminology, and docs now prefer `x-candidate-trial-id` for task auth.
 
-- Keeps the candidate day-window admin operation local/test-only, while also updating the associated day audit and workspace revocation state for the day 2/3 contract-live proof.
-- Lets scenario generation treat demo mode as env-controlled, so local QA can fall back without hard-coding runtime behavior into `runBackend.sh`.
+## Issue / Acceptance Criteria
 
-## Final Scope
+Closes #304
 
-In scope:
+- Consistent Winoe terminology: canonical API routes, docs, auth wording, and Winoe Report ownership copy now use Candidate Trial terminology.
+- Media storage key migration: new uploads use `candidate-trials/...` keys.
+- Backward compatibility aliases/deprecation behavior: legacy route aliases and legacy headers remain accepted and legacy route responses include deprecation metadata.
+- Non-breaking migration: legacy routes still work, legacy headers still work, persisted DB names remain as the compatibility/persistence boundary, no destructive migration was added, and old media keys remain readable/deletable via persisted `storage_key`.
 
-- `app/talent_partners/services/talent_partners_services_talent_partners_admin_ops_candidate_day_window_service.py`
-- `app/trials/services/trials_services_trials_scenario_generation_env_service.py`
-- `tests/talent_partners/services/test_talent_partners_admin_ops_set_candidate_session_day_window_updates_schedule_and_jobs_service.py`
-- `tests/trials/services/test_trials_scenario_generation_env_service.py`
+## Implementation Details
 
-Out of scope:
+### Routes
 
-- compare-summary behavior
-- production auth behavior
-- Winoe Report scoring/evaluation behavior
-- hard-coded credentials
-- committed prod env files
-- dev-auth bypass changes
-- production runtime/provider/model default changes
-- migration-smoke / precommit QA-gate changes
+Canonical routes added:
+
+- `/api/candidate/trials/...`
+- `/api/candidate_trials/{candidate_trial_id}/winoe_report`
+- `/api/admin/candidate_trials/...`
+
+Legacy aliases preserved:
+
+- `/api/candidate/session/...`
+- `/api/candidate_sessions/...`
+- `/api/admin/candidate_sessions/...`
+
+Legacy aliases include:
+
+- `Deprecation: true`
+- `X-Winoe-Canonical-Resource: candidate_trials`
+- `Link: <canonical-path>; rel="successor-version"`
+
+Middleware now applies those compatibility headers to legacy error responses, not just successful route responses.
+
+### Headers
+
+Task auth now supports canonical `x-candidate-trial-id` while preserving legacy `x-candidate-session-id`. Requests with either header are accepted, requests with both headers set to the same value are accepted, and mismatched values are rejected with `403`.
+
+### Media
+
+New upload keys use:
+
+```text
+candidate-trials/{candidate_trial_id}/tasks/{task_id}/recordings/...
+```
+
+Existing `candidate-sessions/...` rows remain readable/deletable because media workflows use the persisted `storage_key`.
+
+### Docs
+
+`README.md` and `docs/api.md` were regenerated/updated. Endpoint coverage is `62`, task auth docs now prefer `x-candidate-trial-id`, and `x-candidate-session-id` is documented only as legacy compatibility.
+
+### Persistence Boundary
+
+DB table/model names like `candidate_sessions` remain intentionally as persistence compatibility. No DB rename was attempted and no migration is required.
 
 ## QA Evidence
 
-Frontend contract-live evidence bundle:
+### Live backend QA
 
-- `winoe-frontend/qa_verifications/Contract-Live-QA/contract_live_qa_latest/artifacts/20260426T201813`
-- sequence: `talent_partner-fresh,candidate-schedule,candidate-day:1,candidate-day:2,candidate-day:3,talent_partner-review`
-- `trialId=1`
-- `candidateSessionId=1`
+- `/health` returned `200 OK`.
+- `/ready` returned `200 OK` after worker startup.
+- Canonical and legacy Candidate Trial routes were exercised live.
+- Legacy current-task error response returned `409` with deprecation headers.
+- Canonical current-task error response returned the same domain response without deprecation headers.
+- Legacy review incomplete-Trial response returned `409` with deprecation headers.
+- Canonical review incomplete-Trial response returned the same domain response without deprecation headers.
+- Winoe Report other-company access returned `403` with `Candidate Trial access forbidden`.
+- Docs auth wording verified.
+- Media upload init produced a canonical key:
 
-Observed browser coverage:
-
-- Day 2 reached in browser.
-- Day 3 reached in browser.
-- Talent Partner submissions/review page reached in browser.
-- Dev-auth bypass was not used.
-- Prod env files were not sourced.
-
-## Backend Checks
-
-```bash
-python3 -m py_compile app/talent_partners/services/talent_partners_services_talent_partners_admin_ops_candidate_day_window_service.py app/trials/services/trials_services_trials_scenario_generation_env_service.py tests/talent_partners/services/test_talent_partners_admin_ops_set_candidate_session_day_window_updates_schedule_and_jobs_service.py tests/trials/services/test_trials_scenario_generation_env_service.py
-
-poetry run pytest tests/talent_partners/services/test_talent_partners_admin_ops_set_candidate_session_day_window_updates_schedule_and_jobs_service.py -q --no-cov
-# 3 passed
-
-poetry run pytest tests/trials/services/test_trials_scenario_generation_env_service.py -q --no-cov
-# 6 passed
-
-git diff --check
-# passed
+```text
+candidate-trials/<candidate_trial_id>/tasks/<task_id>/recordings/<uuid>.mp4
 ```
 
-## Changed Files
+- Legacy persisted media key was readable/deletable:
 
-- `app/talent_partners/services/talent_partners_services_talent_partners_admin_ops_candidate_day_window_service.py`
-  - local/test-only day-window control now also updates day audit and workspace revocation state for the relevant day 2/3 window
-- `app/trials/services/trials_services_trials_scenario_generation_env_service.py`
-  - demo-mode detection now honors env-driven flags before falling back to runtime config
-- `tests/talent_partners/services/test_talent_partners_admin_ops_set_candidate_session_day_window_updates_schedule_and_jobs_service.py`
-  - covers retiming existing day audits and creating/revoking the matching workspace state
-- `tests/trials/services/test_trials_scenario_generation_env_service.py`
-  - covers settings/env-driven demo mode and existing LLM-availability paths
+```text
+candidate-sessions/<candidate_trial_id>/tasks/<task_id>/recordings/qa304-legacy.mp4
+```
 
-## Final Confirmation
+### Automated tests
 
-- [x] No compare-summary behavior is included in this backend diff.
-- [x] No hard-coded credentials are included.
-- [x] No prod env files are committed.
-- [x] No dev-auth bypass changes are included.
-- [x] Demo fallback remains env-controlled only.
-- [x] Day-window support remains local/test-only gated.
-- [x] No production runtime/provider/model defaults were changed.
-- [x] Migration-smoke and precommit QA-gate changes were reverted.
-- [x] Conflict marker scan found only fixture/log strings, not merge markers.
+```bash
+poetry run pytest --no-cov -q tests/candidates/routes/test_candidates_session_resolve_current_task_pre_start_returns_schedule_not_started_routes.py
+# 1 passed
+
+poetry run pytest --no-cov -q tests/candidates/routes/test_candidates_session_review_returns_completed_artifacts_routes.py
+# 2 passed
+
+poetry run pytest --no-cov -q tests/evaluations/routes/test_evaluations_winoe_report_api_auth_404_and_403_routes.py
+# 1 passed
+
+poetry run pytest --no-cov -q tests/shared/http/test_shared_http_app_internals_service.py
+# 10 passed
+
+poetry run pytest --no-cov -q tests/shared/http/routes/test_shared_http_routes_winoe_report_and_jobs_routes.py
+# 5 passed
+
+poetry run python code-quality/documentation/scripts/docs_api_export.py --strict --verify-doc README.md docs/api.md
+# passed, 62/62 endpoints covered
+
+poetry run ruff check .
+# passed
+
+./precommit.sh
+# passed, 1833 passed, coverage 96.21%
+```
+
+Earlier broad focused suite evidence:
+
+```bash
+poetry run pytest --no-cov -q tests/candidates/routes tests/media/services tests/media/routes tests/evaluations/routes tests/talent_partners/routes tests/tasks/routes
+# 325 passed
+
+poetry run pytest --no-cov -q tests/core/db/migrations
+# 46 passed
+```
+
+## Grep Verification
+
+```bash
+grep -rn "Candidate session access forbidden" app/ tests/ docs/ --exclude-dir=.venv --exclude-dir=__pycache__ || true
+# no output
+
+grep -rn "plus x-candidate-session-id" README.md docs/api.md code-quality/documentation app/ tests/ --exclude-dir=.venv --exclude-dir=__pycache__ || true
+# no output
+
+grep -rn "Auth: Candidate bearer token.*x-candidate-session-id" README.md docs/api.md --exclude-dir=.venv --exclude-dir=__pycache__ || true
+# matches only canonical-first docs wording:
+# Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-trial-id`; legacy `x-candidate-session-id` is accepted during the compatibility window.
+```
+
+Broader grep posture:
+
+- Remaining `candidate_sessions` hits are persistence boundary, compatibility aliases/tests, historical migrations, or explicitly documented legacy compatibility.
+- No canonical route/storage-key path uses the old media prefix.
+- New uploads use `candidate-trials/...`.
 
 ## Risk / Rollback
 
-Risk is low if the local/test-only gates remain intact.
+- Breaking-change risk: low, because legacy aliases and headers remain.
+- Migration risk: low, because no destructive DB migration/table rename.
+- Demo risk: low, because live route/header/media QA passed.
+- Security risk: low, because auth checks and ownership enforcement remain unchanged.
+- Rollback: revert PR; no irreversible schema/blob migration performed.
 
-Rollback is to revert the four backend support files above.
+## Reviewer Notes
+
+- Legacy aliases are intentionally aliases, not redirects, to avoid breaking POST/auth/header clients.
+- Middleware applies compatibility headers to legacy error responses because route-level `Response` headers do not survive exception handling.
+- Persistence names remain legacy internally by design to avoid risky schema churn.
+- `candidate_sessions` error codes may remain for client compatibility, but user-facing detail text uses Candidate Trial terminology.
+
+Fixes #304

--- a/tests/candidates/routes/test_candidates_privacy_router_routes.py
+++ b/tests/candidates/routes/test_candidates_privacy_router_routes.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
+from fastapi import Response
 
 from app.candidates.routes.candidate_sessions_routes import (
     candidates_routes_candidate_sessions_routes_candidates_candidate_sessions_routes_privacy_routes as privacy_route,
@@ -55,8 +56,12 @@ async def test_record_candidate_privacy_consent_route(monkeypatch):
     )
 
     response = await privacy_route.record_candidate_privacy_consent(
-        candidate_session_id=17,
+        candidate_trial_id=17,
         payload=CandidatePrivacyConsentRequest(noticeVersion="mvp1"),
+        request=SimpleNamespace(
+            url=SimpleNamespace(path="/api/candidate/trials/17/privacy/consent")
+        ),
+        response=Response(),
         principal=_principal(),
         db=None,
     )

--- a/tests/candidates/routes/test_candidates_session_resolve_current_task_initial_is_day_1_routes.py
+++ b/tests/candidates/routes/test_candidates_session_resolve_current_task_initial_is_day_1_routes.py
@@ -39,10 +39,10 @@ async def test_current_task_initial_is_day_1(async_client, async_session, monkey
     )
 
     res = await async_client.get(
-        f"/api/candidate/session/{cs_id}/current_task",
+        f"/api/candidate/trials/{cs_id}/current_task",
         headers={
             "Authorization": f"Bearer {token}",
-            "x-candidate-session-id": str(cs_id),
+            "x-candidate-trial-id": str(cs_id),
         },
     )
     assert res.status_code == 200, res.text
@@ -60,3 +60,28 @@ async def test_current_task_initial_is_day_1(async_client, async_session, monkey
     assert body["currentWindow"]["windowEndAt"] is not None
     assert isinstance(body["currentWindow"]["isOpen"], bool)
     assert body["currentWindow"]["now"] is not None
+    assert "Deprecation" not in res.headers
+    assert "Link" not in res.headers
+    assert "X-Winoe-Canonical-Resource" not in res.headers
+
+    legacy_res = await async_client.get(
+        f"/api/candidate/session/{cs_id}/current_task",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "x-candidate-session-id": str(cs_id),
+        },
+    )
+    assert legacy_res.status_code == 200, legacy_res.text
+    legacy_body = legacy_res.json()
+    assert legacy_body["currentWindow"].pop("now")
+    canonical_body = {
+        **body,
+        "currentWindow": {**body["currentWindow"]},
+    }
+    assert canonical_body["currentWindow"].pop("now")
+    assert legacy_body == canonical_body
+    assert legacy_res.headers["Deprecation"] == "true"
+    assert legacy_res.headers["X-Winoe-Canonical-Resource"] == "candidate_trials"
+    assert legacy_res.headers["Link"] == (
+        f'</api/candidate/trials/{cs_id}/current_task>; rel="successor-version"'
+    )

--- a/tests/candidates/routes/test_candidates_session_resolve_current_task_pre_start_returns_schedule_not_started_routes.py
+++ b/tests/candidates/routes/test_candidates_session_resolve_current_task_pre_start_returns_schedule_not_started_routes.py
@@ -46,6 +46,11 @@ async def test_current_task_pre_start_returns_schedule_not_started(
         },
     )
     assert res.status_code == 409, res.text
+    assert res.headers["Deprecation"] == "true"
+    assert res.headers["X-Winoe-Canonical-Resource"] == "candidate_trials"
+    assert res.headers["Link"] == (
+        f'</api/candidate/trials/{cs_id}/current_task>; rel="successor-version"'
+    )
     body = res.json()
     assert body["detail"] == "Trial has not started yet."
     assert body["errorCode"] == "SCHEDULE_NOT_STARTED"
@@ -57,3 +62,16 @@ async def test_current_task_pre_start_returns_schedule_not_started(
         "+00:00", "Z"
     )
     assert body["details"]["windowEndAt"] is not None
+
+    canonical_res = await async_client.get(
+        f"/api/candidate/trials/{cs_id}/current_task",
+        headers={
+            "Authorization": "Bearer candidate:jane@example.com",
+            "x-candidate-trial-id": str(cs_id),
+        },
+    )
+    assert canonical_res.status_code == 409, canonical_res.text
+    assert canonical_res.json() == body
+    assert "Deprecation" not in canonical_res.headers
+    assert "X-Winoe-Canonical-Resource" not in canonical_res.headers
+    assert "Link" not in canonical_res.headers

--- a/tests/candidates/routes/test_candidates_session_review_returns_completed_artifacts_routes.py
+++ b/tests/candidates/routes/test_candidates_session_review_returns_completed_artifacts_routes.py
@@ -188,4 +188,20 @@ async def test_candidate_session_review_rejects_incomplete_sessions(
         headers={"Authorization": "Bearer candidate:review-incomplete@example.com"},
     )
     assert response.status_code == 409, response.text
+    assert response.headers["Deprecation"] == "true"
+    assert response.headers["X-Winoe-Canonical-Resource"] == "candidate_trials"
+    assert response.headers["Link"] == (
+        f"</api/candidate/trials/{candidate_session.token}/review>;"
+        ' rel="successor-version"'
+    )
     assert response.json()["detail"] == "Trial is not complete yet"
+
+    canonical_response = await async_client.get(
+        f"/api/candidate/trials/{candidate_session.token}/review",
+        headers={"Authorization": "Bearer candidate:review-incomplete@example.com"},
+    )
+    assert canonical_response.status_code == 409, canonical_response.text
+    assert canonical_response.json() == response.json()
+    assert "Deprecation" not in canonical_response.headers
+    assert "X-Winoe-Canonical-Resource" not in canonical_response.headers
+    assert "Link" not in canonical_response.headers

--- a/tests/candidates/routes/test_candidates_sessions_misc_coverage_routes.py
+++ b/tests/candidates/routes/test_candidates_sessions_misc_coverage_routes.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
+from fastapi import Response
 
 from app.candidates.routes.candidate_sessions_routes import (
     candidates_routes_candidate_sessions_routes_candidates_candidate_sessions_routes_current_task_logic_routes as current_task_logic,
@@ -38,6 +39,7 @@ async def test_schedule_route_returns_rendered_response(monkeypatch):
             githubUsername="octocat",
         ),
         request=SimpleNamespace(headers={"x-correlation-id": "corr-123"}),
+        response=Response(),
         principal=SimpleNamespace(sub="auth0|candidate"),
         db=object(),
         email_service=object(),

--- a/tests/candidates/routes/test_candidates_sessions_router_claim_routes.py
+++ b/tests/candidates/routes/test_candidates_sessions_router_claim_routes.py
@@ -4,6 +4,7 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 
 import pytest
+from fastapi import Response
 
 from app.ai import build_ai_policy_snapshot
 from app.shared.http.routes import candidate_sessions
@@ -51,6 +52,7 @@ async def test_claim_route_uses_claim_service(monkeypatch):
     resp = await candidate_sessions.claim_candidate_session(
         token="t" * 24,
         request=_request(),
+        response=Response(),
         db=stub_db,
         principal=_principal("test@example.com"),
     )

--- a/tests/candidates/routes/test_candidates_sessions_router_routes.py
+++ b/tests/candidates/routes/test_candidates_sessions_router_routes.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 import pytest
-from fastapi import HTTPException
+from fastapi import HTTPException, Response
 
 from app.config import settings
 from app.shared.auth.principal import Principal
@@ -59,6 +59,7 @@ async def test_resolve_candidate_session_propagates_claim_error(monkeypatch):
         await candidate_sessions.resolve_candidate_session(
             token="t" * 24,
             request=_request(),
+            response=Response(),
             db=stub_db,
             principal=_principal("test@example.com"),
         )
@@ -105,8 +106,9 @@ async def test_get_current_task_marks_completed(monkeypatch):
     )
 
     resp = await candidate_sessions.get_current_task(
-        candidate_session_id=cs.id,
+        candidate_trial_id=cs.id,
         request=_request(headers={"x-candidate-session-id": str(cs.id)}),
+        response=Response(),
         db=stub_db,
         principal=_principal("user@example.com"),
     )

--- a/tests/candidates/routes/test_candidates_sessions_routes_unit_routes.py
+++ b/tests/candidates/routes/test_candidates_sessions_routes_unit_routes.py
@@ -1,7 +1,7 @@
 from types import SimpleNamespace
 
 import pytest
-from fastapi import Request
+from fastapi import Request, Response
 
 from app.ai import build_ai_policy_snapshot
 from app.shared.auth import rate_limit
@@ -116,14 +116,23 @@ async def test_candidate_session_rate_limits(monkeypatch):
     )
 
     await candidate_sessions.resolve_candidate_session(
-        token="x" * 20, request=_fake_request(), principal=principal, db=db
+        token="x" * 20,
+        request=_fake_request(),
+        response=Response(),
+        principal=principal,
+        db=db,
     )
     await candidate_sessions.claim_candidate_session(
-        token="x" * 20, request=_fake_request(), db=db, principal=principal
+        token="x" * 20,
+        request=_fake_request(),
+        response=Response(),
+        db=db,
+        principal=principal,
     )
     await candidate_sessions.get_current_task(
-        candidate_session_id=1,
+        candidate_trial_id=1,
         request=_fake_request({"headers": [(b"x-candidate-session-id", b"1")]}),
+        response=Response(),
         principal=principal,
         db=db,
     )

--- a/tests/evaluations/routes/test_evaluations_winoe_report_api_auth_404_and_403_routes.py
+++ b/tests/evaluations/routes/test_evaluations_winoe_report_api_auth_404_and_403_routes.py
@@ -41,3 +41,25 @@ async def test_winoe_report_auth_404_and_403(
         headers=auth_header_factory(outsider),
     )
     assert forbidden_get.status_code == 403
+    assert forbidden_get.json()["detail"] == "Candidate Trial access forbidden"
+    assert "Candidate session" not in forbidden_get.json()["detail"]
+    assert forbidden_get.headers["Deprecation"] == "true"
+    assert forbidden_get.headers["X-Winoe-Canonical-Resource"] == "candidate_trials"
+    assert forbidden_get.headers["Link"] == (
+        f"</api/candidate_trials/{candidate_session.id}/winoe_report>;"
+        ' rel="successor-version"'
+    )
+
+    canonical_forbidden_get = await async_client.get(
+        f"/api/candidate_trials/{candidate_session.id}/winoe_report",
+        headers=auth_header_factory(outsider),
+    )
+    assert canonical_forbidden_get.status_code == 403
+    detail = canonical_forbidden_get.json()["detail"]
+    assert detail == "Candidate Trial access forbidden"
+    assert "Candidate session" not in detail
+    assert "candidate session" not in detail
+    assert "Trial" in detail
+    assert "Deprecation" not in canonical_forbidden_get.headers
+    assert "X-Winoe-Canonical-Resource" not in canonical_forbidden_get.headers
+    assert "Link" not in canonical_forbidden_get.headers

--- a/tests/evaluations/routes/test_evaluations_winoe_report_api_generate_winoe_report_returns_queued_and_get_running_routes.py
+++ b/tests/evaluations/routes/test_evaluations_winoe_report_api_generate_winoe_report_returns_queued_and_get_running_routes.py
@@ -16,26 +16,40 @@ async def test_generate_winoe_report_returns_queued_and_get_running(
     )
 
     before_generate = await async_client.get(
-        f"/api/candidate_sessions/{candidate_session.id}/winoe_report",
+        f"/api/candidate_trials/{candidate_session.id}/winoe_report",
         headers=auth_header_factory(talent_partner),
     )
     assert before_generate.status_code == 200, before_generate.text
     assert before_generate.json() == {"status": "not_started"}
+    assert "Deprecation" not in before_generate.headers
+    assert "Link" not in before_generate.headers
+    assert "X-Winoe-Canonical-Resource" not in before_generate.headers
 
     generate = await async_client.post(
-        f"/api/candidate_sessions/{candidate_session.id}/winoe_report/generate",
+        f"/api/candidate_trials/{candidate_session.id}/winoe_report/generate",
         headers=auth_header_factory(talent_partner),
     )
     assert generate.status_code == 202, generate.text
     body = generate.json()
     assert body["status"] == "queued"
     assert isinstance(body["jobId"], str)
+    assert "Deprecation" not in generate.headers
+    assert "Link" not in generate.headers
+    assert "X-Winoe-Canonical-Resource" not in generate.headers
 
     duplicate_generate = await async_client.post(
         f"/api/candidate_sessions/{candidate_session.id}/winoe_report/generate",
         headers=auth_header_factory(talent_partner),
     )
     assert duplicate_generate.status_code == 202, duplicate_generate.text
+    assert duplicate_generate.headers["Deprecation"] == "true"
+    assert duplicate_generate.headers["Link"] == (
+        f"</api/candidate_trials/{candidate_session.id}/winoe_report/generate>;"
+        ' rel="successor-version"'
+    )
+    assert (
+        duplicate_generate.headers["X-Winoe-Canonical-Resource"] == "candidate_trials"
+    )
     assert duplicate_generate.json()["jobId"] == body["jobId"]
 
     job = await async_session.get(Job, body["jobId"])
@@ -45,8 +59,24 @@ async def test_generate_winoe_report_returns_queued_and_get_running(
     assert job.payload_json["basisFingerprint"]
 
     fetch = await async_client.get(
-        f"/api/candidate_sessions/{candidate_session.id}/winoe_report",
+        f"/api/candidate_trials/{candidate_session.id}/winoe_report",
         headers=auth_header_factory(talent_partner),
     )
     assert fetch.status_code == 200, fetch.text
     assert fetch.json() == {"status": "running"}
+    assert "Deprecation" not in fetch.headers
+    assert "Link" not in fetch.headers
+    assert "X-Winoe-Canonical-Resource" not in fetch.headers
+
+    legacy_fetch = await async_client.get(
+        f"/api/candidate_sessions/{candidate_session.id}/winoe_report",
+        headers=auth_header_factory(talent_partner),
+    )
+    assert legacy_fetch.status_code == 200, legacy_fetch.text
+    assert legacy_fetch.json() == fetch.json()
+    assert legacy_fetch.headers["Deprecation"] == "true"
+    assert legacy_fetch.headers["Link"] == (
+        f"</api/candidate_trials/{candidate_session.id}/winoe_report>;"
+        ' rel="successor-version"'
+    )
+    assert legacy_fetch.headers["X-Winoe-Canonical-Resource"] == "candidate_trials"

--- a/tests/media/routes/test_media_handoff_upload_handoff_upload_init_success_routes.py
+++ b/tests/media/routes/test_media_handoff_upload_handoff_upload_init_success_routes.py
@@ -56,5 +56,8 @@ async def test_handoff_upload_init_success(
         assert recording.status == RECORDING_ASSET_STATUS_UPLOADING
         assert recording.candidate_session_id == candidate_session.id
         assert recording.content_type == "video/mp4"
+        assert recording.storage_key.startswith(
+            f"candidate-trials/{candidate_session.id}/tasks/{task.id}/recordings/"
+        )
     finally:
         get_storage_media_provider.cache_clear()

--- a/tests/media/services/test_media_handoff_upload_service_init_handoff_upload_success_service.py
+++ b/tests/media/services/test_media_handoff_upload_service_init_handoff_upload_success_service.py
@@ -25,5 +25,8 @@ async def test_init_handoff_upload_success(async_session):
 
     assert recording.id > 0
     assert recording.status == "uploading"
+    assert recording.storage_key.startswith(
+        f"candidate-trials/{candidate_session.id}/tasks/{task.id}/recordings/"
+    )
     assert upload_url.startswith("https://fake-storage.local/upload?")
     assert expires_seconds > 0

--- a/tests/media/services/test_media_storage_media_service.py
+++ b/tests/media/services/test_media_storage_media_service.py
@@ -20,7 +20,7 @@ def test_build_recording_storage_key_shape():
         extension="mp4",
         recording_uuid="abc123",
     )
-    assert key == "candidate-sessions/12/tasks/34/recordings/abc123.mp4"
+    assert key == "candidate-trials/12/tasks/34/recordings/abc123.mp4"
 
 
 def test_recording_public_id_round_trip():

--- a/tests/shared/http/routes/test_shared_http_routes_winoe_report_and_jobs_routes.py
+++ b/tests/shared/http/routes/test_shared_http_routes_winoe_report_and_jobs_routes.py
@@ -4,6 +4,8 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from fastapi import Response
+from starlette.requests import Request
 
 from app.shared.auth.principal import Principal
 from app.shared.http.routes import shared_http_routes_jobs_routes as jobs_router
@@ -14,6 +16,21 @@ from app.shared.jobs.repositories.shared_jobs_repositories_models_repository imp
     JOB_STATUS_SUCCEEDED,
 )
 from app.shared.utils.shared_utils_errors_utils import ApiError
+
+
+def _request(path: str) -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "GET",
+            "path": path,
+            "headers": [],
+            "query_string": b"",
+            "server": ("testserver", 80),
+            "scheme": "http",
+            "client": ("testclient", 50000),
+        }
+    )
 
 
 @pytest.mark.asyncio
@@ -33,14 +50,85 @@ async def test_winoe_report_router_generate_and_get_routes(monkeypatch):
         AsyncMock(return_value={"status": "running"}),
     )
 
+    generate_response = Response()
     generated = await winoe_report_router.generate_winoe_report_route(
-        11, object(), user
+        11,
+        _request("/api/candidate_trials/11/winoe_report/generate"),
+        generate_response,
+        object(),
+        user,
     )
-    fetched = await winoe_report_router.get_winoe_report_route(11, object(), user)
+    fetch_response = Response()
 
     assert generated.jobId == "job-1"
     assert generated.status == "queued"
+    assert "Deprecation" not in generate_response.headers
+    assert "Link" not in generate_response.headers
+    assert "X-Winoe-Canonical-Resource" not in generate_response.headers
+
+    fetched = await winoe_report_router.get_winoe_report_route(
+        11,
+        _request("/api/candidate_trials/11/winoe_report"),
+        fetch_response,
+        object(),
+        user,
+    )
+
     assert fetched.status == "running"
+    assert "Deprecation" not in fetch_response.headers
+    assert "Link" not in fetch_response.headers
+    assert "X-Winoe-Canonical-Resource" not in fetch_response.headers
+
+
+@pytest.mark.asyncio
+async def test_winoe_report_router_legacy_routes_mark_deprecated(monkeypatch):
+    user = SimpleNamespace(id=7)
+    monkeypatch.setattr(
+        winoe_report_router, "ensure_talent_partner", lambda _user: None
+    )
+    monkeypatch.setattr(
+        winoe_report_router.winoe_report_api,
+        "generate_winoe_report",
+        AsyncMock(return_value={"jobId": "job-1", "status": "queued"}),
+    )
+    monkeypatch.setattr(
+        winoe_report_router.winoe_report_api,
+        "fetch_winoe_report",
+        AsyncMock(return_value={"status": "running"}),
+    )
+
+    generate_response = Response()
+    generated = await winoe_report_router.generate_winoe_report_route(
+        11,
+        _request("/api/candidate_sessions/11/winoe_report/generate"),
+        generate_response,
+        object(),
+        user,
+    )
+    fetch_response = Response()
+    fetched = await winoe_report_router.get_winoe_report_route(
+        11,
+        _request("/api/candidate_sessions/11/winoe_report"),
+        fetch_response,
+        object(),
+        user,
+    )
+
+    assert generated.jobId == "job-1"
+    assert fetched.status == "running"
+    assert generate_response.headers["Deprecation"] == "true"
+    assert (
+        generate_response.headers["Link"]
+        == '</api/candidate_trials/11/winoe_report/generate>; rel="successor-version"'
+    )
+    assert generate_response.headers["X-Winoe-Canonical-Resource"] == (
+        "candidate_trials"
+    )
+    assert fetch_response.headers["Deprecation"] == "true"
+    assert fetch_response.headers["Link"] == (
+        '</api/candidate_trials/11/winoe_report>; rel="successor-version"'
+    )
+    assert fetch_response.headers["X-Winoe-Canonical-Resource"] == "candidate_trials"
 
 
 def test_jobs_router_public_status_and_poll_helpers():

--- a/tests/shared/http/test_shared_http_app_internals_service.py
+++ b/tests/shared/http/test_shared_http_app_internals_service.py
@@ -133,7 +133,15 @@ def test_create_app_omits_dev_session_controls_without_admin_key(monkeypatch):
     assert (
         _has_route(
             app,
-            "/api/admin/candidate_sessions/{candidate_session_id}/day_windows/control",
+            "/api/admin/candidate_trials/{candidate_trial_id}/day_windows/control",
+            "POST",
+        )
+        is False
+    )
+    assert (
+        _has_route(
+            app,
+            "/api/admin/candidate_sessions/{candidate_trial_id}/day_windows/control",
             "POST",
         )
         is False
@@ -149,7 +157,12 @@ def test_create_app_includes_dev_session_controls_with_admin_key(monkeypatch):
 
     assert _has_route(
         app,
-        "/api/admin/candidate_sessions/{candidate_session_id}/day_windows/control",
+        "/api/admin/candidate_trials/{candidate_trial_id}/day_windows/control",
+        "POST",
+    )
+    assert _has_route(
+        app,
+        "/api/admin/candidate_sessions/{candidate_trial_id}/day_windows/control",
         "POST",
     )
 

--- a/tests/talent_partners/routes/test_talent_partners_admin_demo_ops_reset_candidate_session_dry_run_is_non_mutating_routes.py
+++ b/tests/talent_partners/routes/test_talent_partners_admin_demo_ops_reset_candidate_session_dry_run_is_non_mutating_routes.py
@@ -30,7 +30,7 @@ async def test_reset_candidate_session_dry_run_is_non_mutating(
     await async_session.commit()
 
     response = await async_client.post(
-        f"/api/admin/candidate_sessions/{candidate_session.id}/reset",
+        f"/api/admin/candidate_trials/{candidate_session.id}/reset",
         json={
             "targetState": "not_started",
             "reason": "Dry run reset",

--- a/tests/talent_partners/routes/test_talent_partners_admin_demo_route_and_misc_coverage_routes.py
+++ b/tests/talent_partners/routes/test_talent_partners_admin_demo_route_and_misc_coverage_routes.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from fastapi import Response
 
 from app.shared.http import shared_http_middleware_perf_middleware as middleware_perf
 from app.talent_partners.routes.admin_routes import demo_ops
@@ -51,13 +52,17 @@ async def test_admin_demo_route_response_mapping(monkeypatch):
         ),
     )
     reset_response = await demo_ops.reset_candidate_session(
-        candidate_session_id=101,
+        candidate_trial_id=101,
         payload=SimpleNamespace(
             targetState="claimed",
             reason="reset",
             overrideIfEvaluated=False,
             dryRun=False,
         ),
+        request=SimpleNamespace(
+            url=SimpleNamespace(path="/api/admin/candidate_trials/101/reset")
+        ),
+        response=Response(),
         db=object(),
         actor=SimpleNamespace(actor_id="actor-1"),
     )

--- a/tests/talent_partners/routes/test_talent_partners_admin_dev_session_controls_routes.py
+++ b/tests/talent_partners/routes/test_talent_partners_admin_dev_session_controls_routes.py
@@ -45,7 +45,7 @@ async def test_admin_day_window_control_route_maps_response(async_client, monkey
     )
 
     response = await async_client.post(
-        "/api/admin/candidate_sessions/42/day_windows/control",
+        "/api/admin/candidate_trials/42/day_windows/control",
         headers={"X-Admin-Key": "test-admin-key"},
         json={
             "targetDayIndex": 4,
@@ -61,6 +61,26 @@ async def test_admin_day_window_control_route_maps_response(async_client, monkey
     assert payload["targetDayIndex"] == 4
     assert payload["auditId"] == "audit-day-window"
     assert payload["currentDayWindow"]["state"] == "active"
+    assert "Deprecation" not in response.headers
+    assert "Link" not in response.headers
+    assert "X-Winoe-Canonical-Resource" not in response.headers
+
+    legacy_response = await async_client.post(
+        "/api/admin/candidate_sessions/42/day_windows/control",
+        headers={"X-Admin-Key": "test-admin-key"},
+        json={
+            "targetDayIndex": 4,
+            "reason": "accelerate day 4",
+            "candidateTimezone": "America/New_York",
+        },
+    )
+    assert legacy_response.status_code == 200
+    assert legacy_response.json() == payload
+    assert legacy_response.headers["Deprecation"] == "true"
+    assert legacy_response.headers["X-Winoe-Canonical-Resource"] == "candidate_trials"
+    assert legacy_response.headers["Link"] == (
+        '</api/admin/candidate_trials/42/day_windows/control>; rel="successor-version"'
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/tasks/routes/test_tasks_run_run_tests_missing_headers_returns_401_routes.py
+++ b/tests/tasks/routes/test_tasks_run_run_tests_missing_headers_returns_401_routes.py
@@ -10,6 +10,7 @@ async def test_run_tests_missing_headers_returns_401(async_client):
     resp = await async_client.post("/api/tasks/1/run", json={})
     assert resp.status_code == 401
     assert resp.json()["detail"] in {
+        "Missing Candidate Trial headers",
         "Missing candidate session headers",
         "Not authenticated",
     }


### PR DESCRIPTION
## Summary

This PR adds canonical Candidate Trial route/resource naming while preserving legacy `candidate_sessions` / `candidate/session` compatibility aliases. It adds legacy deprecation headers for both success and error responses, supports canonical `x-candidate-trial-id` while preserving legacy `x-candidate-session-id`, and migrates new media upload keys from `candidate-sessions/...` to `candidate-trials/...`.

Legacy persisted media keys remain readable/deletable, Winoe Report ownership copy now uses Candidate Trial terminology, and docs now prefer `x-candidate-trial-id` for task auth.

## Issue / Acceptance Criteria

Closes #304

- Consistent Winoe terminology: canonical API routes, docs, auth wording, and Winoe Report ownership copy now use Candidate Trial terminology.
- Media storage key migration: new uploads use `candidate-trials/...` keys.
- Backward compatibility aliases/deprecation behavior: legacy route aliases and legacy headers remain accepted and legacy route responses include deprecation metadata.
- Non-breaking migration: legacy routes still work, legacy headers still work, persisted DB names remain as the compatibility/persistence boundary, no destructive migration was added, and old media keys remain readable/deletable via persisted `storage_key`.

## Implementation Details

### Routes

Canonical routes added:

- `/api/candidate/trials/...`
- `/api/candidate_trials/{candidate_trial_id}/winoe_report`
- `/api/admin/candidate_trials/...`

Legacy aliases preserved:

- `/api/candidate/session/...`
- `/api/candidate_sessions/...`
- `/api/admin/candidate_sessions/...`

Legacy aliases include:

- `Deprecation: true`
- `X-Winoe-Canonical-Resource: candidate_trials`
- `Link: <canonical-path>; rel="successor-version"`

Middleware now applies those compatibility headers to legacy error responses, not just successful route responses.

### Headers

Task auth now supports canonical `x-candidate-trial-id` while preserving legacy `x-candidate-session-id`. Requests with either header are accepted, requests with both headers set to the same value are accepted, and mismatched values are rejected with `403`.

### Media

New upload keys use:

```text
candidate-trials/{candidate_trial_id}/tasks/{task_id}/recordings/...
```

Existing `candidate-sessions/...` rows remain readable/deletable because media workflows use the persisted `storage_key`.

### Docs

`README.md` and `docs/api.md` were regenerated/updated. Endpoint coverage is `62`, task auth docs now prefer `x-candidate-trial-id`, and `x-candidate-session-id` is documented only as legacy compatibility.

### Persistence Boundary

DB table/model names like `candidate_sessions` remain intentionally as persistence compatibility. No DB rename was attempted and no migration is required.

## QA Evidence

### Live backend QA

- `/health` returned `200 OK`.
- `/ready` returned `200 OK` after worker startup.
- Canonical and legacy Candidate Trial routes were exercised live.
- Legacy current-task error response returned `409` with deprecation headers.
- Canonical current-task error response returned the same domain response without deprecation headers.
- Legacy review incomplete-Trial response returned `409` with deprecation headers.
- Canonical review incomplete-Trial response returned the same domain response without deprecation headers.
- Winoe Report other-company access returned `403` with `Candidate Trial access forbidden`.
- Docs auth wording verified.
- Media upload init produced a canonical key:

```text
candidate-trials/<candidate_trial_id>/tasks/<task_id>/recordings/<uuid>.mp4
```

- Legacy persisted media key was readable/deletable:

```text
candidate-sessions/<candidate_trial_id>/tasks/<task_id>/recordings/qa304-legacy.mp4
```

### Automated tests

```bash
poetry run pytest --no-cov -q tests/candidates/routes/test_candidates_session_resolve_current_task_pre_start_returns_schedule_not_started_routes.py
# 1 passed

poetry run pytest --no-cov -q tests/candidates/routes/test_candidates_session_review_returns_completed_artifacts_routes.py
# 2 passed

poetry run pytest --no-cov -q tests/evaluations/routes/test_evaluations_winoe_report_api_auth_404_and_403_routes.py
# 1 passed

poetry run pytest --no-cov -q tests/shared/http/test_shared_http_app_internals_service.py
# 10 passed

poetry run pytest --no-cov -q tests/shared/http/routes/test_shared_http_routes_winoe_report_and_jobs_routes.py
# 5 passed

poetry run python code-quality/documentation/scripts/docs_api_export.py --strict --verify-doc README.md docs/api.md
# passed, 62/62 endpoints covered

poetry run ruff check .
# passed

./precommit.sh
# passed, 1833 passed, coverage 96.21%
```

Earlier broad focused suite evidence:

```bash
poetry run pytest --no-cov -q tests/candidates/routes tests/media/services tests/media/routes tests/evaluations/routes tests/talent_partners/routes tests/tasks/routes
# 325 passed

poetry run pytest --no-cov -q tests/core/db/migrations
# 46 passed
```

## Grep Verification

```bash
grep -rn "Candidate session access forbidden" app/ tests/ docs/ --exclude-dir=.venv --exclude-dir=__pycache__ || true
# no output

grep -rn "plus x-candidate-session-id" README.md docs/api.md code-quality/documentation app/ tests/ --exclude-dir=.venv --exclude-dir=__pycache__ || true
# no output

grep -rn "Auth: Candidate bearer token.*x-candidate-session-id" README.md docs/api.md --exclude-dir=.venv --exclude-dir=__pycache__ || true
# matches only canonical-first docs wording:
# Auth: Candidate bearer token (`candidate:access`) plus `x-candidate-trial-id`; legacy `x-candidate-session-id` is accepted during the compatibility window.
```

Broader grep posture:

- Remaining `candidate_sessions` hits are persistence boundary, compatibility aliases/tests, historical migrations, or explicitly documented legacy compatibility.
- No canonical route/storage-key path uses the old media prefix.
- New uploads use `candidate-trials/...`.

## Risk / Rollback

- Breaking-change risk: low, because legacy aliases and headers remain.
- Migration risk: low, because no destructive DB migration/table rename.
- Demo risk: low, because live route/header/media QA passed.
- Security risk: low, because auth checks and ownership enforcement remain unchanged.
- Rollback: revert PR; no irreversible schema/blob migration performed.

## Reviewer Notes

- Legacy aliases are intentionally aliases, not redirects, to avoid breaking POST/auth/header clients.
- Middleware applies compatibility headers to legacy error responses because route-level `Response` headers do not survive exception handling.
- Persistence names remain legacy internally by design to avoid risky schema churn.
- `candidate_sessions` error codes may remain for client compatibility, but user-facing detail text uses Candidate Trial terminology.

Fixes #304
