### PR TITLE
Implement media retention and purge scheduling

### DIFF
--- a/alembic/versions/202604200001_add_media_retention_purge_audits.py
+++ b/alembic/versions/202604200001_add_media_retention_purge_audits.py
@@ -1,0 +1,134 @@
+"""Add media retention purge metadata and audits.
+
+Revision ID: 202604200001
+Revises: 202604190001
+Create Date: 2026-04-20 00:01:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "202604200001"
+down_revision: str | Sequence[str] | None = "202604190001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def _backfill_retention_expires_at() -> None:
+    bind = op.get_bind()
+    dialect = bind.dialect.name
+    if dialect == "postgresql":
+        bind.execute(
+            sa.text(
+                """
+                UPDATE recording_assets
+                SET retention_expires_at = created_at + INTERVAL '30 days'
+                WHERE retention_expires_at IS NULL
+                """
+            )
+        )
+    elif dialect == "sqlite":
+        bind.execute(
+            sa.text(
+                """
+                UPDATE recording_assets
+                SET retention_expires_at = datetime(created_at, '+30 days')
+                WHERE retention_expires_at IS NULL
+                """
+            )
+        )
+    else:
+        bind.execute(
+            sa.text(
+                """
+                UPDATE recording_assets
+                SET retention_expires_at = created_at
+                WHERE retention_expires_at IS NULL
+                """
+            )
+        )
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("recording_assets") as batch_op:
+        batch_op.add_column(
+            sa.Column("retention_expires_at", sa.DateTime(timezone=True), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column("purge_reason", sa.String(length=50), nullable=True)
+        )
+        batch_op.add_column(
+            sa.Column("purge_status", sa.String(length=50), nullable=True)
+        )
+        batch_op.create_index(
+            "ix_recording_assets_retention_expires_purged",
+            ["retention_expires_at", "purged_at"],
+            unique=False,
+        )
+
+    _backfill_retention_expires_at()
+
+    op.create_table(
+        "media_purge_audits",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column("media_id", sa.Integer(), nullable=False),
+        sa.Column("candidate_session_id", sa.Integer(), nullable=True),
+        sa.Column("trial_id", sa.Integer(), nullable=True),
+        sa.Column("candidate_user_id", sa.Integer(), nullable=True),
+        sa.Column("actor_type", sa.String(length=50), nullable=False),
+        sa.Column("actor_id", sa.String(length=255), nullable=True),
+        sa.Column("purge_reason", sa.String(length=50), nullable=False),
+        sa.Column("outcome", sa.String(length=50), nullable=False),
+        sa.Column("error_summary", sa.Text(), nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+            server_default=sa.func.now(),
+        ),
+    )
+    op.create_index(
+        "ix_media_purge_audits_media_created_at",
+        "media_purge_audits",
+        ["media_id", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_media_purge_audits_reason_created_at",
+        "media_purge_audits",
+        ["purge_reason", "created_at"],
+        unique=False,
+    )
+    op.create_index(
+        "ix_media_purge_audits_candidate_session_created_at",
+        "media_purge_audits",
+        ["candidate_session_id", "created_at"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_media_purge_audits_candidate_session_created_at",
+        table_name="media_purge_audits",
+    )
+    op.drop_index(
+        "ix_media_purge_audits_reason_created_at",
+        table_name="media_purge_audits",
+    )
+    op.drop_index(
+        "ix_media_purge_audits_media_created_at",
+        table_name="media_purge_audits",
+    )
+    op.drop_table("media_purge_audits")
+
+    with op.batch_alter_table("recording_assets") as batch_op:
+        batch_op.drop_index("ix_recording_assets_retention_expires_purged")
+        batch_op.drop_column("purge_status")
+        batch_op.drop_column("purge_reason")
+        batch_op.drop_column("retention_expires_at")

--- a/app/media/repositories/purge_audits/__init__.py
+++ b/app/media/repositories/purge_audits/__init__.py
@@ -1,0 +1,27 @@
+from app.media.repositories.purge_audits.media_repositories_purge_audits_core_model import (
+    MEDIA_PURGE_ACTOR_OPERATOR,
+    MEDIA_PURGE_ACTOR_SYSTEM,
+    MEDIA_PURGE_OUTCOME_FAILED,
+    MEDIA_PURGE_OUTCOME_PARTIAL,
+    MEDIA_PURGE_OUTCOME_SKIPPED,
+    MEDIA_PURGE_OUTCOME_SUCCESS,
+    MEDIA_PURGE_REASON_DATA_REQUEST,
+    MEDIA_PURGE_REASON_RETENTION_EXPIRED,
+    MediaPurgeAudit,
+)
+from app.media.repositories.purge_audits.media_repositories_purge_audits_core_repository import (
+    create_audit,
+)
+
+__all__ = [
+    "MEDIA_PURGE_ACTOR_OPERATOR",
+    "MEDIA_PURGE_ACTOR_SYSTEM",
+    "MEDIA_PURGE_OUTCOME_FAILED",
+    "MEDIA_PURGE_OUTCOME_PARTIAL",
+    "MEDIA_PURGE_OUTCOME_SKIPPED",
+    "MEDIA_PURGE_OUTCOME_SUCCESS",
+    "MEDIA_PURGE_REASON_DATA_REQUEST",
+    "MEDIA_PURGE_REASON_RETENTION_EXPIRED",
+    "MediaPurgeAudit",
+    "create_audit",
+]

--- a/app/media/repositories/purge_audits/media_repositories_purge_audits_core_model.py
+++ b/app/media/repositories/purge_audits/media_repositories_purge_audits_core_model.py
@@ -1,0 +1,61 @@
+"""Media purge audit records."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from sqlalchemy import DateTime, Index, Integer, String, Text, func
+from sqlalchemy.orm import Mapped, mapped_column
+
+from app.shared.database.shared_database_base_model import Base
+
+MEDIA_PURGE_ACTOR_SYSTEM = "system"
+MEDIA_PURGE_ACTOR_OPERATOR = "operator"
+MEDIA_PURGE_REASON_RETENTION_EXPIRED = "retention_expired"
+MEDIA_PURGE_REASON_DATA_REQUEST = "data_request"
+MEDIA_PURGE_OUTCOME_SUCCESS = "success"
+MEDIA_PURGE_OUTCOME_PARTIAL = "partial"
+MEDIA_PURGE_OUTCOME_FAILED = "failed"
+MEDIA_PURGE_OUTCOME_SKIPPED = "skipped"
+
+
+class MediaPurgeAudit(Base):
+    """Privacy-safe audit record for media purge attempts."""
+
+    __tablename__ = "media_purge_audits"
+    __table_args__ = (
+        Index("ix_media_purge_audits_media_created_at", "media_id", "created_at"),
+        Index("ix_media_purge_audits_reason_created_at", "purge_reason", "created_at"),
+        Index(
+            "ix_media_purge_audits_candidate_session_created_at",
+            "candidate_session_id",
+            "created_at",
+        ),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    media_id: Mapped[int] = mapped_column(Integer, nullable=False)
+    candidate_session_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    trial_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    candidate_user_id: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    actor_type: Mapped[str] = mapped_column(String(50), nullable=False)
+    actor_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    purge_reason: Mapped[str] = mapped_column(String(50), nullable=False)
+    outcome: Mapped[str] = mapped_column(String(50), nullable=False)
+    error_summary: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, server_default=func.now()
+    )
+
+
+__all__ = [
+    "MEDIA_PURGE_ACTOR_OPERATOR",
+    "MEDIA_PURGE_ACTOR_SYSTEM",
+    "MEDIA_PURGE_OUTCOME_FAILED",
+    "MEDIA_PURGE_OUTCOME_PARTIAL",
+    "MEDIA_PURGE_OUTCOME_SKIPPED",
+    "MEDIA_PURGE_OUTCOME_SUCCESS",
+    "MEDIA_PURGE_REASON_DATA_REQUEST",
+    "MEDIA_PURGE_REASON_RETENTION_EXPIRED",
+    "MediaPurgeAudit",
+]

--- a/app/media/repositories/purge_audits/media_repositories_purge_audits_core_repository.py
+++ b/app/media/repositories/purge_audits/media_repositories_purge_audits_core_repository.py
@@ -1,0 +1,47 @@
+"""Repository helpers for media purge audit records."""
+
+from __future__ import annotations
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.media.repositories.purge_audits.media_repositories_purge_audits_core_model import (
+    MediaPurgeAudit,
+)
+
+
+async def create_audit(
+    db: AsyncSession,
+    *,
+    media_id: int,
+    candidate_session_id: int | None,
+    trial_id: int | None,
+    candidate_user_id: int | None,
+    actor_type: str,
+    actor_id: str | None,
+    purge_reason: str,
+    outcome: str,
+    error_summary: str | None = None,
+    commit: bool = False,
+) -> MediaPurgeAudit:
+    """Create a media purge audit record."""
+    audit = MediaPurgeAudit(
+        media_id=media_id,
+        candidate_session_id=candidate_session_id,
+        trial_id=trial_id,
+        candidate_user_id=candidate_user_id,
+        actor_type=actor_type,
+        actor_id=actor_id,
+        purge_reason=purge_reason,
+        outcome=outcome,
+        error_summary=error_summary,
+    )
+    db.add(audit)
+    if commit:
+        await db.commit()
+        await db.refresh(audit)
+    else:
+        await db.flush()
+    return audit
+
+
+__all__ = ["create_audit"]

--- a/app/media/repositories/recordings/__init__.py
+++ b/app/media/repositories/recordings/__init__.py
@@ -4,6 +4,8 @@ import app.media.repositories.recordings.media_repositories_recordings_media_rec
 import app.media.repositories.recordings.media_repositories_recordings_media_recordings_predicates_repository as repository_predicates
 import app.media.repositories.recordings.media_repositories_recordings_media_recordings_queries_repository as repository_queries
 from app.media.repositories.recordings.media_repositories_recordings_media_recordings_core_model import (
+    RECORDING_ASSET_PURGE_REASON_DATA_REQUEST,
+    RECORDING_ASSET_PURGE_REASON_RETENTION_EXPIRED,
     RECORDING_ASSET_STATUS_DELETED,
     RECORDING_ASSET_STATUS_FAILED,
     RECORDING_ASSET_STATUS_PROCESSING,
@@ -32,6 +34,8 @@ from app.media.repositories.recordings.media_repositories_recordings_media_recor
 
 __all__ = [
     "DOWNLOADABLE_RECORDING_STATUSES",
+    "RECORDING_ASSET_PURGE_REASON_DATA_REQUEST",
+    "RECORDING_ASSET_PURGE_REASON_RETENTION_EXPIRED",
     "RECORDING_ASSET_STATUSES",
     "RECORDING_ASSET_STATUS_DELETED",
     "RECORDING_ASSET_STATUS_FAILED",

--- a/app/media/repositories/recordings/media_repositories_recordings_media_recordings_core_model.py
+++ b/app/media/repositories/recordings/media_repositories_recordings_media_recordings_core_model.py
@@ -26,6 +26,11 @@ RECORDING_ASSET_STATUS_DELETED = "deleted"
 RECORDING_ASSET_STATUS_PURGED = "purged"
 RECORDING_ASSET_KIND_RECORDING = "recording"
 RECORDING_ASSET_KIND_SUPPLEMENTAL = "supplemental"
+RECORDING_ASSET_PURGE_STATUS_PENDING = "pending"
+RECORDING_ASSET_PURGE_STATUS_PURGED = "purged"
+RECORDING_ASSET_PURGE_STATUS_FAILED = "failed"
+RECORDING_ASSET_PURGE_REASON_RETENTION_EXPIRED = "retention_expired"
+RECORDING_ASSET_PURGE_REASON_DATA_REQUEST = "data_request"
 
 RECORDING_ASSET_STATUSES = (
     RECORDING_ASSET_STATUS_UPLOADING,
@@ -68,6 +73,11 @@ class RecordingAsset(Base, TimestampMixin):
         Index("ix_recording_assets_candidate_session_id", "candidate_session_id"),
         Index("ix_recording_assets_task_id", "task_id"),
         Index(
+            "ix_recording_assets_retention_expires_purged",
+            "retention_expires_at",
+            "purged_at",
+        ),
+        Index(
             "ix_recording_assets_candidate_session_task_kind",
             "candidate_session_id",
             "task_id",
@@ -103,6 +113,11 @@ class RecordingAsset(Base, TimestampMixin):
     purged_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    retention_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    purge_reason: Mapped[str | None] = mapped_column(String(50), nullable=True)
+    purge_status: Mapped[str | None] = mapped_column(String(50), nullable=True)
     consent_version: Mapped[str | None] = mapped_column(String(100), nullable=True)
     consent_timestamp: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
@@ -125,6 +140,11 @@ __all__ = [
     "RECORDING_ASSET_STATUS_PURGED",
     "RECORDING_ASSET_KIND_RECORDING",
     "RECORDING_ASSET_KIND_SUPPLEMENTAL",
+    "RECORDING_ASSET_PURGE_STATUS_PENDING",
+    "RECORDING_ASSET_PURGE_STATUS_PURGED",
+    "RECORDING_ASSET_PURGE_STATUS_FAILED",
+    "RECORDING_ASSET_PURGE_REASON_RETENTION_EXPIRED",
+    "RECORDING_ASSET_PURGE_REASON_DATA_REQUEST",
     "RECORDING_ASSET_STATUSES",
     "RECORDING_ASSET_STATUS_CHECK_CONSTRAINT_NAME",
     "RECORDING_ASSET_STORAGE_KEY_UNIQUE_CONSTRAINT_NAME",

--- a/app/media/repositories/recordings/media_repositories_recordings_media_recordings_core_repository.py
+++ b/app/media/repositories/recordings/media_repositories_recordings_media_recordings_core_repository.py
@@ -18,6 +18,7 @@ from .media_repositories_recordings_media_recordings_queries_repository import (
     get_expired_for_retention,
     get_latest_for_task_session,
     get_latest_playback_safe_for_task_session,
+    list_for_candidate_session,
     list_for_task_session,
 )
 
@@ -29,6 +30,7 @@ __all__ = [
     "get_by_id_for_update",
     "get_latest_for_task_session",
     "get_latest_playback_safe_for_task_session",
+    "list_for_candidate_session",
     "list_for_task_session",
     "is_deleted_or_purged",
     "is_downloadable",

--- a/app/media/repositories/recordings/media_repositories_recordings_media_recordings_mutations_repository.py
+++ b/app/media/repositories/recordings/media_repositories_recordings_media_recordings_mutations_repository.py
@@ -8,6 +8,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.media.repositories.recordings.media_repositories_recordings_media_recordings_core_model import (
     RECORDING_ASSET_KIND_RECORDING,
+    RECORDING_ASSET_PURGE_STATUS_PURGED,
     RECORDING_ASSET_STATUS_DELETED,
     RECORDING_ASSET_STATUS_PURGED,
     RecordingAsset,
@@ -28,6 +29,7 @@ async def create_recording_asset(
     consent_version: str | None = None,
     consent_timestamp: datetime | None = None,
     ai_notice_version: str | None = None,
+    retention_expires_at: datetime | None = None,
     created_at: datetime | None = None,
     commit: bool = True,
 ) -> RecordingAsset:
@@ -44,6 +46,7 @@ async def create_recording_asset(
         consent_version=consent_version,
         consent_timestamp=consent_timestamp,
         ai_notice_version=ai_notice_version,
+        retention_expires_at=retention_expires_at,
         created_at=created_at or datetime.now(UTC),
     )
     db.add(recording)
@@ -98,6 +101,7 @@ async def mark_purged(
     db: AsyncSession,
     *,
     recording: RecordingAsset,
+    purge_reason: str,
     now: datetime | None = None,
     commit: bool = True,
 ) -> RecordingAsset:
@@ -108,6 +112,8 @@ async def mark_purged(
     if recording.purged_at is None:
         recording.purged_at = resolved_now
     recording.status = RECORDING_ASSET_STATUS_PURGED
+    recording.purge_reason = purge_reason
+    recording.purge_status = RECORDING_ASSET_PURGE_STATUS_PURGED
     if commit:
         await db.commit()
         await db.refresh(recording)

--- a/app/media/repositories/recordings/media_repositories_recordings_media_recordings_queries_repository.py
+++ b/app/media/repositories/recordings/media_repositories_recordings_media_recordings_queries_repository.py
@@ -9,6 +9,10 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.media.repositories.recordings.media_repositories_recordings_media_recordings_core_model import (
     RECORDING_ASSET_KIND_RECORDING,
+    RECORDING_ASSET_STATUS_DELETED,
+    RECORDING_ASSET_STATUS_FAILED,
+    RECORDING_ASSET_STATUS_READY,
+    RECORDING_ASSET_STATUS_UPLOADED,
     RecordingAsset,
 )
 from app.media.repositories.recordings.media_repositories_recordings_media_recordings_predicates_repository import (
@@ -103,11 +107,49 @@ async def get_expired_for_retention(
     limit: int = 200,
 ) -> list[RecordingAsset]:
     """Return expired for retention."""
-    cutoff = (now or datetime.now(UTC)) - timedelta(days=max(1, int(retention_days)))
+    resolved_now = now or datetime.now(UTC)
+    cutoff = resolved_now - timedelta(days=max(1, int(retention_days)))
     stmt = (
         select(RecordingAsset)
-        .where(RecordingAsset.created_at <= cutoff, RecordingAsset.purged_at.is_(None))
+        .where(
+            RecordingAsset.purged_at.is_(None),
+            RecordingAsset.status.in_(
+                (
+                    RECORDING_ASSET_STATUS_UPLOADED,
+                    RECORDING_ASSET_STATUS_READY,
+                    RECORDING_ASSET_STATUS_FAILED,
+                    RECORDING_ASSET_STATUS_DELETED,
+                )
+            ),
+            (
+                (RecordingAsset.retention_expires_at.is_not(None))
+                & (RecordingAsset.retention_expires_at <= resolved_now)
+            )
+            | (
+                (RecordingAsset.retention_expires_at.is_(None))
+                & (RecordingAsset.created_at <= cutoff)
+            ),
+        )
         .order_by(RecordingAsset.created_at.asc(), RecordingAsset.id.asc())
         .limit(max(1, int(limit)))
     )
+    return (await db.execute(stmt)).scalars().all()
+
+
+async def list_for_candidate_session(
+    db: AsyncSession,
+    *,
+    candidate_session_id: int,
+    include_purged: bool = False,
+    limit: int = 500,
+) -> list[RecordingAsset]:
+    """Return media assets scoped to a Candidate session."""
+    stmt = select(RecordingAsset).where(
+        RecordingAsset.candidate_session_id == candidate_session_id
+    )
+    if not include_purged:
+        stmt = stmt.where(RecordingAsset.purged_at.is_(None))
+    stmt = stmt.order_by(
+        RecordingAsset.created_at.asc(), RecordingAsset.id.asc()
+    ).limit(max(1, int(limit)))
     return (await db.execute(stmt)).scalars().all()

--- a/app/media/repositories/transcripts/__init__.py
+++ b/app/media/repositories/transcripts/__init__.py
@@ -18,6 +18,7 @@ from app.media.repositories.transcripts.media_repositories_transcripts_media_tra
     get_or_create_transcript,
     hard_delete_by_recording_id,
     mark_deleted,
+    redact_by_recording_id,
     update_status,
     update_transcript,
 )
@@ -31,6 +32,7 @@ __all__ = [
     "Transcript",
     "create_transcript",
     "hard_delete_by_recording_id",
+    "redact_by_recording_id",
     "get_by_recording_id",
     "get_or_create_transcript",
     "mark_deleted",

--- a/app/media/repositories/transcripts/media_repositories_transcripts_media_transcripts_core_repository.py
+++ b/app/media/repositories/transcripts/media_repositories_transcripts_media_transcripts_core_repository.py
@@ -4,6 +4,7 @@ from .media_repositories_transcripts_media_transcripts_create_repository import 
 )
 from .media_repositories_transcripts_media_transcripts_delete_repository import (
     hard_delete_by_recording_id,
+    redact_by_recording_id,
 )
 from .media_repositories_transcripts_media_transcripts_lookup_repository import (
     TRANSCRIPT_EVALUATION_STATE_EMPTY,
@@ -24,6 +25,7 @@ from .media_repositories_transcripts_media_transcripts_update_repository import 
 __all__ = [
     "create_transcript",
     "hard_delete_by_recording_id",
+    "redact_by_recording_id",
     "get_by_recording_id",
     "get_or_create_transcript",
     "mark_deleted",

--- a/app/media/repositories/transcripts/media_repositories_transcripts_media_transcripts_delete_repository.py
+++ b/app/media/repositories/transcripts/media_repositories_transcripts_media_transcripts_delete_repository.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
-from sqlalchemy import delete
+from datetime import UTC, datetime
+
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.media.repositories.transcripts.media_repositories_transcripts_media_transcripts_core_model import (
@@ -24,3 +26,32 @@ async def hard_delete_by_recording_id(
     if commit:
         await db.commit()
     return deleted_count
+
+
+async def redact_by_recording_id(
+    db: AsyncSession,
+    recording_id: int,
+    *,
+    now: datetime | None = None,
+    commit: bool = True,
+) -> int:
+    """Redact transcript content for a purged recording while keeping audit shape."""
+    existing = (
+        await db.execute(
+            select(Transcript).where(Transcript.recording_id == recording_id)
+        )
+    ).scalar_one_or_none()
+    if existing is None:
+        return 0
+    resolved_now = now or datetime.now(UTC)
+    existing.text = None
+    existing.segments_json = None
+    existing.last_error = None
+    if existing.deleted_at is None:
+        existing.deleted_at = resolved_now
+    if commit:
+        await db.commit()
+        await db.refresh(existing)
+    else:
+        await db.flush()
+    return 1

--- a/app/media/services/media_services_media_handoff_upload_complete_service.py
+++ b/app/media/services/media_services_media_handoff_upload_complete_service.py
@@ -39,6 +39,7 @@ from app.media.services.media_services_media_handoff_upload_validation_service i
     require_recording_access,
 )
 from app.media.services.media_services_media_privacy_service import (
+    compute_media_retention_expires_at,
     require_media_consent,
 )
 from app.media.services.media_services_media_transcription_jobs_service import (
@@ -99,6 +100,10 @@ async def complete_handoff_upload(
                 actual_duration_seconds=object_metadata.duration_seconds
             )
         recording.status = RECORDING_ASSET_STATUS_UPLOADED
+    if recording.retention_expires_at is None:
+        recording.retention_expires_at = compute_media_retention_expires_at(
+            datetime.now(UTC)
+        )
     transcript = None
     transcript_created = False
     job = None

--- a/app/media/services/media_services_media_privacy_model.py
+++ b/app/media/services/media_services_media_privacy_model.py
@@ -11,5 +11,6 @@ class MediaRetentionPurgeResult:
 
     scanned_count: int
     purged_count: int
+    skipped_count: int
     failed_count: int
     purged_recording_ids: list[int]

--- a/app/media/services/media_services_media_privacy_purge_service.py
+++ b/app/media/services/media_services_media_privacy_purge_service.py
@@ -3,24 +3,204 @@
 from __future__ import annotations
 
 import logging
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.candidates.candidate_sessions.repositories.candidates_candidate_sessions_repositories_candidates_candidate_sessions_candidate_session_model import (
+    CandidateSession,
+)
 from app.config import settings
 from app.integrations.storage_media import StorageMediaProvider
 from app.integrations.storage_media.integrations_storage_media_storage_media_base_client import (
     StorageMediaError,
 )
+from app.media.repositories.purge_audits import (
+    MEDIA_PURGE_ACTOR_OPERATOR,
+    MEDIA_PURGE_ACTOR_SYSTEM,
+    MEDIA_PURGE_OUTCOME_FAILED,
+    MEDIA_PURGE_OUTCOME_SKIPPED,
+    MEDIA_PURGE_OUTCOME_SUCCESS,
+)
+from app.media.repositories.purge_audits import (
+    create_audit as create_purge_audit,
+)
 from app.media.repositories.recordings import repository as recordings_repo
 from app.media.repositories.recordings.media_repositories_recordings_media_recordings_core_model import (
+    RECORDING_ASSET_PURGE_REASON_DATA_REQUEST,
+    RECORDING_ASSET_PURGE_REASON_RETENTION_EXPIRED,
+    RECORDING_ASSET_PURGE_STATUS_FAILED,
     RECORDING_ASSET_STATUS_PURGED,
+    RecordingAsset,
 )
 from app.media.repositories.transcripts import repository as transcripts_repo
 
 from .media_services_media_privacy_model import MediaRetentionPurgeResult
 
 logger = logging.getLogger("app.media.services.media_services_media_privacy_service")
+
+_SAFE_ERROR_MAX_LENGTH = 255
+
+
+def compute_media_retention_expires_at(
+    anchor: datetime | None = None, *, retention_days: int | None = None
+) -> datetime:
+    """Return the expiration timestamp for a media retention policy."""
+    resolved_anchor = anchor or datetime.now(UTC)
+    resolved_days = int(retention_days or settings.storage_media.MEDIA_RETENTION_DAYS)
+    if resolved_days <= 0:
+        raise ValueError("MEDIA_RETENTION_DAYS must be > 0")
+    return resolved_anchor + timedelta(days=resolved_days)
+
+
+def _safe_error_summary(exc: Exception) -> str:
+    return " ".join(str(exc).split())[:_SAFE_ERROR_MAX_LENGTH]
+
+
+async def _candidate_context(
+    db: AsyncSession, candidate_session_id: int | None
+) -> tuple[int | None, int | None]:
+    if candidate_session_id is None:
+        return None, None
+    candidate_session = await db.get(CandidateSession, candidate_session_id)
+    if candidate_session is None:
+        return None, None
+    return candidate_session.trial_id, candidate_session.candidate_user_id
+
+
+async def _write_audit(
+    db: AsyncSession,
+    *,
+    recording: RecordingAsset,
+    actor_type: str,
+    actor_id: str | None,
+    purge_reason: str,
+    outcome: str,
+    error_summary: str | None = None,
+) -> None:
+    candidate_session_id = getattr(recording, "candidate_session_id", None)
+    trial_id, candidate_user_id = await _candidate_context(db, candidate_session_id)
+    await create_purge_audit(
+        db,
+        media_id=recording.id,
+        candidate_session_id=candidate_session_id,
+        trial_id=trial_id,
+        candidate_user_id=candidate_user_id,
+        actor_type=actor_type,
+        actor_id=actor_id,
+        purge_reason=purge_reason,
+        outcome=outcome,
+        error_summary=error_summary,
+        commit=False,
+    )
+
+
+async def _purge_recording(
+    db: AsyncSession,
+    *,
+    recording_id: int,
+    storage_provider: StorageMediaProvider,
+    purge_reason: str,
+    actor_type: str,
+    actor_id: str | None,
+    now: datetime,
+) -> tuple[bool, bool]:
+    recording = await recordings_repo.get_by_id_for_update(db, recording_id)
+    if recording is None:
+        return False, True
+    if (
+        recording.purged_at is not None
+        or recording.status == RECORDING_ASSET_STATUS_PURGED
+    ):
+        await _write_audit(
+            db,
+            recording=recording,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            purge_reason=purge_reason,
+            outcome=MEDIA_PURGE_OUTCOME_SKIPPED,
+        )
+        await db.commit()
+        return False, True
+    try:
+        storage_provider.delete_object(recording.storage_key)
+        if (
+            purge_reason == RECORDING_ASSET_PURGE_REASON_RETENTION_EXPIRED
+            and recording.retention_expires_at is None
+        ):
+            recording.retention_expires_at = now
+        await transcripts_repo.redact_by_recording_id(
+            db, recording.id, now=now, commit=False
+        )
+        await recordings_repo.mark_purged(
+            db,
+            recording=recording,
+            purge_reason=purge_reason,
+            now=now,
+            commit=False,
+        )
+        await _write_audit(
+            db,
+            recording=recording,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            purge_reason=purge_reason,
+            outcome=MEDIA_PURGE_OUTCOME_SUCCESS,
+        )
+        await db.commit()
+        logger.info(
+            "media_purge_event outcome=success mediaId=%s reason=%s",
+            recording.id,
+            purge_reason,
+        )
+        return True, False
+    except StorageMediaError as exc:
+        await db.rollback()
+        recording = await recordings_repo.get_by_id_for_update(db, recording_id)
+        if recording is not None:
+            recording.purge_reason = purge_reason
+            recording.purge_status = RECORDING_ASSET_PURGE_STATUS_FAILED
+            error_summary = _safe_error_summary(exc)
+            await _write_audit(
+                db,
+                recording=recording,
+                actor_type=actor_type,
+                actor_id=actor_id,
+                purge_reason=purge_reason,
+                outcome=MEDIA_PURGE_OUTCOME_FAILED,
+                error_summary=error_summary,
+            )
+            await db.commit()
+        logger.warning(
+            "media_purge_event outcome=failed mediaId=%s reason=%s error=%s",
+            recording_id,
+            purge_reason,
+            _safe_error_summary(exc),
+        )
+        return False, False
+    except Exception as exc:
+        await db.rollback()
+        recording = await recordings_repo.get_by_id_for_update(db, recording_id)
+        if recording is not None:
+            recording.purge_reason = purge_reason
+            recording.purge_status = RECORDING_ASSET_PURGE_STATUS_FAILED
+            await _write_audit(
+                db,
+                recording=recording,
+                actor_type=actor_type,
+                actor_id=actor_id,
+                purge_reason=purge_reason,
+                outcome=MEDIA_PURGE_OUTCOME_FAILED,
+                error_summary=type(exc).__name__,
+            )
+            await db.commit()
+        logger.warning(
+            "media_purge_event outcome=failed mediaId=%s reason=%s errorType=%s",
+            recording_id,
+            purge_reason,
+            type(exc).__name__,
+        )
+        return False, False
 
 
 async def purge_expired_media_assets(
@@ -30,6 +210,8 @@ async def purge_expired_media_assets(
     retention_days: int | None = None,
     batch_limit: int = 200,
     now: datetime | None = None,
+    actor_type: str = MEDIA_PURGE_ACTOR_SYSTEM,
+    actor_id: str | None = None,
 ) -> MediaRetentionPurgeResult:
     """Purge expired media assets."""
     resolved_now = now or datetime.now(UTC)
@@ -44,43 +226,83 @@ async def purge_expired_media_assets(
     )
 
     purged_recording_ids: list[int] = []
+    skipped_count = 0
     failed_count = 0
     for candidate in candidates:
-        try:
-            recording = await recordings_repo.get_by_id_for_update(db, candidate.id)
-            if (
-                recording is None
-                or recording.purged_at is not None
-                or recording.status == RECORDING_ASSET_STATUS_PURGED
-            ):
-                await db.rollback()
-                continue
-            storage_provider.delete_object(recording.storage_key)
-            await transcripts_repo.hard_delete_by_recording_id(
-                db, recording.id, commit=False
-            )
-            await recordings_repo.mark_purged(
-                db, recording=recording, now=resolved_now, commit=False
-            )
-            await db.commit()
-            purged_recording_ids.append(recording.id)
-            logger.info("purge executed recordingId=%s", recording.id)
-        except StorageMediaError as exc:
-            await db.rollback()
+        purged, skipped = await _purge_recording(
+            db,
+            recording_id=candidate.id,
+            storage_provider=storage_provider,
+            purge_reason=RECORDING_ASSET_PURGE_REASON_RETENTION_EXPIRED,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            now=resolved_now,
+        )
+        if purged:
+            purged_recording_ids.append(candidate.id)
+        elif skipped:
+            skipped_count += 1
+        else:
             failed_count += 1
-            logger.warning(
-                "purge failed recordingId=%s reason=%s",
-                candidate.id,
-                " ".join(str(exc).split())[:255],
-            )
-        except Exception:
-            await db.rollback()
-            failed_count += 1
-            logger.exception("purge failed recordingId=%s", candidate.id)
 
     return MediaRetentionPurgeResult(
         scanned_count=len(candidates),
         purged_count=len(purged_recording_ids),
+        skipped_count=skipped_count,
         failed_count=failed_count,
         purged_recording_ids=purged_recording_ids,
     )
+
+
+async def purge_candidate_session_media_for_data_request(
+    db: AsyncSession,
+    *,
+    candidate_session_id: int,
+    storage_provider: StorageMediaProvider,
+    actor_type: str = MEDIA_PURGE_ACTOR_OPERATOR,
+    actor_id: str | None = None,
+    batch_limit: int = 500,
+    now: datetime | None = None,
+) -> MediaRetentionPurgeResult:
+    """Purge media for a Candidate data deletion request."""
+    resolved_now = now or datetime.now(UTC)
+    recordings = await recordings_repo.list_for_candidate_session(
+        db,
+        candidate_session_id=candidate_session_id,
+        include_purged=False,
+        limit=batch_limit,
+    )
+    purged_recording_ids: list[int] = []
+    skipped_count = 0
+    failed_count = 0
+    for recording in recordings:
+        purged, skipped = await _purge_recording(
+            db,
+            recording_id=recording.id,
+            storage_provider=storage_provider,
+            purge_reason=RECORDING_ASSET_PURGE_REASON_DATA_REQUEST,
+            actor_type=actor_type,
+            actor_id=actor_id,
+            now=resolved_now,
+        )
+        if purged:
+            purged_recording_ids.append(recording.id)
+        elif skipped:
+            skipped_count += 1
+        else:
+            failed_count += 1
+
+    return MediaRetentionPurgeResult(
+        scanned_count=len(recordings),
+        purged_count=len(purged_recording_ids),
+        skipped_count=skipped_count,
+        failed_count=failed_count,
+        purged_recording_ids=purged_recording_ids,
+    )
+
+
+__all__ = [
+    "compute_media_retention_expires_at",
+    "purge_candidate_session_media_for_data_request",
+    "purge_expired_media_assets",
+]

--- a/app/media/services/media_services_media_privacy_service.py
+++ b/app/media/services/media_services_media_privacy_service.py
@@ -10,11 +10,17 @@ from .media_services_media_privacy_consent_service import (
 )
 from .media_services_media_privacy_delete_service import delete_recording_asset
 from .media_services_media_privacy_model import MediaRetentionPurgeResult
-from .media_services_media_privacy_purge_service import purge_expired_media_assets
+from .media_services_media_privacy_purge_service import (
+    compute_media_retention_expires_at,
+    purge_candidate_session_media_for_data_request,
+    purge_expired_media_assets,
+)
 
 __all__ = [
     "MediaRetentionPurgeResult",
+    "compute_media_retention_expires_at",
     "delete_recording_asset",
+    "purge_candidate_session_media_for_data_request",
     "purge_expired_media_assets",
     "record_candidate_session_consent",
     "recordings_repo",

--- a/app/media/services/media_services_media_retention_jobs_service.py
+++ b/app/media/services/media_services_media_retention_jobs_service.py
@@ -1,0 +1,33 @@
+"""Shared job helpers for media retention purge."""
+
+from __future__ import annotations
+
+from app.config import settings
+
+MEDIA_RETENTION_PURGE_JOB_TYPE = "media_retention_purge"
+MEDIA_RETENTION_PURGE_MAX_ATTEMPTS = 3
+
+
+def media_retention_purge_idempotency_key() -> str:
+    """Return stable idempotency key for the singleton retention purge job."""
+    return "media_retention_purge:global"
+
+
+def build_media_retention_purge_payload(
+    *, batch_limit: int = 200, retention_days: int | None = None
+) -> dict[str, int]:
+    """Build a privacy-safe media retention purge job payload."""
+    payload = {"batchLimit": max(1, int(batch_limit))}
+    if retention_days is not None:
+        payload["retentionDays"] = int(retention_days)
+    else:
+        payload["retentionDays"] = int(settings.storage_media.MEDIA_RETENTION_DAYS)
+    return payload
+
+
+__all__ = [
+    "MEDIA_RETENTION_PURGE_JOB_TYPE",
+    "MEDIA_RETENTION_PURGE_MAX_ATTEMPTS",
+    "build_media_retention_purge_payload",
+    "media_retention_purge_idempotency_key",
+]

--- a/app/shared/database/shared_database_models_model.py
+++ b/app/shared/database/shared_database_models_model.py
@@ -10,6 +10,9 @@ from app.evaluations.repositories.evaluations_repositories_evaluations_core_mode
 from app.evaluations.repositories.evaluations_repositories_evaluations_rubric_snapshot_model import (
     WinoeRubricSnapshot,
 )
+from app.media.repositories.purge_audits.media_repositories_purge_audits_core_model import (
+    MediaPurgeAudit,
+)
 from app.media.repositories.recordings.media_repositories_recordings_media_recordings_core_model import (
     RecordingAsset,
 )
@@ -69,6 +72,7 @@ __all__ = [
     "EvaluationReviewerReport",
     "WinoeRubricSnapshot",
     "Job",
+    "MediaPurgeAudit",
     "NotificationDeliveryAudit",
     "WorkerHeartbeat",
     "RecordingAsset",

--- a/app/shared/jobs/handlers/__init__.py
+++ b/app/shared/jobs/handlers/__init__.py
@@ -10,6 +10,7 @@ import app.shared.jobs.handlers.shared_jobs_handlers_evaluation_run_handler as e
 import app.shared.jobs.handlers.shared_jobs_handlers_github_workflow_artifact_parse_handler as github_workflow_artifact_parse
 import app.shared.jobs.handlers.shared_jobs_handlers_github_workflow_artifact_parse_payload_handler as github_workflow_artifact_parse_payload
 import app.shared.jobs.handlers.shared_jobs_handlers_github_workflow_artifact_parse_persist_handler as github_workflow_artifact_parse_persist
+import app.shared.jobs.handlers.shared_jobs_handlers_media_retention_purge_handler as media_retention_purge
 import app.shared.jobs.handlers.shared_jobs_handlers_notifications_talent_partner_updates_handler as notifications_talent_partner_updates
 import app.shared.jobs.handlers.shared_jobs_handlers_scenario_generation_handler as scenario_generation
 import app.shared.jobs.handlers.shared_jobs_handlers_scenario_generation_parse_handler as scenario_generation_parse
@@ -45,6 +46,10 @@ from app.shared.jobs.handlers.shared_jobs_handlers_github_workflow_artifact_pars
     GITHUB_WORKFLOW_ARTIFACT_PARSE_JOB_TYPE,
     handle_github_workflow_artifact_parse,
 )
+from app.shared.jobs.handlers.shared_jobs_handlers_media_retention_purge_handler import (
+    MEDIA_RETENTION_PURGE_JOB_TYPE,
+    handle_media_retention_purge,
+)
 from app.shared.jobs.handlers.shared_jobs_handlers_notifications_talent_partner_updates_handler import (
     CANDIDATE_COMPLETED_NOTIFICATION_JOB_TYPE,
     WINOE_REPORT_READY_NOTIFICATION_JOB_TYPE,
@@ -77,6 +82,8 @@ __all__ = [
     "handle_evaluation_run",
     "GITHUB_WORKFLOW_ARTIFACT_PARSE_JOB_TYPE",
     "handle_github_workflow_artifact_parse",
+    "MEDIA_RETENTION_PURGE_JOB_TYPE",
+    "handle_media_retention_purge",
     "CANDIDATE_COMPLETED_NOTIFICATION_JOB_TYPE",
     "WINOE_REPORT_READY_NOTIFICATION_JOB_TYPE",
     "handle_candidate_completed_notification",
@@ -101,6 +108,7 @@ __all__ = [
     "github_workflow_artifact_parse",
     "github_workflow_artifact_parse_payload",
     "github_workflow_artifact_parse_persist",
+    "media_retention_purge",
     "notifications_talent_partner_updates",
     "scenario_generation",
     "scenario_generation_parse",

--- a/app/shared/jobs/handlers/shared_jobs_handlers_media_retention_purge_handler.py
+++ b/app/shared/jobs/handlers/shared_jobs_handlers_media_retention_purge_handler.py
@@ -1,0 +1,37 @@
+"""Worker handler for media retention purge jobs."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from app.integrations.storage_media import get_storage_media_provider
+from app.media.services.media_services_media_privacy_service import (
+    purge_expired_media_assets,
+)
+from app.media.services.media_services_media_retention_jobs_service import (
+    MEDIA_RETENTION_PURGE_JOB_TYPE,
+)
+from app.shared.database import async_session_maker
+from app.shared.utils.shared_utils_parsing_utils import parse_positive_int
+
+
+async def handle_media_retention_purge(payload_json: dict[str, Any]) -> dict[str, Any]:
+    """Run media retention purge through the shared worker."""
+    retention_days = parse_positive_int(payload_json.get("retentionDays"))
+    batch_limit = parse_positive_int(payload_json.get("batchLimit")) or 200
+    async with async_session_maker() as db:
+        result = await purge_expired_media_assets(
+            db,
+            storage_provider=get_storage_media_provider(),
+            retention_days=retention_days,
+            batch_limit=batch_limit,
+        )
+    return {
+        "scannedCount": result.scanned_count,
+        "purgedCount": result.purged_count,
+        "skippedCount": result.skipped_count,
+        "failedCount": result.failed_count,
+    }
+
+
+__all__ = ["MEDIA_RETENTION_PURGE_JOB_TYPE", "handle_media_retention_purge"]

--- a/app/shared/jobs/worker_runtime/shared_jobs_worker_runtime_registry_service.py
+++ b/app/shared/jobs/worker_runtime/shared_jobs_worker_runtime_registry_service.py
@@ -45,6 +45,7 @@ def register_builtin_handlers() -> None:
         DAY_CLOSE_FINALIZE_TEXT_JOB_TYPE,
         EVALUATION_RUN_JOB_TYPE,
         GITHUB_WORKFLOW_ARTIFACT_PARSE_JOB_TYPE,
+        MEDIA_RETENTION_PURGE_JOB_TYPE,
         SCENARIO_GENERATION_JOB_TYPE,
         TRANSCRIBE_RECORDING_JOB_TYPE,
         TRIAL_CLEANUP_JOB_TYPE,
@@ -55,6 +56,7 @@ def register_builtin_handlers() -> None:
         handle_day_close_finalize_text,
         handle_evaluation_run,
         handle_github_workflow_artifact_parse,
+        handle_media_retention_purge,
         handle_scenario_generation,
         handle_transcribe_recording,
         handle_trial_cleanup,
@@ -81,6 +83,7 @@ def register_builtin_handlers() -> None:
     )
     register_handler(SCENARIO_GENERATION_JOB_TYPE, handle_scenario_generation)
     register_handler(TRANSCRIBE_RECORDING_JOB_TYPE, handle_transcribe_recording)
+    register_handler(MEDIA_RETENTION_PURGE_JOB_TYPE, handle_media_retention_purge)
 
 
 __all__ = [

--- a/app/talent_partners/routes/admin_routes/talent_partners_routes_admin_routes_talent_partners_admin_routes_demo_ops_responses_routes.py
+++ b/app/talent_partners/routes/admin_routes/talent_partners_routes_admin_routes_talent_partners_admin_routes_demo_ops_responses_routes.py
@@ -46,6 +46,7 @@ def build_media_purge_response(result) -> MediaRetentionPurgeResponse:
         status="ok",
         scannedCount=result.scanned_count,
         purgedCount=result.purged_count,
+        skippedCount=getattr(result, "skipped_count", 0),
         failedCount=result.failed_count,
         purgedRecordingIds=result.purged_recording_ids,
     )

--- a/app/talent_partners/routes/admin_routes/talent_partners_routes_admin_routes_talent_partners_admin_routes_demo_ops_routes.py
+++ b/app/talent_partners/routes/admin_routes/talent_partners_routes_admin_routes_talent_partners_admin_routes_demo_ops_routes.py
@@ -8,6 +8,7 @@ from fastapi import APIRouter, Depends, Path, Request, Response, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from app.integrations.storage_media import StorageMediaProvider
+from app.media.repositories.purge_audits import MEDIA_PURGE_ACTOR_OPERATOR
 from app.media.services.media_services_media_privacy_service import (
     purge_expired_media_assets,
 )
@@ -198,12 +199,13 @@ async def purge_media_retention(
     ],
 ) -> MediaRetentionPurgeResponse:
     """Purge media retention."""
-    del actor
     result = await purge_expired_media_assets(
         db,
         storage_provider=storage_provider,
         retention_days=payload.retentionDays,
         batch_limit=payload.batchLimit,
+        actor_type=MEDIA_PURGE_ACTOR_OPERATOR,
+        actor_id=getattr(actor, "actor_id", None),
     )
     return build_media_purge_response(result)
 

--- a/app/talent_partners/schemas/talent_partners_schemas_talent_partners_admin_ops_schema.py
+++ b/app/talent_partners/schemas/talent_partners_schemas_talent_partners_admin_ops_schema.py
@@ -110,6 +110,7 @@ class MediaRetentionPurgeResponse(APIModel):
     status: Literal["ok"]
     scannedCount: int
     purgedCount: int
+    skippedCount: int = 0
     failedCount: int
     purgedRecordingIds: list[int]
 

--- a/pr.md
+++ b/pr.md
@@ -1,101 +1,236 @@
-# PR: Add operator endpoints for failed jobs and retry controls
-
 ## Summary
 
-- Adds admin-only operator visibility for failed background jobs so production and demo operators can inspect failures without reading worker logs or raw job payloads.
-- Adds retry controls for dead-letter jobs, including safe state transition back to `queued`.
-- Surfaces safe, human-readable failure summaries on Trial detail through `backgroundFailures`.
-- Extends local/dev admin QA support with real DB-backed admin users while preserving production JWT/Auth0 admin role behavior.
-- Covers auth, retry behavior, redaction, Trial scoping, and route/detail regressions with focused and full-suite tests.
+Implement policy-driven media retention and purge scheduling for Day 4 media artifacts.
 
-## What Changed
+This PR adds configurable retention metadata, an expired-media purge path, privacy-safe purge audit records, and a scoped data-request deletion hook. The purge flow redacts transcript content while preserving auditability and Evidence Trail shape.
 
-- Added `GET /api/admin/jobs/failed` to list failed and dead-letter background jobs for admins.
-- Added `POST /api/admin/jobs/{job_id}/retry` to retry retryable dead-letter jobs.
-- Added safe failure reason summaries that avoid exposing secrets, stack traces, bearer tokens, API keys, GitHub tokens, or raw payloads.
-- Added Trial detail `backgroundFailures` so failed generation/evaluation work is visible in the Trial view.
-- Scoped Trial failure visibility to the relevant Trial and company.
-- Supported local/dev admin auth via `x-dev-user-email` only when the email belongs to a real DB user with `role="admin"`.
-- Kept production admin auth on the existing JWT/Auth0 admin role path.
-- Removed generated `issue-305-iteration*.diff` artifacts from the PR contents.
+## What changed
 
-## API Changes
-### `GET /api/admin/jobs/failed`
+- Added configurable media retention via `MEDIA_RETENTION_DAYS`.
+- Added retention expiration and purge metadata to recording assets.
+- Added media purge audit records for retention and data-request purges.
+- Added expired-media purge service behavior.
+- Registered the `media_retention_purge` shared worker handler.
+- Added script/operator paths for triggering retention purge.
+- Added scoped data-request media purge support for Candidate sessions.
+- Redacted transcript text/segments during purge instead of silently hard-deleting transcript rows.
+- Preserved idempotency for already-purged media and missing storage objects.
+- Added tests for config, retention selection, purge behavior, audit records, worker registration, operator route behavior, missing storage, and data-request scoping.
 
-- Returns a failed-job listing for admin operators.
-- Includes safe job metadata and human-readable failure reason summaries.
-- Restricts access to admin users only.
-- Rejects unauthenticated requests with `401`.
-- Rejects Talent Partner and candidate access with `403`.
+## Acceptance criteria
 
-### `POST /api/admin/jobs/{job_id}/retry`
+- [x] Configurable retention period
+  - `MEDIA_RETENTION_DAYS` is configurable.
+  - Default remains `45`, matching the existing repo convention.
+  - Invalid values such as `0` are rejected.
 
-- Retries a dead-letter job by moving it back to `queued`.
-- Returns `404 JOB_NOT_FOUND` for unknown job IDs.
-- Returns `409 JOB_NOT_RETRYABLE` when the job is not in a retryable dead-letter state.
-- Restricts access to admin users only.
+- [x] Purge job for expired media
+  - Expired media is selected by retention metadata.
+  - Purge runs through the media privacy service.
+  - `media_retention_purge` is registered with the shared worker runtime.
+  - Admin/operator and script trigger paths are available.
+  - Purge is idempotent and safe to rerun.
 
-### Trial detail `backgroundFailures`
+- [x] Audit log for purge events
+  - `media_purge_audits` records purge attempts.
+  - Audit rows include media, Candidate session, Trial, actor, reason, outcome, and safe error summary where applicable.
+  - Worker/system purges use `actor_type=system`.
+  - Operator-triggered purges use `actor_type=operator`.
+  - Audit records do not include signed URLs, credentials, tokens, or raw transcript body.
 
-- Adds `backgroundFailures` to Trial detail responses.
-- Reports safe failure summaries for failed background jobs tied to the Trial.
-- Excludes unrelated Trial failures.
-- Preserves company scoping; cross-company Trial access returns `404`.
+- [x] Deletion workflows for data requests
+  - Added `purge_candidate_session_media_for_data_request(...)`.
+  - Data-request purge is scoped to the requested Candidate session.
+  - Unrelated Candidate/Trial media is not touched.
+  - Reruns are idempotent.
+  - Audit reason is `data_request`.
 
-## Security / Access Control
+## QA evidence
 
-- Operator endpoints are admin-only.
-- Local/dev admin QA uses `x-dev-user-email` with a real DB user whose `role="admin"`.
-- Production auth still relies on the existing JWT/Auth0 admin role path.
-- Talent Partner and candidate access to operator endpoints returns `403`.
-- Unauthenticated access to operator endpoints returns `401`.
-- Cross-company Trial access remains hidden with `404`.
+### Migration / schema
 
-## Failure Reason Redaction
+- `poetry run alembic upgrade head` passed.
+- `poetry run alembic heads` returned `202604200001 (head)`.
+- Verified schema:
+  - `recording_assets.retention_expires_at`
+  - `recording_assets.purge_reason`
+  - `recording_assets.purge_status`
+  - existing `recording_assets.purged_at`
+  - `media_purge_audits`
+- Verified indexes:
+  - `ix_recording_assets_retention_expires_purged`
+  - `ix_media_purge_audits_media_created_at`
+  - `ix_media_purge_audits_reason_created_at`
+  - `ix_media_purge_audits_candidate_session_created_at`
 
-- Failure summaries are human-readable but safe for operator UI/API use.
-- Raw secrets, stack traces, bearer tokens, API keys, GitHub tokens, and raw payloads are not exposed.
-- Redaction behavior is covered by focused tests and manual API QA.
+### Config verification
 
-## Data / Migration Notes
+- `poetry run pytest --no-cov -q tests/config/test_config_storage_media_settings_utils.py`
+  - `11 passed in 0.59s`
+- Runtime checks:
+  - default `MEDIA_RETENTION_DAYS = 45`
+  - override `MEDIA_RETENTION_DAYS=7` works
+  - invalid `MEDIA_RETENTION_DAYS=0` is rejected
 
-- No migration was needed because existing job fields were sufficient.
-- `failedAt` uses `updated_at` for dead-letter rows because the job model has no dedicated `failed_at`.
-- Retry reuses existing job state fields and moves retryable dead-letter jobs back to `queued`.
-- Generated `issue-305-iteration*.diff` artifacts were removed/not included.
+### Focused automated tests
 
-## QA Evidence
-### Automated
+- `poetry run pytest --no-cov -q tests/config tests/media tests/shared/jobs tests/talent_partners/routes/test_talent_partners_admin_media_purge_routes.py tests/integrations/storage_media/test_integrations_storage_media_s3_provider_delete_object_handles_success_and_missing_service.py`
+  - `332 passed in 19.34s`
 
-- Ruff: poetry run ruff check app tests — passed
-- Focused #305 tests: 17 passed
-- Route pattern regression: 1 passed
-- Trial detail snapshot regression: 1 passed
-- Full suite: 1850 passed, 13 warnings
-- Coverage: 96.06%
+- Previously failing direct test:
+  - `poetry run pytest --no-cov -q tests/media/repositories/test_media_repositories_recordings_repository_retention_helpers_repository.py`
+  - `2 passed in 0.33s`
 
-### Manual API QA
+### Full regression / precommit
 
-- Admin failed-job list returned `200`
-- Talent Partner and candidate access returned `403`
-- Unauthenticated access returned `401`
-- Retry dead-letter job returned `200`
-- Retried job moved to `queued`
-- Unknown job returned `404 JOB_NOT_FOUND`
-- Non-retryable job returned `409 JOB_NOT_RETRYABLE`
-- Trial detail returned `backgroundFailures`
-- Unrelated Trial failures excluded
-- Cross-company Trial access returned `404`
-- Raw secrets, stack traces, bearer tokens, API keys, GitHub tokens, and raw payloads were not exposed
+- `./precommit.sh`
+  - `1857 passed, 13 warnings`
+  - coverage `96.02%`
+  - required coverage `96%` reached
+  - all precommit checks passed
 
-### Grep Verification
+- `git diff --check`
+  - passed
 
-- Changed-file legacy terminology grep: no hits
-- Changed-file retired v3 terminology grep: no hits
+## Manual QA evidence
 
-## Risks / Follow-ups
+### Retention purge success path
 
-- `failedAt` is derived from `updated_at` for dead-letter rows until the job model grows a dedicated failure timestamp.
-- Retry behavior is intentionally limited to retryable dead-letter jobs; broader operator workflows can build on these endpoints later.
+Seeded:
+- Talent Partner
+- Trial
+- Candidate session
+- Day 4 handoff task
+- ready media asset
+- transcript with text/segments
+- fake storage object
+- expired `retention_expires_at`
 
-Fixes #305
+Observed:
+- `scanned_count=1`
+- `purged_count=1`
+- `failed_count=0`
+- media `status=purged`
+- `purge_reason=retention_expired`
+- `purge_status=purged`
+- `purged_at` set
+- transcript row still exists
+- transcript `text=null`
+- transcript `segments_json=null`
+- transcript `deleted_at` set
+- storage object removed
+- audit row written with `outcome=success`
+- audit actor type `system`
+- audit actor id `null`
+- Candidate session and Trial context present
+
+### Day 4 upload retention metadata
+
+Verified Day 4 upload completion sets retention metadata:
+- `status=uploaded`
+- `retention_expires_at` set
+- retention delta matches `45` days
+
+### Idempotent rerun
+
+Second purge against already-purged media:
+- `scanned_count=0`
+- `purged_count=0`
+- `failed_count=0`
+- media stayed purged
+- transcript stayed redacted
+- audit count remained stable
+
+### Missing storage object behavior
+
+Seeded two expired assets:
+- one missing from storage
+- one present in storage
+
+Observed:
+- `scanned_count=2`
+- `purged_count=2`
+- `failed_count=0`
+- both media records became purged
+- both transcripts redacted
+- audit rows written with `outcome=success`
+- missing object did not fail the batch
+
+### Operator-triggered purge
+
+Direct admin route invocation returned:
+- `status=ok`
+- `scannedCount=1`
+- `purgedCount=1`
+- `skippedCount=0`
+- `failedCount=0`
+
+Audit verified:
+- `actor_type=operator`
+- `actor_id=admin-qa-306`
+- `purge_reason=retention_expired`
+
+### Shared worker/system purge
+
+Verified:
+- `media_retention_purge` handler is registered.
+- Payload maps `batchLimit` and `retentionDays`.
+- Worker result:
+  - `scannedCount=1`
+  - `purgedCount=1`
+  - `skippedCount=0`
+  - `failedCount=0`
+
+Audit verified:
+- `actor_type=system`
+- `actor_id=null`
+- `purge_reason=retention_expired`
+
+### Data-request deletion hook
+
+Seeded Candidate session A and B under the same Trial.
+
+Ran `purge_candidate_session_media_for_data_request(...)` for Candidate session A only.
+
+Observed:
+- Candidate session A media purged.
+- Candidate session A transcript redacted.
+- Candidate session A audit reason `data_request`.
+- Candidate session A audit actor `operator`.
+- Candidate session A audit actor id `privacy-qa-operator`.
+- Candidate session B media remained uploaded.
+- Candidate session B transcript remained untouched.
+- Candidate session B had no audit row.
+- Rerun for Candidate session A returned no additional purge work.
+
+## Security / privacy
+
+Verified #306 manual QA logs and audit rows do not contain:
+- signed URLs
+- access tokens
+- storage credentials
+- raw transcript body
+- raw transcript segments
+- full exception traces in operator-facing output
+
+## Terminology check
+
+Changed-file terminology scan passed with zero hits for retired terms.
+
+## Notes / limitations
+
+- No app-level periodic scheduler/cron cadence exists in this repo.
+- This PR provides the registered shared worker handler, operator/admin trigger path, and script trigger path.
+- Deployment cadence for invoking the idempotent purge job remains an ops concern.
+
+## Risk
+
+Low-to-medium.
+
+The purge path touches privacy-sensitive media and Evidence Trail artifacts, so the risk is primarily around data deletion correctness and auditability. Manual QA covered success, rerun idempotency, missing storage, operator/system actor semantics, and scoped data-request deletion.
+
+## Rollback
+
+Revert this PR and run Alembic downgrade according to repo migration conventions if needed. Existing media records are only purged when the purge job/operator path runs; the migration itself adds metadata/audit structures and backfills retention timestamps.
+
+Fixes #306

--- a/scripts/purge_media_retention.py
+++ b/scripts/purge_media_retention.py
@@ -43,6 +43,7 @@ async def _run(retention_days: int | None, batch_limit: int) -> int:
         "media_retention_purge"
         f" scanned={result.scanned_count}"
         f" purged={result.purged_count}"
+        f" skipped={result.skipped_count}"
         f" failed={result.failed_count}"
     )
     if result.purged_recording_ids:

--- a/tests/config/test_config_storage_media_settings_utils.py
+++ b/tests/config/test_config_storage_media_settings_utils.py
@@ -16,6 +16,14 @@ def test_storage_media_settings_validates_media_retention_days():
         StorageMediaSettings(MEDIA_RETENTION_DAYS=0)
 
 
+def test_storage_media_settings_default_media_retention_days():
+    assert StorageMediaSettings().MEDIA_RETENTION_DAYS == 45
+
+
+def test_storage_media_settings_allows_media_retention_days_override():
+    assert StorageMediaSettings(MEDIA_RETENTION_DAYS=7).MEDIA_RETENTION_DAYS == 7
+
+
 def test_storage_media_settings_validates_signed_url_expiry_positive():
     with pytest.raises(ValidationError):
         StorageMediaSettings(SIGNED_URL_EXPIRY_SECONDS=0)

--- a/tests/media/repositories/media_repositories_utils.py
+++ b/tests/media/repositories/media_repositories_utils.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import UTC, datetime, timedelta
 
 from app.media.repositories.recordings import (
+    RECORDING_ASSET_PURGE_REASON_RETENTION_EXPIRED,
     RECORDING_ASSET_STATUS_DELETED,
     RECORDING_ASSET_STATUS_FAILED,
     RECORDING_ASSET_STATUS_PURGED,

--- a/tests/media/repositories/test_media_repositories_recordings_repository_retention_helpers_repository.py
+++ b/tests/media/repositories/test_media_repositories_recordings_repository_retention_helpers_repository.py
@@ -48,6 +48,7 @@ async def test_recordings_repository_retention_helpers(async_session):
     await recordings_repo.mark_purged(
         async_session,
         recording=old_recording,
+        purge_reason=RECORDING_ASSET_PURGE_REASON_RETENTION_EXPIRED,
         commit=True,
     )
     assert old_recording.purged_at is not None
@@ -94,6 +95,7 @@ async def test_recordings_repository_mark_deleted_and_mark_purged_preserve_termi
     await recordings_repo.mark_purged(
         async_session,
         recording=recording,
+        purge_reason=RECORDING_ASSET_PURGE_REASON_RETENTION_EXPIRED,
         now=datetime.now(UTC),
         commit=False,
     )

--- a/tests/media/services/media_privacy_service_utils.py
+++ b/tests/media/services/media_privacy_service_utils.py
@@ -5,13 +5,21 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 from fastapi import HTTPException
+from sqlalchemy import select
 
 from app.config import settings
 from app.integrations.storage_media import (
     FakeStorageMediaProvider,
     StorageMediaError,
 )
+from app.media.repositories.purge_audits import (
+    MEDIA_PURGE_ACTOR_OPERATOR,
+    MEDIA_PURGE_ACTOR_SYSTEM,
+    MediaPurgeAudit,
+)
 from app.media.repositories.recordings import (
+    RECORDING_ASSET_PURGE_REASON_DATA_REQUEST,
+    RECORDING_ASSET_PURGE_REASON_RETENTION_EXPIRED,
     RECORDING_ASSET_STATUS_PURGED,
     RECORDING_ASSET_STATUS_UPLOADED,
 )
@@ -22,6 +30,7 @@ from app.media.repositories.transcripts import (
 from app.media.repositories.transcripts import repository as transcripts_repo
 from app.media.services.media_services_media_privacy_service import (
     delete_recording_asset,
+    purge_candidate_session_media_for_data_request,
     purge_expired_media_assets,
     record_candidate_session_consent,
     require_media_consent,

--- a/tests/media/services/test_media_privacy_service_data_request_purges_scoped_candidate_media_service.py
+++ b/tests/media/services/test_media_privacy_service_data_request_purges_scoped_candidate_media_service.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.media.services.media_privacy_service_utils import *
+
+
+@pytest.mark.asyncio
+async def test_data_request_purges_only_associated_candidate_media(async_session):
+    talent_partner = await create_talent_partner(
+        async_session, email="privacy-data-request@test.com"
+    )
+    trial, tasks = await create_trial(async_session, created_by=talent_partner)
+    task = _handoff_task(tasks)
+    target_session = await create_candidate_session(async_session, trial=trial)
+    other_session = await create_candidate_session(
+        async_session, trial=trial, invite_email="other-data-request@test.com"
+    )
+    provider = FakeStorageMediaProvider()
+
+    async def _recording(candidate_session, name: str):
+        recording = await recordings_repo.create_recording_asset(
+            async_session,
+            candidate_session_id=candidate_session.id,
+            task_id=task.id,
+            storage_key=(
+                f"candidate-sessions/{candidate_session.id}/tasks/{task.id}/"
+                f"recordings/{name}.mp4"
+            ),
+            content_type="video/mp4",
+            bytes_count=2048,
+            status=RECORDING_ASSET_STATUS_UPLOADED,
+            commit=True,
+        )
+        provider.set_object_metadata(
+            recording.storage_key,
+            content_type=recording.content_type,
+            size_bytes=recording.bytes,
+        )
+        await transcripts_repo.create_transcript(
+            async_session,
+            recording_id=recording.id,
+            status=TRANSCRIPT_STATUS_READY,
+            text=f"transcript-{name}",
+            commit=True,
+        )
+        return recording
+
+    target_recording = await _recording(target_session, "target")
+    other_recording = await _recording(other_session, "other")
+
+    first = await purge_candidate_session_media_for_data_request(
+        async_session,
+        candidate_session_id=target_session.id,
+        storage_provider=provider,
+        actor_id="privacy-operator",
+    )
+    second = await purge_candidate_session_media_for_data_request(
+        async_session,
+        candidate_session_id=target_session.id,
+        storage_provider=provider,
+        actor_id="privacy-operator",
+    )
+
+    refreshed_target = await recordings_repo.get_by_id(
+        async_session, target_recording.id
+    )
+    refreshed_other = await recordings_repo.get_by_id(async_session, other_recording.id)
+    target_transcript = await transcripts_repo.get_by_recording_id(
+        async_session, target_recording.id, include_deleted=True
+    )
+    audits = (
+        (
+            await async_session.execute(
+                select(MediaPurgeAudit).where(
+                    MediaPurgeAudit.media_id == target_recording.id
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert first.purged_count == 1
+    assert second.scanned_count == 0
+    assert refreshed_target.status == RECORDING_ASSET_STATUS_PURGED
+    assert refreshed_target.purge_reason == "data_request"
+    assert target_transcript.text is None
+    assert refreshed_other.status == RECORDING_ASSET_STATUS_UPLOADED
+    assert provider.get_object_metadata(other_recording.storage_key) is not None
+    assert len(audits) == 1
+    assert audits[0].purge_reason == RECORDING_ASSET_PURGE_REASON_DATA_REQUEST
+    assert audits[0].actor_type == MEDIA_PURGE_ACTOR_OPERATOR
+    assert audits[0].actor_id == "privacy-operator"

--- a/tests/media/services/test_media_privacy_service_purge_expired_media_assets_logs_without_sensitive_payload_service.py
+++ b/tests/media/services/test_media_privacy_service_purge_expired_media_assets_logs_without_sensitive_payload_service.py
@@ -60,6 +60,6 @@ async def test_purge_expired_media_assets_logs_without_sensitive_payload(
 
     log_text = "\n".join(record.getMessage() for record in caplog.records)
     assert recording.id in result.purged_recording_ids
-    assert f"purge executed recordingId={recording.id}" in log_text
+    assert f"mediaId={recording.id}" in log_text
     assert "do-not-log-this-purge-transcript" not in log_text
     assert "https://" not in log_text

--- a/tests/media/services/test_media_privacy_service_purge_expired_media_assets_missing_storage_is_idempotent_service.py
+++ b/tests/media/services/test_media_privacy_service_purge_expired_media_assets_missing_storage_is_idempotent_service.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.media.services.media_privacy_service_utils import *
+
+
+@pytest.mark.asyncio
+async def test_purge_expired_media_assets_missing_storage_is_idempotent(async_session):
+    talent_partner = await create_talent_partner(
+        async_session, email="privacy-purge-missing-storage@test.com"
+    )
+    trial, tasks = await create_trial(async_session, created_by=talent_partner)
+    task = _handoff_task(tasks)
+    candidate_session = await create_candidate_session(async_session, trial=trial)
+
+    now = datetime.now(UTC).replace(microsecond=0)
+
+    async def _recording(name: str):
+        recording = await recordings_repo.create_recording_asset(
+            async_session,
+            candidate_session_id=candidate_session.id,
+            task_id=task.id,
+            storage_key=(
+                f"candidate-sessions/{candidate_session.id}/tasks/{task.id}/"
+                f"recordings/{name}.mp4"
+            ),
+            content_type="video/mp4",
+            bytes_count=2048,
+            status=RECORDING_ASSET_STATUS_UPLOADED,
+            retention_expires_at=now - timedelta(seconds=1),
+            commit=True,
+        )
+        await transcripts_repo.create_transcript(
+            async_session,
+            recording_id=recording.id,
+            status=TRANSCRIPT_STATUS_READY,
+            text=f"transcript-{name}",
+            segments_json=[{"text": f"segment-{name}"}],
+            commit=True,
+        )
+        return recording
+
+    missing_recording = await _recording("missing")
+    present_recording = await _recording("present")
+    provider = FakeStorageMediaProvider()
+    provider.set_object_metadata(
+        present_recording.storage_key,
+        content_type=present_recording.content_type,
+        size_bytes=present_recording.bytes,
+    )
+
+    result = await purge_expired_media_assets(
+        async_session,
+        storage_provider=provider,
+        batch_limit=20,
+        now=now,
+    )
+
+    refreshed_missing = await recordings_repo.get_by_id(
+        async_session, missing_recording.id
+    )
+    missing_transcript = await transcripts_repo.get_by_recording_id(
+        async_session,
+        missing_recording.id,
+        include_deleted=True,
+    )
+    audits = (
+        (
+            await async_session.execute(
+                select(MediaPurgeAudit).where(
+                    MediaPurgeAudit.media_id.in_(
+                        [missing_recording.id, present_recording.id]
+                    )
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+
+    assert result.scanned_count == 2
+    assert result.purged_count == 2
+    assert result.failed_count == 0
+    assert set(result.purged_recording_ids) == {
+        missing_recording.id,
+        present_recording.id,
+    }
+    assert refreshed_missing is not None
+    assert refreshed_missing.status == RECORDING_ASSET_STATUS_PURGED
+    assert (
+        refreshed_missing.purge_reason == RECORDING_ASSET_PURGE_REASON_RETENTION_EXPIRED
+    )
+    assert missing_transcript is not None
+    assert missing_transcript.text is None
+    assert missing_transcript.segments_json is None
+    assert missing_transcript.deleted_at is not None
+    assert len(audits) == 2
+    assert {audit.outcome for audit in audits} == {"success"}
+    assert {audit.actor_type for audit in audits} == {MEDIA_PURGE_ACTOR_SYSTEM}

--- a/tests/media/services/test_media_privacy_service_purge_expired_media_assets_removes_storage_and_transcript_service.py
+++ b/tests/media/services/test_media_privacy_service_purge_expired_media_assets_removes_storage_and_transcript_service.py
@@ -68,4 +68,8 @@ async def test_purge_expired_media_assets_removes_storage_and_transcript(async_s
     assert refreshed is not None
     assert refreshed.status == RECORDING_ASSET_STATUS_PURGED
     assert refreshed.purged_at is not None
-    assert transcript is None
+    assert refreshed.retention_expires_at is not None
+    assert transcript is not None
+    assert transcript.text is None
+    assert transcript.segments_json is None
+    assert transcript.deleted_at is not None

--- a/tests/media/services/test_media_privacy_service_purge_expired_media_assets_writes_success_audit_service.py
+++ b/tests/media/services/test_media_privacy_service_purge_expired_media_assets_writes_success_audit_service.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.media.services.media_privacy_service_utils import *
+
+
+@pytest.mark.asyncio
+async def test_purge_expired_media_assets_writes_success_audit(async_session):
+    talent_partner = await create_talent_partner(
+        async_session, email="privacy-purge-audit@test.com"
+    )
+    trial, tasks = await create_trial(async_session, created_by=talent_partner)
+    task = _handoff_task(tasks)
+    candidate_session = await create_candidate_session(async_session, trial=trial)
+
+    now = datetime.now(UTC).replace(microsecond=0)
+    recording = await recordings_repo.create_recording_asset(
+        async_session,
+        candidate_session_id=candidate_session.id,
+        task_id=task.id,
+        storage_key=(
+            f"candidate-sessions/{candidate_session.id}/tasks/{task.id}/"
+            "recordings/purge-audit.mp4"
+        ),
+        content_type="video/mp4",
+        bytes_count=2048,
+        status=RECORDING_ASSET_STATUS_UPLOADED,
+        retention_expires_at=now - timedelta(seconds=1),
+        commit=True,
+    )
+    provider = FakeStorageMediaProvider()
+    provider.set_object_metadata(
+        recording.storage_key,
+        content_type=recording.content_type,
+        size_bytes=recording.bytes,
+    )
+
+    result = await purge_expired_media_assets(
+        async_session,
+        storage_provider=provider,
+        batch_limit=20,
+        now=now,
+    )
+
+    audit = (
+        await async_session.execute(
+            select(MediaPurgeAudit).where(MediaPurgeAudit.media_id == recording.id)
+        )
+    ).scalar_one()
+    assert result.purged_count == 1
+    assert audit.candidate_session_id == candidate_session.id
+    assert audit.trial_id == trial.id
+    assert audit.purge_reason == "retention_expired"
+    assert audit.actor_type == MEDIA_PURGE_ACTOR_SYSTEM
+    assert audit.actor_id is None
+    assert audit.outcome == "success"
+    assert audit.error_summary is None

--- a/tests/shared/jobs/handlers/test_shared_jobs_handlers_media_retention_purge_handler.py
+++ b/tests/shared/jobs/handlers/test_shared_jobs_handlers_media_retention_purge_handler.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.media.services.media_services_media_retention_jobs_service import (
+    MEDIA_RETENTION_PURGE_JOB_TYPE,
+)
+from app.shared.jobs import worker
+from app.shared.jobs.handlers import media_retention_purge as handler
+
+
+class _SessionMaker:
+    def __init__(self, db):
+        self.db = db
+
+    async def __aenter__(self):
+        return self.db
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_media_retention_purge_handler_maps_payload(monkeypatch):
+    calls = {}
+
+    async def _purge(db, *, storage_provider, retention_days, batch_limit, **kwargs):
+        calls["db"] = db
+        calls["storage_provider"] = storage_provider
+        calls["retention_days"] = retention_days
+        calls["batch_limit"] = batch_limit
+        calls["kwargs"] = kwargs
+        return SimpleNamespace(
+            scanned_count=4,
+            purged_count=3,
+            skipped_count=1,
+            failed_count=0,
+        )
+
+    monkeypatch.setattr(handler, "async_session_maker", lambda: _SessionMaker("db"))
+    monkeypatch.setattr(handler, "get_storage_media_provider", lambda: "provider")
+    monkeypatch.setattr(handler, "purge_expired_media_assets", _purge)
+
+    result = await handler.handle_media_retention_purge(
+        {"retentionDays": 7, "batchLimit": 50}
+    )
+
+    assert calls == {
+        "db": "db",
+        "storage_provider": "provider",
+        "retention_days": 7,
+        "batch_limit": 50,
+        "kwargs": {},
+    }
+    assert result == {
+        "scannedCount": 4,
+        "purgedCount": 3,
+        "skippedCount": 1,
+        "failedCount": 0,
+    }
+
+
+def test_media_retention_purge_is_registered_builtin_handler():
+    worker.clear_handlers()
+    try:
+        worker.register_builtin_handlers()
+        assert worker.has_handler(MEDIA_RETENTION_PURGE_JOB_TYPE)
+    finally:
+        worker.clear_handlers()

--- a/tests/talent_partners/routes/test_talent_partners_admin_media_purge_routes.py
+++ b/tests/talent_partners/routes/test_talent_partners_admin_media_purge_routes.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from app.media.repositories.purge_audits import MEDIA_PURGE_ACTOR_OPERATOR
 from app.talent_partners.routes.admin_routes import demo_ops
 from app.talent_partners.schemas.talent_partners_schemas_talent_partners_admin_ops_schema import (
     MediaRetentionPurgeRequest,
@@ -18,13 +19,18 @@ async def test_purge_media_retention_route_maps_service_result(monkeypatch):
         storage_provider,
         retention_days: int | None,
         batch_limit: int,
+        actor_type: str,
+        actor_id: str | None,
     ):
         del db, storage_provider
         assert retention_days == 30
         assert batch_limit == 50
+        assert actor_type == MEDIA_PURGE_ACTOR_OPERATOR
+        assert actor_id == "admin-1"
         return SimpleNamespace(
             scanned_count=3,
             purged_count=2,
+            skipped_count=0,
             failed_count=1,
             purged_recording_ids=[11, 12],
         )
@@ -34,12 +40,13 @@ async def test_purge_media_retention_route_maps_service_result(monkeypatch):
     result = await demo_ops.purge_media_retention(
         payload=MediaRetentionPurgeRequest(retentionDays=30, batchLimit=50),
         db=None,
-        actor=SimpleNamespace(),
+        actor=SimpleNamespace(actor_id="admin-1"),
         storage_provider=SimpleNamespace(),
     )
 
     assert result.status == "ok"
     assert result.scannedCount == 3
     assert result.purgedCount == 2
+    assert result.skippedCount == 0
     assert result.failedCount == 1
     assert result.purgedRecordingIds == [11, 12]


### PR DESCRIPTION
## Summary

Implement policy-driven media retention and purge scheduling for Day 4 media artifacts.

This PR adds configurable retention metadata, an expired-media purge path, privacy-safe purge audit records, and a scoped data-request deletion hook. The purge flow redacts transcript content while preserving auditability and Evidence Trail shape.

## What changed

- Added configurable media retention via `MEDIA_RETENTION_DAYS`.
- Added retention expiration and purge metadata to recording assets.
- Added media purge audit records for retention and data-request purges.
- Added expired-media purge service behavior.
- Registered the `media_retention_purge` shared worker handler.
- Added script/operator paths for triggering retention purge.
- Added scoped data-request media purge support for Candidate sessions.
- Redacted transcript text/segments during purge instead of silently hard-deleting transcript rows.
- Preserved idempotency for already-purged media and missing storage objects.
- Added tests for config, retention selection, purge behavior, audit records, worker registration, operator route behavior, missing storage, and data-request scoping.

## Acceptance criteria

- [x] Configurable retention period
  - `MEDIA_RETENTION_DAYS` is configurable.
  - Default remains `45`, matching the existing repo convention.
  - Invalid values such as `0` are rejected.

- [x] Purge job for expired media
  - Expired media is selected by retention metadata.
  - Purge runs through the media privacy service.
  - `media_retention_purge` is registered with the shared worker runtime.
  - Admin/operator and script trigger paths are available.
  - Purge is idempotent and safe to rerun.

- [x] Audit log for purge events
  - `media_purge_audits` records purge attempts.
  - Audit rows include media, Candidate session, Trial, actor, reason, outcome, and safe error summary where applicable.
  - Worker/system purges use `actor_type=system`.
  - Operator-triggered purges use `actor_type=operator`.
  - Audit records do not include signed URLs, credentials, tokens, or raw transcript body.

- [x] Deletion workflows for data requests
  - Added `purge_candidate_session_media_for_data_request(...)`.
  - Data-request purge is scoped to the requested Candidate session.
  - Unrelated Candidate/Trial media is not touched.
  - Reruns are idempotent.
  - Audit reason is `data_request`.

## QA evidence

### Migration / schema

- `poetry run alembic upgrade head` passed.
- `poetry run alembic heads` returned `202604200001 (head)`.
- Verified schema:
  - `recording_assets.retention_expires_at`
  - `recording_assets.purge_reason`
  - `recording_assets.purge_status`
  - existing `recording_assets.purged_at`
  - `media_purge_audits`
- Verified indexes:
  - `ix_recording_assets_retention_expires_purged`
  - `ix_media_purge_audits_media_created_at`
  - `ix_media_purge_audits_reason_created_at`
  - `ix_media_purge_audits_candidate_session_created_at`

### Config verification

- `poetry run pytest --no-cov -q tests/config/test_config_storage_media_settings_utils.py`
  - `11 passed in 0.59s`
- Runtime checks:
  - default `MEDIA_RETENTION_DAYS = 45`
  - override `MEDIA_RETENTION_DAYS=7` works
  - invalid `MEDIA_RETENTION_DAYS=0` is rejected

### Focused automated tests

- `poetry run pytest --no-cov -q tests/config tests/media tests/shared/jobs tests/talent_partners/routes/test_talent_partners_admin_media_purge_routes.py tests/integrations/storage_media/test_integrations_storage_media_s3_provider_delete_object_handles_success_and_missing_service.py`
  - `332 passed in 19.34s`

- Previously failing direct test:
  - `poetry run pytest --no-cov -q tests/media/repositories/test_media_repositories_recordings_repository_retention_helpers_repository.py`
  - `2 passed in 0.33s`

### Full regression / precommit

- `./precommit.sh`
  - `1857 passed, 13 warnings`
  - coverage `96.02%`
  - required coverage `96%` reached
  - all precommit checks passed

- `git diff --check`
  - passed

## Manual QA evidence

### Retention purge success path

Seeded:
- Talent Partner
- Trial
- Candidate session
- Day 4 handoff task
- ready media asset
- transcript with text/segments
- fake storage object
- expired `retention_expires_at`

Observed:
- `scanned_count=1`
- `purged_count=1`
- `failed_count=0`
- media `status=purged`
- `purge_reason=retention_expired`
- `purge_status=purged`
- `purged_at` set
- transcript row still exists
- transcript `text=null`
- transcript `segments_json=null`
- transcript `deleted_at` set
- storage object removed
- audit row written with `outcome=success`
- audit actor type `system`
- audit actor id `null`
- Candidate session and Trial context present

### Day 4 upload retention metadata

Verified Day 4 upload completion sets retention metadata:
- `status=uploaded`
- `retention_expires_at` set
- retention delta matches `45` days

### Idempotent rerun

Second purge against already-purged media:
- `scanned_count=0`
- `purged_count=0`
- `failed_count=0`
- media stayed purged
- transcript stayed redacted
- audit count remained stable

### Missing storage object behavior

Seeded two expired assets:
- one missing from storage
- one present in storage

Observed:
- `scanned_count=2`
- `purged_count=2`
- `failed_count=0`
- both media records became purged
- both transcripts redacted
- audit rows written with `outcome=success`
- missing object did not fail the batch

### Operator-triggered purge

Direct admin route invocation returned:
- `status=ok`
- `scannedCount=1`
- `purgedCount=1`
- `skippedCount=0`
- `failedCount=0`

Audit verified:
- `actor_type=operator`
- `actor_id=admin-qa-306`
- `purge_reason=retention_expired`

### Shared worker/system purge

Verified:
- `media_retention_purge` handler is registered.
- Payload maps `batchLimit` and `retentionDays`.
- Worker result:
  - `scannedCount=1`
  - `purgedCount=1`
  - `skippedCount=0`
  - `failedCount=0`

Audit verified:
- `actor_type=system`
- `actor_id=null`
- `purge_reason=retention_expired`

### Data-request deletion hook

Seeded Candidate session A and B under the same Trial.

Ran `purge_candidate_session_media_for_data_request(...)` for Candidate session A only.

Observed:
- Candidate session A media purged.
- Candidate session A transcript redacted.
- Candidate session A audit reason `data_request`.
- Candidate session A audit actor `operator`.
- Candidate session A audit actor id `privacy-qa-operator`.
- Candidate session B media remained uploaded.
- Candidate session B transcript remained untouched.
- Candidate session B had no audit row.
- Rerun for Candidate session A returned no additional purge work.

## Security / privacy

Verified #306 manual QA logs and audit rows do not contain:
- signed URLs
- access tokens
- storage credentials
- raw transcript body
- raw transcript segments
- full exception traces in operator-facing output

## Terminology check

Changed-file terminology scan passed with zero hits for retired terms.

## Notes / limitations

- No app-level periodic scheduler/cron cadence exists in this repo.
- This PR provides the registered shared worker handler, operator/admin trigger path, and script trigger path.
- Deployment cadence for invoking the idempotent purge job remains an ops concern.

## Risk

Low-to-medium.

The purge path touches privacy-sensitive media and Evidence Trail artifacts, so the risk is primarily around data deletion correctness and auditability. Manual QA covered success, rerun idempotency, missing storage, operator/system actor semantics, and scoped data-request deletion.

## Rollback

Revert this PR and run Alembic downgrade according to repo migration conventions if needed. Existing media records are only purged when the purge job/operator path runs; the migration itself adds metadata/audit structures and backfills retention timestamps.

Fixes #306
