### PR TITLE
Add deterministic demo provisioning mode with fake GitHub provider for local/YC rehearsal

### DIFF
--- a/app/config/config_settings_shims_config.py
+++ b/app/config/config_settings_shims_config.py
@@ -5,6 +5,10 @@ from __future__ import annotations
 import os
 
 
+def _is_truthy(value: object) -> bool:
+    return str(value).strip().lower() in {"1", "true", "yes", "on"}
+
+
 class SettingsShimMixin:
     """Represent settings shim mixin data and behavior."""
 
@@ -57,3 +61,23 @@ class SettingsShimMixin:
         env_val = os.getenv("DEV_AUTH_BYPASS") or os.getenv("WINOE_DEV_AUTH_BYPASS")
         value = (env_val if env_val is not None else self.DEV_AUTH_BYPASS) or ""
         return value.strip() == "1"
+
+    def is_production_environment(self) -> bool:
+        """Return whether the configured runtime environment is production."""
+        env_candidates = (
+            os.getenv("WINOE_ENV"),
+            os.getenv("ENV"),
+            getattr(self, "ENV", None),
+        )
+        return any(
+            str(env).strip().lower() in {"prod", "production"}
+            for env in env_candidates
+            if env is not None and str(env).strip()
+        )
+
+    @property
+    def demo_mode_enabled(self) -> bool:
+        """Return whether demo mode is active outside production."""
+        return _is_truthy(getattr(self, "DEMO_MODE", None)) and not (
+            self.is_production_environment()
+        )

--- a/app/integrations/github/__init__.py
+++ b/app/integrations/github/__init__.py
@@ -3,6 +3,12 @@ from app.integrations.github.actions_runner import (
     GithubActionsRunner,
 )
 from app.integrations.github.client import GithubClient, GithubError, WorkflowRun
+from app.integrations.github.integrations_github_factory_client import (
+    get_github_provisioning_client,
+)
+from app.integrations.github.integrations_github_fake_provider_client import (
+    FakeGithubClient,
+)
 from app.submissions.repositories.github_native.workspaces.submissions_repositories_github_native_workspaces_submissions_github_native_workspaces_core_model import (
     Workspace,
 )
@@ -10,8 +16,10 @@ from app.submissions.repositories.github_native.workspaces.submissions_repositor
 __all__ = [
     "GithubClient",
     "GithubError",
+    "FakeGithubClient",
     "WorkflowRun",
     "Workspace",
     "ActionsRunResult",
     "GithubActionsRunner",
+    "get_github_provisioning_client",
 ]

--- a/app/integrations/github/integrations_github_factory_client.py
+++ b/app/integrations/github/integrations_github_factory_client.py
@@ -1,0 +1,42 @@
+"""Application module for integrations github factory client workflows."""
+
+from __future__ import annotations
+
+import logging
+from functools import lru_cache
+
+from app.config import settings
+from app.config.config_settings_shims_config import _is_truthy
+from app.integrations.github.client import GithubClient
+from app.integrations.github.integrations_github_fake_provider_client import (
+    FakeGithubClient,
+    get_fake_github_client,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@lru_cache(maxsize=1)
+def _real_github_client_singleton() -> GithubClient:
+    return GithubClient(
+        base_url=settings.github.GITHUB_API_BASE,
+        token=settings.github.GITHUB_TOKEN,
+        default_org=settings.github.GITHUB_ORG or None,
+    )
+
+
+def get_github_provisioning_client() -> GithubClient | FakeGithubClient:
+    """Return the configured GitHub provider for workspace provisioning."""
+    if settings.demo_mode_enabled:
+        return get_fake_github_client()
+    if _is_truthy(getattr(settings, "DEMO_MODE", None)) and (
+        settings.is_production_environment()
+    ):
+        logger.warning(
+            "DEMO_MODE requested but disabled in production; using real GitHub provider.",
+            extra={"env": str(getattr(settings, "ENV", "") or "").lower()},
+        )
+    return _real_github_client_singleton()
+
+
+__all__ = ["get_github_provisioning_client"]

--- a/app/integrations/github/integrations_github_fake_provider_client.py
+++ b/app/integrations/github/integrations_github_fake_provider_client.py
@@ -1,0 +1,979 @@
+"""Application module for integrations github fake provider client workflows."""
+
+from __future__ import annotations
+
+import base64
+import io
+import json
+import logging
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+from functools import lru_cache
+from hashlib import sha256
+from typing import Any
+from zipfile import ZIP_DEFLATED, ZipFile
+
+from app.config import settings
+from app.integrations.github.client import GithubError, WorkflowRun
+
+logger = logging.getLogger(__name__)
+
+_DEMO_REPO_OWNER = "winoe-ai-demo"
+_DEMO_CODESPACE_BASE_URL = "https://codespaces.demo.winoe.ai"
+_DEMO_BOT_LOGIN = "winoe-demo-bot"
+_DEFAULT_BRANCH = "main"
+_EVIDENCE_ARTIFACT_NAMES = (
+    "winoe-commit-metadata",
+    "winoe-file-creation-timeline",
+    "winoe-repo-tree-summary",
+    "winoe-dependency-manifests",
+    "winoe-test-detection",
+    "winoe-test-results",
+    "winoe-lint-detection",
+    "winoe-lint-results",
+    "winoe-evidence-manifest",
+)
+
+
+def _stable_digest(*parts: object) -> bytes:
+    seed = "\u241f".join("" if part is None else str(part) for part in parts)
+    return sha256(seed.encode("utf-8")).digest()
+
+
+def _stable_hex(*parts: object, length: int = 40) -> str:
+    return sha256(_stable_digest(*parts)).hexdigest()[:length]
+
+
+def _stable_int(*parts: object, start: int, stop: int) -> int:
+    span = stop - start
+    if span <= 0:
+        raise ValueError("invalid stable int range")
+    return start + (int.from_bytes(_stable_digest(*parts)[:8], "big") % span)
+
+
+def _stable_time(*parts: object) -> str:
+    base = datetime(2026, 1, 1, 12, 0, tzinfo=UTC)
+    offset = _stable_int(*parts, start=0, stop=60 * 24 * 30)
+    return (base + timedelta(minutes=offset)).isoformat().replace("+00:00", "Z")
+
+
+def _repo_owner_name(full_name: str) -> tuple[str, str]:
+    owner, repo = full_name.split("/", 1)
+    return owner, repo
+
+
+def _strip_ref(ref: str) -> str:
+    return ref.replace("refs/heads/", "").replace("refs/", "").strip()
+
+
+def _fake_codespace_name(repo_name: str, branch: str) -> str:
+    suffix = _stable_hex(repo_name, branch, "codespace", length=8)
+    return f"{repo_name}-{branch}-{suffix}"
+
+
+def _fake_workflow_run_id(full_name: str, seq: int) -> int:
+    return _stable_int(
+        full_name, seq, "workflow-run", start=10_000_000, stop=99_999_999
+    )
+
+
+def _fake_workflow_head_sha(full_name: str, seq: int) -> str:
+    return _stable_hex(full_name, seq, "head-sha")
+
+
+def _fake_compare_files(full_name: str, seq: int) -> list[dict[str, Any]]:
+    repo_name = _repo_owner_name(full_name)[1]
+    if seq % 2 == 0:
+        paths = [
+            "src/app.py",
+            "src/domain/models.py",
+            "tests/test_app.py",
+            "tests/test_domain_models.py",
+        ]
+    else:
+        paths = [
+            "src/app.py",
+            "src/services/provisioning.py",
+            "tests/test_app.py",
+            "docs/runbook.md",
+        ]
+    files: list[dict[str, Any]] = []
+    for index, path in enumerate(paths, start=1):
+        lines = 8 + _stable_int(full_name, seq, path, start=0, stop=12)
+        files.append(
+            {
+                "filename": path,
+                "status": "added",
+                "additions": lines,
+                "deletions": 0,
+                "changes": lines,
+                "patch": (
+                    f"@@ -0,0 +1,{lines} @@\n"
+                    f"+# {repo_name} {path}\n"
+                    f"+# demo change {index}\n"
+                ),
+            }
+        )
+    return files
+
+
+def _fake_commit_story(full_name: str, seq: int) -> list[dict[str, Any]]:
+    head_sha = _fake_workflow_head_sha(full_name, seq)
+    root_sha = _stable_hex(full_name, "bootstrap", length=40)
+    commits = [
+        {
+            "sha": root_sha,
+            "timestamp": _stable_time(full_name, "bootstrap"),
+            "message": "Initialize empty Trial workspace",
+            "files_changed": [
+                ".devcontainer/devcontainer.json",
+                "README.md",
+                ".gitignore",
+                ".github/workflows/winoe-evidence-capture.yml",
+            ],
+            "files_changed_count": 4,
+            "insertions": 180,
+            "deletions": 0,
+        },
+        {
+            "sha": _stable_hex(full_name, seq, "commit-2"),
+            "timestamp": _stable_time(full_name, seq, "commit-2"),
+            "message": "Add devcontainer and workspace README",
+            "files_changed": [".devcontainer/devcontainer.json", "README.md"],
+            "files_changed_count": 2,
+            "insertions": 68,
+            "deletions": 0,
+        },
+        {
+            "sha": _stable_hex(full_name, seq, "commit-3"),
+            "timestamp": _stable_time(full_name, seq, "commit-3"),
+            "message": "Add workspace scaffolding and tests",
+            "files_changed": [
+                "src/app.py",
+                "src/services/provisioning.py",
+                "tests/test_app.py",
+                "tests/test_provisioning.py",
+            ],
+            "files_changed_count": 4,
+            "insertions": 154,
+            "deletions": 0,
+        },
+        {
+            "sha": head_sha,
+            "timestamp": _stable_time(full_name, seq, "head"),
+            "message": "Document local run and handoff instructions",
+            "files_changed": ["docs/runbook.md"],
+            "files_changed_count": 1,
+            "insertions": 22,
+            "deletions": 0,
+        },
+    ]
+    return commits
+
+
+def _fake_detection_payload(full_name: str, seq: int) -> dict[str, Any]:
+    return {
+        "detected": True,
+        "tool": "python",
+        "command": "python -m pytest",
+        "manifest_path": "pyproject.toml",
+        "reason": "detected from pyproject.toml",
+        "summary": {
+            "projectType": "python",
+            "workspace": full_name,
+            "entryPoint": "src/app.py",
+            "runSequence": seq,
+        },
+    }
+
+
+def _fake_test_results(full_name: str, seq: int) -> dict[str, Any]:
+    passed = 14 + _stable_int(full_name, seq, "passed", start=0, stop=7)
+    failed = 0 if seq % 3 else 1
+    total = passed + failed
+    return {
+        "passed": passed,
+        "failed": failed,
+        "total": total,
+        "stdout": (
+            "Collected deterministic demo results.\n"
+            f"Workspace: {full_name}\n"
+            "All core provisioning checks completed."
+        ),
+        "stderr": "" if failed == 0 else "1 test failed in demo rehearsal mode.",
+        "summary": {
+            "suite": "demo-rehearsal",
+            "status": "passed" if failed == 0 else "failed",
+            "filesTouched": [
+                "README.md",
+                "src/app.py",
+                "tests/test_app.py",
+            ],
+        },
+    }
+
+
+def _fake_lint_results(full_name: str, _seq: int) -> dict[str, Any]:
+    return {
+        "passed": 1,
+        "failed": 0,
+        "total": 1,
+        "stdout": f"ruff check .\n{full_name}: no issues found.",
+        "stderr": "",
+        "summary": {
+            "suite": "lint",
+            "status": "passed",
+            "ruleCount": 0,
+        },
+    }
+
+
+def _fake_manifest_payload(full_name: str, seq: int) -> dict[str, Any]:
+    return {
+        "detected": True,
+        "manifests": [
+            {
+                "path": "pyproject.toml",
+                "kind": "python",
+                "test_command": "python -m pytest",
+                "lint_command": "python -m ruff check .",
+                "reason": "demo workspace manifest",
+            }
+        ],
+        "summary": {
+            "workspace": full_name,
+            "runSequence": seq,
+        },
+    }
+
+
+def _artifact_zip(payload_name: str, payload: dict[str, Any]) -> bytes:
+    buffer = io.BytesIO()
+    with ZipFile(buffer, "w", compression=ZIP_DEFLATED) as zf:
+        zf.writestr(f"{payload_name}.json", json.dumps(payload, sort_keys=True))
+    return buffer.getvalue()
+
+
+@dataclass(slots=True)
+class _CommitState:
+    sha: str
+    tree_sha: str
+    parents: list[str]
+    message: str
+    files: list[str]
+    timestamp: str
+
+
+@dataclass(slots=True)
+class _RunState:
+    run_id: int
+    workflow_file: str
+    ref: str
+    seq: int
+    head_sha: str
+    status: str
+    conclusion: str | None
+    created_at: str
+    html_url: str
+    artifacts: list[dict[str, Any]] = field(default_factory=list)
+    artifact_zip_by_id: dict[int, bytes] = field(default_factory=dict)
+    compare_payload: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(slots=True)
+class _RepoState:
+    full_name: str
+    owner: str
+    name: str
+    repo_id: int
+    default_branch: str
+    archived: bool = False
+    collaborators: set[str] = field(default_factory=set)
+    files: dict[str, str] = field(default_factory=dict)
+    branches: dict[str, str] = field(default_factory=dict)
+    blobs: dict[str, str] = field(default_factory=dict)
+    trees: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    commits: dict[str, _CommitState] = field(default_factory=dict)
+    runs: dict[int, _RunState] = field(default_factory=dict)
+    codespace_name: str | None = None
+    codespace_state: str | None = None
+    codespace_url: str | None = None
+    next_run_seq: int = 1
+
+
+class FakeGithubClient:
+    """Deterministic fake GitHub provider for local/demo rehearsals."""
+
+    def __init__(
+        self,
+        *,
+        base_url: str = "https://api.github.com",
+        token: str = "",
+        default_org: str | None = None,
+    ) -> None:
+        self.base_url = base_url.rstrip("/")
+        self.token = token
+        self.default_org = default_org
+        self._repos: dict[str, _RepoState] = {}
+        self._commit_by_sha: dict[str, _CommitState] = {}
+        self._tree_by_sha: dict[str, list[dict[str, Any]]] = {}
+        self._blob_by_sha: dict[str, str] = {}
+        self._run_by_repo: dict[str, dict[int, _RunState]] = {}
+
+    async def aclose(self) -> None:
+        """No-op close hook for interface compatibility."""
+
+    async def get_authenticated_user_login(self) -> str | None:
+        """Return the deterministic demo login."""
+        return _DEMO_BOT_LOGIN
+
+    async def create_empty_repo(
+        self,
+        *,
+        owner: str,
+        repo_name: str,
+        private: bool = True,
+        default_branch: str = _DEFAULT_BRANCH,
+    ) -> dict[str, Any]:
+        """Create a deterministic empty repo payload."""
+        state = self._ensure_repo_state(owner, repo_name, default_branch)
+        state.archived = False
+        return self._repo_payload(state, private=private)
+
+    async def get_repo(self, repo_full_name: str) -> dict[str, Any]:
+        """Return repository metadata."""
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        return self._repo_payload(state)
+
+    async def archive_repo(self, repo_full_name: str) -> dict[str, Any]:
+        """Archive the repository in memory."""
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        state.archived = True
+        return self._repo_payload(state)
+
+    async def unarchive_repo(self, repo_full_name: str) -> dict[str, Any]:
+        """Unarchive the repository in memory."""
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        state.archived = False
+        return self._repo_payload(state)
+
+    async def delete_repo(self, repo_full_name: str) -> dict[str, Any]:
+        """Delete the repository from memory."""
+        self._repos.pop(repo_full_name, None)
+        self._run_by_repo.pop(repo_full_name, None)
+        return {"deleted": True, "full_name": repo_full_name}
+
+    async def add_collaborator(
+        self, repo_full_name: str, username: str, *, permission: str = "push"
+    ) -> dict[str, Any]:
+        """Add a collaborator to the fake repository."""
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        state.collaborators.add(username)
+        return {
+            "permission": permission,
+            "repository": {"full_name": repo_full_name},
+            "user": {"login": username},
+        }
+
+    async def remove_collaborator(
+        self, repo_full_name: str, username: str
+    ) -> dict[str, Any]:
+        """Remove a collaborator from the fake repository."""
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        state.collaborators.discard(username)
+        return {"removed": True, "repository": {"full_name": repo_full_name}}
+
+    async def get_branch(self, repo_full_name: str, branch: str) -> dict[str, Any]:
+        """Return branch metadata."""
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        branch_name = _strip_ref(branch)
+        sha = state.branches.get(branch_name)
+        if sha is None:
+            raise GithubError("Branch not found", status_code=404)
+        return {
+            "name": branch_name,
+            "commit": {
+                "sha": sha,
+                "url": f"{self.base_url}/repos/{repo_full_name}/commits/{sha}",
+            },
+        }
+
+    async def get_ref(self, repo_full_name: str, ref: str) -> dict[str, Any]:
+        """Return git ref metadata."""
+        branch_name = _strip_ref(ref)
+        branch = await self.get_branch(repo_full_name, branch_name)
+        return {
+            "ref": f"refs/heads/{branch_name}",
+            "object": {"sha": branch["commit"]["sha"], "type": "commit"},
+        }
+
+    async def create_ref(
+        self, repo_full_name: str, *, ref: str, sha: str
+    ) -> dict[str, Any]:
+        """Create a git ref."""
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        branch_name = _strip_ref(ref)
+        state.branches[branch_name] = sha
+        return {"ref": f"refs/heads/{branch_name}", "object": {"sha": sha}}
+
+    async def update_ref(
+        self,
+        repo_full_name: str,
+        *,
+        ref: str,
+        sha: str,
+        force: bool = False,
+    ) -> dict[str, Any]:
+        """Update a git ref."""
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        branch_name = _strip_ref(ref)
+        state.branches[branch_name] = sha
+        return {
+            "ref": f"refs/heads/{branch_name}",
+            "object": {"sha": sha},
+            "force": force,
+        }
+
+    async def get_file_contents(
+        self, repo_full_name: str, file_path: str, *, ref: str | None = None
+    ) -> dict[str, Any]:
+        """Return file contents for the fake repository."""
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        content = state.files.get(file_path)
+        if content is None:
+            raise GithubError("File not found", status_code=404)
+        blob_sha = _stable_hex(repo_full_name, file_path, content)
+        return {
+            "path": file_path,
+            "sha": blob_sha,
+            "content": base64.b64encode(content.encode("utf-8")).decode("ascii"),
+            "encoding": "base64",
+            "ref": ref or state.default_branch,
+        }
+
+    async def create_or_update_file(
+        self,
+        repo_full_name: str,
+        file_path: str,
+        *,
+        content: str,
+        message: str,
+        branch: str | None = None,
+        sha: str | None = None,
+    ) -> dict[str, Any]:
+        """Create or update a file in the fake repository."""
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        branch_name = _strip_ref(branch or state.default_branch)
+        state.files[file_path] = content
+        commit_sha = _stable_hex(
+            repo_full_name, branch_name, file_path, message, content, sha or ""
+        )
+        tree_sha = _stable_hex(repo_full_name, branch_name, "tree", file_path, content)
+        state.branches[branch_name] = commit_sha
+        state.trees[tree_sha] = [{"path": file_path, "content": content}]
+        state.commits[commit_sha] = _CommitState(
+            sha=commit_sha,
+            tree_sha=tree_sha,
+            parents=[],
+            message=message,
+            files=[file_path],
+            timestamp=_stable_time(repo_full_name, branch_name, file_path, message),
+        )
+        self._commit_by_sha[commit_sha] = state.commits[commit_sha]
+        self._tree_by_sha[tree_sha] = state.trees[tree_sha]
+        return {
+            "content": {"path": file_path, "sha": _stable_hex(content, file_path)},
+            "commit": {
+                "sha": commit_sha,
+                "message": message,
+                "tree": {"sha": tree_sha},
+            },
+        }
+
+    async def create_blob(
+        self,
+        repo_full_name: str,
+        *,
+        content: str,
+        encoding: str = "utf-8",
+    ) -> dict[str, Any]:
+        """Create a fake git blob."""
+        del encoding
+        sha = _stable_hex(repo_full_name, content, "blob")
+        self._blob_by_sha[sha] = content
+        return {"sha": sha}
+
+    async def create_tree(
+        self,
+        repo_full_name: str,
+        *,
+        tree: list[dict],
+        base_tree: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a fake git tree."""
+        tree_sha = _stable_hex(
+            repo_full_name, json.dumps(tree, sort_keys=True), base_tree
+        )
+        self._tree_by_sha[tree_sha] = list(tree)
+        return {"sha": tree_sha}
+
+    async def get_commit(self, repo_full_name: str, commit_sha: str) -> dict[str, Any]:
+        """Return a fake git commit."""
+        del repo_full_name
+        commit = self._commit_by_sha.get(commit_sha)
+        if commit is None:
+            return {
+                "sha": commit_sha,
+                "tree": {"sha": _stable_hex(commit_sha, "tree")},
+                "parents": [],
+                "message": "demo commit",
+            }
+        return {
+            "sha": commit.sha,
+            "tree": {"sha": commit.tree_sha},
+            "parents": [{"sha": parent} for parent in commit.parents],
+            "message": commit.message,
+        }
+
+    async def create_commit(
+        self,
+        repo_full_name: str,
+        *,
+        message: str,
+        tree: str,
+        parents: list[str],
+    ) -> dict[str, Any]:
+        """Create a fake git commit."""
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        files = [
+            entry.get("path")
+            for entry in self._tree_by_sha.get(tree, [])
+            if entry.get("path")
+        ]
+        commit_sha = _stable_hex(
+            repo_full_name, message, tree, json.dumps(parents, sort_keys=True)
+        )
+        commit = _CommitState(
+            sha=commit_sha,
+            tree_sha=tree,
+            parents=list(parents),
+            message=message,
+            files=[str(path) for path in files],
+            timestamp=_stable_time(repo_full_name, message, tree),
+        )
+        state.commits[commit_sha] = commit
+        self._commit_by_sha[commit_sha] = commit
+        return {
+            "sha": commit_sha,
+            "tree": {"sha": tree},
+            "parents": [{"sha": sha} for sha in parents],
+        }
+
+    async def list_commits(
+        self,
+        repo_full_name: str,
+        *,
+        sha: str | None = None,
+        per_page: int = 30,
+    ) -> list[dict[str, Any]]:
+        """Return a fake commit history."""
+        del per_page
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        if sha and sha in state.commits:
+            commit = state.commits[sha]
+            return [
+                {
+                    "sha": commit.sha,
+                    "commit": {
+                        "message": commit.message,
+                        "author": {"date": commit.timestamp},
+                    },
+                }
+            ]
+        return [
+            {
+                "sha": commit.sha,
+                "commit": {
+                    "message": commit.message,
+                    "author": {"date": commit.timestamp},
+                },
+            }
+            for commit in state.commits.values()
+        ]
+
+    async def create_codespace(
+        self,
+        repo_full_name: str,
+        *,
+        ref: str | None = None,
+        devcontainer_path: str = ".devcontainer/devcontainer.json",
+        machine: str | None = None,
+        location: str | None = None,
+    ) -> dict[str, Any]:
+        """Create a deterministic fake Codespace."""
+        del machine, location
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        branch_name = _strip_ref(ref or state.default_branch)
+        repo_name = _repo_owner_name(repo_full_name)[1]
+        name = _fake_codespace_name(repo_name, branch_name)
+        web_url = f"{_DEMO_CODESPACE_BASE_URL}/{repo_name}?ref={branch_name}"
+        state.codespace_name = name
+        state.codespace_state = "available"
+        state.codespace_url = web_url
+        return {
+            "name": name,
+            "state": "available",
+            "web_url": web_url,
+            "repository": {"full_name": repo_full_name},
+            "devcontainer_path": devcontainer_path,
+        }
+
+    async def get_codespace(
+        self, repo_full_name: str, codespace_name: str
+    ) -> dict[str, Any]:
+        """Return a deterministic fake Codespace payload."""
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        if state.codespace_name and state.codespace_name != codespace_name:
+            raise GithubError("Codespace not found", status_code=404)
+        if state.codespace_name is None:
+            state.codespace_name = codespace_name
+            state.codespace_state = "available"
+            state.codespace_url = (
+                f"{_DEMO_CODESPACE_BASE_URL}/{_repo_owner_name(repo_full_name)[1]}"
+            )
+        return {
+            "name": state.codespace_name,
+            "state": state.codespace_state or "available",
+            "web_url": state.codespace_url,
+            "repository": {"full_name": repo_full_name},
+        }
+
+    async def trigger_workflow_dispatch(
+        self,
+        repo_full_name: str,
+        workflow_id_or_file: str,
+        *,
+        ref: str,
+        inputs: dict | None = None,
+    ) -> None:
+        """Create a deterministic fake workflow run."""
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        run_seq = state.next_run_seq
+        state.next_run_seq += 1
+        run_id = _fake_workflow_run_id(repo_full_name, run_seq)
+        head_sha = _fake_workflow_head_sha(repo_full_name, run_seq)
+        requested_inputs = {
+            key: "" if value is None else str(value)
+            for key, value in sorted((inputs or {}).items())
+        }
+        compare_payload = {
+            "ahead_by": len(_fake_compare_files(repo_full_name, run_seq)),
+            "behind_by": 0,
+            "total_commits": 3,
+            "files": _fake_compare_files(repo_full_name, run_seq),
+            "requested_inputs": requested_inputs,
+        }
+        artifacts = self._build_run_artifacts(repo_full_name, run_seq)
+        run = _RunState(
+            run_id=run_id,
+            workflow_file=workflow_id_or_file,
+            ref=_strip_ref(ref),
+            seq=run_seq,
+            head_sha=head_sha,
+            status="completed",
+            conclusion="success" if run_seq % 3 else "failure",
+            created_at=_stable_time(repo_full_name, run_seq, "workflow-run"),
+            html_url=f"https://github.com/{repo_full_name}/actions/runs/{run_id}",
+            artifacts=artifacts[0],
+            artifact_zip_by_id=artifacts[1],
+            compare_payload=compare_payload,
+        )
+        state.runs[run_id] = run
+        self._run_by_repo.setdefault(repo_full_name, {})[run_id] = run
+
+    async def list_workflow_runs(
+        self,
+        repo_full_name: str,
+        workflow_id_or_file: str,
+        *,
+        branch: str | None = None,
+        per_page: int = 5,
+    ) -> list[WorkflowRun]:
+        """Return fake workflow runs for the repository."""
+        del per_page
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        runs = [
+            run
+            for run in state.runs.values()
+            if run.workflow_file == workflow_id_or_file
+            and (branch is None or _strip_ref(branch) == run.ref)
+        ]
+        runs.sort(key=lambda item: item.run_id, reverse=True)
+        return [self._workflow_run_payload(run) for run in runs]
+
+    async def get_workflow_run(self, repo_full_name: str, run_id: int) -> WorkflowRun:
+        """Return a single fake workflow run."""
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        run = state.runs.get(run_id)
+        if run is None:
+            raise GithubError("Workflow run not found", status_code=404)
+        return self._workflow_run_payload(run)
+
+    async def list_artifacts(
+        self, repo_full_name: str, run_id: int
+    ) -> list[dict[str, Any]]:
+        """Return fake workflow artifacts."""
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        run = state.runs.get(run_id)
+        if run is None:
+            return []
+        return list(run.artifacts)
+
+    async def download_artifact_zip(
+        self, repo_full_name: str, artifact_id: int
+    ) -> bytes:
+        """Return fake artifact zip bytes."""
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        for run in state.runs.values():
+            if artifact_id in run.artifact_zip_by_id:
+                return run.artifact_zip_by_id[artifact_id]
+        raise GithubError("Artifact not found", status_code=404)
+
+    async def get_compare(
+        self, repo_full_name: str, base: str, head: str
+    ) -> dict[str, Any]:
+        """Return a deterministic compare payload."""
+        state = self._ensure_repo_state_from_full_name(repo_full_name)
+        head_run = next(
+            (run for run in state.runs.values() if run.head_sha == head), None
+        )
+        if head_run is not None:
+            payload = dict(head_run.compare_payload)
+            payload["base_commit"] = {"sha": base}
+            payload["head_commit"] = {"sha": head}
+            return payload
+        base_commit = state.commits.get(base)
+        head_commit = state.commits.get(head)
+        if base_commit is None and head_commit is None:
+            return {
+                "ahead_by": 1,
+                "behind_by": 0,
+                "total_commits": 1,
+                "files": _fake_compare_files(repo_full_name, 1),
+                "base_commit": {"sha": base},
+                "head_commit": {"sha": head},
+            }
+        base_files = set(base_commit.files if base_commit else [])
+        head_files = set(head_commit.files if head_commit else [])
+        files: list[dict[str, Any]] = []
+        for path in sorted(head_files - base_files):
+            files.append(
+                {
+                    "filename": path,
+                    "status": "added",
+                    "additions": 12,
+                    "deletions": 0,
+                    "changes": 12,
+                    "patch": f"@@ -0,0 +1,12 @@\n+{path}\n",
+                }
+            )
+        return {
+            "ahead_by": len(files),
+            "behind_by": 0,
+            "total_commits": 1,
+            "files": files,
+            "base_commit": {"sha": base},
+            "head_commit": {"sha": head},
+        }
+
+    async def generate_repo_from_template(self, *_args, **_kwargs):
+        """This legacy path is unsupported in demo mode."""
+        raise GithubError("This path is not supported in demo mode")
+
+    def _ensure_repo_state(
+        self, owner: str, repo_name: str, default_branch: str
+    ) -> _RepoState:
+        full_name = f"{owner}/{repo_name}"
+        state = self._repos.get(full_name)
+        if state is not None:
+            return state
+        repo_id = _stable_int(full_name, "repo-id", start=10_000, stop=99_999)
+        state = _RepoState(
+            full_name=full_name,
+            owner=owner,
+            name=repo_name,
+            repo_id=repo_id,
+            default_branch=default_branch,
+        )
+        self._repos[full_name] = state
+        return state
+
+    def _ensure_repo_state_from_full_name(self, repo_full_name: str) -> _RepoState:
+        owner, repo_name = _repo_owner_name(repo_full_name)
+        return self._ensure_repo_state(owner, repo_name, _DEFAULT_BRANCH)
+
+    def _repo_payload(
+        self, state: _RepoState, *, private: bool = True
+    ) -> dict[str, Any]:
+        return {
+            "id": state.repo_id,
+            "name": state.name,
+            "full_name": state.full_name,
+            "private": private,
+            "archived": state.archived,
+            "default_branch": state.default_branch,
+            "html_url": f"https://github.com/{state.full_name}",
+            "url": f"https://api.github.com/repos/{state.full_name}",
+            "owner": {"login": state.owner},
+        }
+
+    def _workflow_run_payload(self, run: _RunState) -> WorkflowRun:
+        return WorkflowRun(
+            id=run.run_id,
+            status=run.status,
+            conclusion=run.conclusion,
+            html_url=run.html_url,
+            head_sha=run.head_sha,
+            artifact_count=len(run.artifacts),
+            event="workflow_dispatch",
+            created_at=run.created_at,
+        )
+
+    def _build_run_artifacts(
+        self, repo_full_name: str, seq: int
+    ) -> tuple[list[dict[str, Any]], dict[int, bytes]]:
+        base_id = _stable_int(
+            repo_full_name, seq, "artifact-base", start=1_000, stop=9_999
+        )
+        artifact_json_names = {
+            "winoe-commit-metadata": "commit_metadata",
+            "winoe-file-creation-timeline": "file_creation_timeline",
+            "winoe-repo-tree-summary": "repo_tree_summary",
+            "winoe-dependency-manifests": "dependency_manifests",
+            "winoe-test-detection": "test_detection",
+            "winoe-test-results": "test_results",
+            "winoe-lint-detection": "lint_detection",
+            "winoe-lint-results": "lint_results",
+            "winoe-evidence-manifest": "evidence_manifest",
+        }
+        payloads: dict[str, dict[str, Any]] = {
+            "winoe-commit-metadata": {
+                "head_commit": _fake_workflow_head_sha(repo_full_name, seq),
+                "commits": _fake_commit_story(repo_full_name, seq),
+            },
+            "winoe-file-creation-timeline": {
+                "files": [
+                    {
+                        "commit_sha": _stable_hex(
+                            repo_full_name, "bootstrap", length=40
+                        ),
+                        "timestamp": _stable_time(repo_full_name, "bootstrap"),
+                        "message": "Initialize empty Trial workspace",
+                        "files": [
+                            ".devcontainer/devcontainer.json",
+                            "README.md",
+                            ".gitignore",
+                            ".github/workflows/winoe-evidence-capture.yml",
+                        ],
+                    },
+                    {
+                        "commit_sha": _stable_hex(repo_full_name, seq, "commit-3"),
+                        "timestamp": _stable_time(repo_full_name, seq, "commit-3"),
+                        "message": "Add workspace scaffolding and tests",
+                        "files": [
+                            "src/app.py",
+                            "src/services/provisioning.py",
+                            "tests/test_app.py",
+                        ],
+                    },
+                ],
+                "best_effort": False,
+            },
+            "winoe-repo-tree-summary": {
+                "files": [
+                    ".devcontainer/devcontainer.json",
+                    ".gitignore",
+                    ".github/workflows/winoe-evidence-capture.yml",
+                    "README.md",
+                    "docs/runbook.md",
+                    "src/app.py",
+                    "src/services/provisioning.py",
+                    "tests/test_app.py",
+                    "tests/test_provisioning.py",
+                ],
+                "directories": [
+                    [".devcontainer", 1],
+                    [".github/workflows", 1],
+                    ["docs", 1],
+                    ["src", 2],
+                    ["tests", 2],
+                ],
+                "extension_counts": [
+                    [".json", 1],
+                    [".md", 2],
+                    [".py", 4],
+                    [".yml", 1],
+                    ["[no extension]", 1],
+                ],
+                "file_count": 9,
+            },
+            "winoe-dependency-manifests": _fake_manifest_payload(repo_full_name, seq),
+            "winoe-test-detection": _fake_detection_payload(repo_full_name, seq),
+            "winoe-test-results": _fake_test_results(repo_full_name, seq),
+            "winoe-lint-detection": {
+                "detected": True,
+                "tool": "ruff",
+                "command": "python -m ruff check .",
+                "manifest_path": "pyproject.toml",
+                "reason": "detected from pyproject.toml",
+            },
+            "winoe-lint-results": _fake_lint_results(repo_full_name, seq),
+            "winoe-evidence-manifest": {
+                "artifacts": [
+                    {"name": name, "status": "success"}
+                    for name in _EVIDENCE_ARTIFACT_NAMES
+                ],
+                "generated_artifacts": list(_EVIDENCE_ARTIFACT_NAMES),
+                "best_effort": True,
+            },
+        }
+        artifacts: list[dict[str, Any]] = []
+        artifact_zip_by_id: dict[int, bytes] = {}
+        for index, name in enumerate(_EVIDENCE_ARTIFACT_NAMES, start=1):
+            artifact_id = base_id + index
+            payload = payloads[name]
+            artifact_zip = _artifact_zip(artifact_json_names[name], payload)
+            artifact_zip_by_id[artifact_id] = artifact_zip
+            artifacts.append(
+                {
+                    "id": artifact_id,
+                    "name": name,
+                    "size_in_bytes": len(artifact_zip),
+                    "archive_download_url": (
+                        f"https://github.com/{repo_full_name}/suites/{seq}/artifacts/{artifact_id}"
+                    ),
+                    "expired": False,
+                    "workflow_run": {"id": _fake_workflow_run_id(repo_full_name, seq)},
+                }
+            )
+        return artifacts, artifact_zip_by_id
+
+
+@lru_cache(maxsize=1)
+def get_fake_github_client() -> FakeGithubClient:
+    """Return the singleton fake GitHub provider."""
+    logger.warning(
+        "DEMO MODE ACTIVE: using fake GitHub provider; no GitHub resources will be created.",
+        extra={
+            "demo_mode": True,
+            "env": str(getattr(settings, "ENV", "") or "").lower(),
+        },
+    )
+    return FakeGithubClient(
+        base_url=settings.github.GITHUB_API_BASE,
+        token=settings.github.GITHUB_TOKEN,
+        default_org=settings.github.GITHUB_ORG or None,
+    )
+
+
+__all__ = ["FakeGithubClient", "get_fake_github_client"]

--- a/app/shared/http/dependencies/shared_http_dependencies_admin_demo_utils.py
+++ b/app/shared/http/dependencies/shared_http_dependencies_admin_demo_utils.py
@@ -30,7 +30,7 @@ async def require_demo_mode_admin(
     db: Annotated[AsyncSession, Depends(get_session)],
 ) -> DemoAdminActor:
     """Require demo mode admin."""
-    if not bool(settings.DEMO_MODE):
+    if not settings.demo_mode_enabled:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Not found")
 
     principal = await get_principal(credentials, request)

--- a/app/shared/http/dependencies/shared_http_dependencies_github_native_utils.py
+++ b/app/shared/http/dependencies/shared_http_dependencies_github_native_utils.py
@@ -10,15 +10,14 @@ from fastapi import Depends
 from app.config import settings
 from app.integrations.github import GithubClient
 from app.integrations.github.actions_runner import GithubActionsRunner
+from app.integrations.github.integrations_github_factory_client import (
+    get_github_provisioning_client,
+)
 
 
 @lru_cache(maxsize=1)
 def _github_client_singleton() -> GithubClient:
-    return GithubClient(
-        base_url=settings.github.GITHUB_API_BASE,
-        token=settings.github.GITHUB_TOKEN,
-        default_org=settings.github.GITHUB_ORG or None,
-    )
+    return get_github_provisioning_client()
 
 
 def get_github_client() -> GithubClient:
@@ -40,7 +39,8 @@ def get_actions_runner(
     github_client: Annotated[GithubClient, Depends(get_github_client)],
 ) -> GithubActionsRunner:
     """Actions runner dependency with configured workflow file."""
-    if github_client is not _github_client_singleton():
+    current_client = _github_client_singleton()
+    if github_client is not current_client:
         return GithubActionsRunner(
             github_client,
             workflow_file=settings.github.GITHUB_ACTIONS_WORKFLOW_FILE,

--- a/app/shared/http/schemas/shared_http_schemas_readiness_schema.py
+++ b/app/shared/http/schemas/shared_http_schemas_readiness_schema.py
@@ -36,3 +36,4 @@ class ReadinessPayload(APIModel):
     status: ReadinessPayloadStatus
     checkedAt: str
     checks: ReadinessChecks
+    demoMode: bool = False

--- a/app/shared/http/shared_http_readiness_service.py
+++ b/app/shared/http/shared_http_readiness_service.py
@@ -311,8 +311,7 @@ def _check_github_readiness() -> ReadinessCheck:
     github_cfg = settings.github
     token = str(github_cfg.GITHUB_TOKEN or "").strip()
     org = str(github_cfg.GITHUB_ORG or "").strip()
-    template_owner = str(github_cfg.GITHUB_TEMPLATE_OWNER or "").strip()
-    if settings.DEMO_MODE and not token and not org and not template_owner:
+    if settings.demo_mode_enabled:
         return _readiness_check(
             status="skipped",
             code="demo_mode",
@@ -324,11 +323,11 @@ def _check_github_readiness() -> ReadinessCheck:
             code="no_provider_configured",
             detail="GitHub token is missing.",
         )
-    if not org and not template_owner:
+    if not org:
         return _readiness_check(
             status="not_ready",
             code="missing_github_org",
-            detail="GitHub org or template owner is missing.",
+            detail="GitHub org is missing.",
         )
     return _readiness_check(
         status="ready",
@@ -337,7 +336,6 @@ def _check_github_readiness() -> ReadinessCheck:
         data={
             "apiBase": github_cfg.GITHUB_API_BASE,
             "orgConfigured": bool(org),
-            "templateOwnerConfigured": bool(template_owner),
         },
     )
 
@@ -488,6 +486,7 @@ async def build_readiness_payload(
         else "not_ready"
     )
     return {
+        "demoMode": settings.demo_mode_enabled,
         "status": overall_status,
         "checkedAt": resolved_now.isoformat().replace("+00:00", "Z"),
         "checks": checks,

--- a/app/shared/jobs/handlers/shared_jobs_handlers_github_workflow_artifact_parse_handler.py
+++ b/app/shared/jobs/handlers/shared_jobs_handlers_github_workflow_artifact_parse_handler.py
@@ -8,6 +8,9 @@ from typing import Any
 from app.config import settings
 from app.integrations.github import GithubClient
 from app.integrations.github.actions_runner import GithubActionsRunner
+from app.integrations.github.integrations_github_factory_client import (
+    get_github_provisioning_client,
+)
 from app.integrations.github.webhooks.handlers.integrations_github_webhooks_handlers_workflow_run_handler import (
     GITHUB_WORKFLOW_ARTIFACT_PARSE_JOB_TYPE,
 )
@@ -44,11 +47,7 @@ def _normalized_text(value: Any) -> str | None:
 
 
 def _build_actions_runner() -> tuple[GithubActionsRunner, GithubClient]:
-    github_client = GithubClient(
-        base_url=settings.github.GITHUB_API_BASE,
-        token=settings.github.GITHUB_TOKEN,
-        default_org=settings.github.GITHUB_ORG or None,
-    )
+    github_client = get_github_provisioning_client()
     runner = GithubActionsRunner(
         github_client,
         workflow_file=settings.github.GITHUB_ACTIONS_WORKFLOW_FILE,

--- a/app/trials/services/trials_services_trials_scenario_generation_env_service.py
+++ b/app/trials/services/trials_services_trials_scenario_generation_env_service.py
@@ -23,9 +23,11 @@ def _is_truthy(value) -> bool:
 
 def is_demo_mode_enabled() -> bool:
     """Return whether demo mode enabled."""
-    if _is_truthy(getattr(settings, "DEMO_MODE", False)):
+    if settings.demo_mode_enabled:
         return True
-    if any(_is_truthy(os.getenv(key)) for key in DEMO_MODE_ENV_KEYS):
+    if not settings.is_production_environment() and any(
+        _is_truthy(os.getenv(key)) for key in DEMO_MODE_ENV_KEYS
+    ):
         return True
     return allow_demo_or_test_mode(resolve_scenario_generation_config().runtime_mode)
 

--- a/pr.md
+++ b/pr.md
@@ -1,236 +1,193 @@
+## Title
+
+Add deterministic demo provisioning mode with fake GitHub provider for local/YC rehearsal
+
 ## Summary
 
-Implement policy-driven media retention and purge scheduling for Day 4 media artifacts.
+Added production-safe `DEMO_MODE` support for deterministic fake GitHub provisioning used for Winoe AI local and YC rehearsal flows.
 
-This PR adds configurable retention metadata, an expired-media purge path, privacy-safe purge audit records, and a scoped data-request deletion hook. The purge flow redacts transcript content while preserving auditability and Evidence Trail shape.
+The real GitHub provider remains the default and is unchanged. Demo mode is blocked in production, and the fake provider returns stable repo URLs, Codespace URLs, workflow metadata, commit SHAs, compare data, and artifact outputs so Candidate Day 2/3 workspace views and Evidence Trail paths can render without touching real GitHub.
 
-## What changed
+The original issue’s template-generation wording is retired by the v4 pivot. This implementation simulates empty-repo from-scratch provisioning instead.
 
-- Added configurable media retention via `MEDIA_RETENTION_DAYS`.
-- Added retention expiration and purge metadata to recording assets.
-- Added media purge audit records for retention and data-request purges.
-- Added expired-media purge service behavior.
-- Registered the `media_retention_purge` shared worker handler.
-- Added script/operator paths for triggering retention purge.
-- Added scoped data-request media purge support for Candidate sessions.
-- Redacted transcript text/segments during purge instead of silently hard-deleting transcript rows.
-- Preserved idempotency for already-purged media and missing storage objects.
-- Added tests for config, retention selection, purge behavior, audit records, worker registration, operator route behavior, missing storage, and data-request scoping.
+## Why this matters
 
-## Acceptance criteria
+Winoe AI rehearsals need to be fast, repeatable, and safe. Before this change, demo runs could create real repositories, Codespaces, and workflow runs, which made rehearsals slow, expensive, and fragile.
 
-- [x] Configurable retention period
-  - `MEDIA_RETENTION_DAYS` is configurable.
-  - Default remains `45`, matching the existing repo convention.
-  - Invalid values such as `0` are rejected.
+This update makes it possible to rehearse a full Trial, Project Brief, Candidate workspace, and Evidence Trail flow locally or in YC-facing demo environments without external GitHub side effects.
 
-- [x] Purge job for expired media
-  - Expired media is selected by retention metadata.
-  - Purge runs through the media privacy service.
-  - `media_retention_purge` is registered with the shared worker runtime.
-  - Admin/operator and script trigger paths are available.
-  - Purge is idempotent and safe to rerun.
+## Implementation Details
 
-- [x] Audit log for purge events
-  - `media_purge_audits` records purge attempts.
-  - Audit rows include media, Candidate session, Trial, actor, reason, outcome, and safe error summary where applicable.
-  - Worker/system purges use `actor_type=system`.
-  - Operator-triggered purges use `actor_type=operator`.
-  - Audit records do not include signed URLs, credentials, tokens, or raw transcript body.
+- Added `DEMO_MODE` config support in `app/config/`.
+- Added a fake GitHub provider alongside the real provider in `app/integrations/github/`.
+- Wired provisioning through a provider factory so workspace bootstrap, workflow artifact parsing, and readiness checks all respect demo mode.
+- Kept the real `GithubClient` as the default path.
+- Added safe production override behavior so `WINOE_ENV=production` disables demo mode even if `DEMO_MODE=true`.
+- Added deterministic demo data generation for:
+  - empty repository creation
+  - devcontainer/workspace bootstrap
+  - collaborator add
+  - Codespace create/get
+  - workflow dispatch
+  - workflow run metadata
+  - artifact list/download
+  - compare/diff metadata
 
-- [x] Deletion workflows for data requests
-  - Added `purge_candidate_session_media_for_data_request(...)`.
-  - Data-request purge is scoped to the requested Candidate session.
-  - Unrelated Candidate/Trial media is not touched.
-  - Reruns are idempotent.
-  - Audit reason is `data_request`.
+## Production Safety
 
-## QA evidence
+- `DEMO_MODE=true` only activates the fake provider outside production.
+- `ENV=production` or `WINOE_ENV=production` overrides `DEMO_MODE` and keeps the real provider active.
+- Readiness exposes a safe `demoMode` state and skips GitHub readiness in demo mode.
+- The demo-mode warning is logged without exposing secrets.
 
-### Migration / schema
+## Demo Behavior
 
-- `poetry run alembic upgrade head` passed.
-- `poetry run alembic heads` returned `202604200001 (head)`.
-- Verified schema:
-  - `recording_assets.retention_expires_at`
-  - `recording_assets.purge_reason`
-  - `recording_assets.purge_status`
-  - existing `recording_assets.purged_at`
-  - `media_purge_audits`
-- Verified indexes:
-  - `ix_recording_assets_retention_expires_purged`
-  - `ix_media_purge_audits_media_created_at`
-  - `ix_media_purge_audits_reason_created_at`
-  - `ix_media_purge_audits_candidate_session_created_at`
+The fake provider is deterministic for stable demo inputs. The same candidate/session inputs produce the same repo URL, Codespace URL, workflow run metadata, fake SHAs, and artifact names.
 
-### Config verification
+Representative QA samples:
 
-- `poetry run pytest --no-cov -q tests/config/test_config_storage_media_settings_utils.py`
-  - `11 passed in 0.59s`
-- Runtime checks:
-  - default `MEDIA_RETENTION_DAYS = 45`
-  - override `MEDIA_RETENTION_DAYS=7` works
-  - invalid `MEDIA_RETENTION_DAYS=0` is rejected
+- Candidate `7`
+  - repo: `winoe-workspaces/candidate-7`
+  - Codespace URL: `https://codespaces.demo.winoe.ai/candidate-7?ref=main`
+  - bootstrap SHA: `b2ebae120faea7c5b6f4d24f1679331c2180d4d6`
+- Candidate `8`
+  - repo: `winoe-workspaces/candidate-8`
+  - Codespace URL: `https://codespaces.demo.winoe.ai/candidate-8?ref=main`
+  - bootstrap SHA: `7d61e3332aa39d289027ea5bcc0e88e02fafbc37`
+- Candidate `11`
+  - repo: `winoe-workspaces/candidate-11`
+  - Codespace URL: `https://codespaces.demo.winoe.ai/candidate-11?ref=main`
+  - bootstrap SHA: `1d01f9a8daff9e31c5e2164a61235393abb35131`
+  - workflow run: `97838170`
+  - workflow run URL: `https://github.com/winoe-workspaces/candidate-11/actions/runs/97838170`
 
-### Focused automated tests
+Different candidate/session inputs produce distinct stable values, so separate rehearsals remain plausible while still being repeatable.
 
-- `poetry run pytest --no-cov -q tests/config tests/media tests/shared/jobs tests/talent_partners/routes/test_talent_partners_admin_media_purge_routes.py tests/integrations/storage_media/test_integrations_storage_media_s3_provider_delete_object_handles_success_and_missing_service.py`
-  - `332 passed in 19.34s`
+## Evidence Trail Behavior
 
-- Previously failing direct test:
-  - `poetry run pytest --no-cov -q tests/media/repositories/test_media_repositories_recordings_repository_retention_helpers_repository.py`
-  - `2 passed in 0.33s`
+Demo mode produces realistic Evidence Trail artifacts for a from-scratch workspace build, including commit history, file creation timeline, repo tree summary, dependency manifests, test detection, test results, lint detection, lint results, and the evidence manifest.
 
-### Full regression / precommit
+Evidence artifact examples:
 
-- `./precommit.sh`
-  - `1857 passed, 13 warnings`
-  - coverage `96.02%`
-  - required coverage `96%` reached
-  - all precommit checks passed
+- `winoe-commit-metadata`
+- `winoe-file-creation-timeline`
+- `winoe-repo-tree-summary`
+- `winoe-dependency-manifests`
+- `winoe-test-detection`
+- `winoe-test-results`
+- `winoe-lint-detection`
+- `winoe-lint-results`
+- `winoe-evidence-manifest`
 
-- `git diff --check`
-  - passed
+Representative evidence snippets:
 
-## Manual QA evidence
+- first commit message: `Initialize empty Trial workspace`
+- first commit files:
+  - `.devcontainer/devcontainer.json`
+  - `README.md`
+  - `.gitignore`
+  - `.github/workflows/winoe-evidence-capture.yml`
+- repo tree sample:
+  - `.devcontainer/devcontainer.json`
+  - `.gitignore`
+  - `.github/workflows/winoe-evidence-capture.yml`
+  - `README.md`
+  - `docs/runbook.md`
+- test results summary:
+  - `status: passed`
+  - `suite: demo-rehearsal`
+- lint results summary:
+  - `status: passed`
+  - `suite: lint`
 
-### Retention purge success path
+The workflow artifact parse path now uses the provider factory, so demo mode does not bypass fake GitHub when parsing Evidence Trail artifacts.
 
-Seeded:
-- Talent Partner
-- Trial
-- Candidate session
-- Day 4 handoff task
-- ready media asset
-- transcript with text/segments
-- fake storage object
-- expired `retention_expires_at`
+## Tests / QA
 
-Observed:
-- `scanned_count=1`
-- `purged_count=1`
-- `failed_count=0`
-- media `status=purged`
-- `purge_reason=retention_expired`
-- `purge_status=purged`
-- `purged_at` set
-- transcript row still exists
-- transcript `text=null`
-- transcript `segments_json=null`
-- transcript `deleted_at` set
-- storage object removed
-- audit row written with `outcome=success`
-- audit actor type `system`
-- audit actor id `null`
-- Candidate session and Trial context present
+### Full quality gate
 
-### Day 4 upload retention metadata
+- `python3 -m pytest ; echo "PYTEST_EXIT_CODE=$?"`
+  - Exit code: `0`
+  - Result: `1876 passed, 1 skipped`
+  - Coverage: `96.46%`
+  - `coverage.xml` written
+  - Shell printed `PYTEST_EXIT_CODE=0`
 
-Verified Day 4 upload completion sets retention metadata:
-- `status=uploaded`
-- `retention_expires_at` set
-- retention delta matches `45` days
+### Wrapper / precommit-equivalent
 
-### Idempotent rerun
+- `./precommit.sh ; echo "PRECOMMIT_EXIT_CODE=$?"`
+  - Exit code: `0`
+  - Result: `✅ All pre-commit checks passed!`
 
-Second purge against already-purged media:
-- `scanned_count=0`
-- `purged_count=0`
-- `failed_count=0`
-- media stayed purged
-- transcript stayed redacted
-- audit count remained stable
+### Lint / format
 
-### Missing storage object behavior
+- `.venv/bin/ruff check . ; echo "RUFF_CHECK_EXIT_CODE=$?"`
+  - Exit code: `0`
+- `.venv/bin/ruff format --check . ; echo "RUFF_FORMAT_EXIT_CODE=$?"`
+  - Exit code: `0`
 
-Seeded two expired assets:
-- one missing from storage
-- one present in storage
+### Focused #307 tests
 
-Observed:
-- `scanned_count=2`
-- `purged_count=2`
-- `failed_count=0`
-- both media records became purged
-- both transcripts redacted
-- audit rows written with `outcome=success`
-- missing object did not fail the batch
+```bash
+python3 -m pytest --no-cov \
+  tests/integrations/github/test_integrations_github_fake_provider_client.py \
+  tests/submissions/services/test_submissions_workspace_bootstrap_service.py \
+  tests/shared/http/test_shared_http_readiness_service.py \
+  tests/config/test_config_demo_mode_env_values_utils.py \
+  tests/shared/http/dependencies/test_shared_http_dependencies_github_native_service.py \
+  tests/shared/jobs/handlers/test_shared_jobs_handlers_github_workflow_artifact_parse_build_actions_runner_returns_configured_runner_and_client_handler.py \
+  ; echo "FOCUSED_EXIT_CODE=$?"
+```
 
-### Operator-triggered purge
+- Exit code: `0`
+- `36 passed`
 
-Direct admin route invocation returned:
-- `status=ok`
-- `scannedCount=1`
-- `purgedCount=1`
-- `skippedCount=0`
-- `failedCount=0`
+### Manual QA evidence
 
-Audit verified:
-- `actor_type=operator`
-- `actor_id=admin-qa-306`
-- `purge_reason=retention_expired`
+- Local non-production + `DEMO_MODE=true` returns `FakeGithubClient`.
+- Local non-production + `DEMO_MODE=false` returns real `GithubClient`.
+- Production / `WINOE_ENV=production` + `DEMO_MODE=true` suppresses the fake provider and returns real `GithubClient`.
+- Demo-mode warning is safe and does not expose secrets.
+- Same stable inputs return the same repo URL, Codespace URL, workflow metadata, fake SHAs, and artifact names.
+- Different candidate/session inputs produce distinct stable values.
+- Day 2/3 workspace bootstrap works using the fake provider without real GitHub calls.
+- Artifact parse / Evidence Trail path uses the fake provider in demo mode.
+- Readiness payload exposes `demoMode: true` in local demo mode and `demoMode: false` under the production override.
 
-### Shared worker/system purge
+## Grep Verification
 
-Verified:
-- `media_retention_purge` handler is registered.
-- Payload maps `batchLimit` and `retentionDays`.
-- Worker result:
-  - `scannedCount=1`
-  - `purgedCount=1`
-  - `skippedCount=0`
-  - `failedCount=0`
+Commands run:
 
-Audit verified:
-- `actor_type=system`
-- `actor_id=null`
-- `purge_reason=retention_expired`
+```bash
+grep -RniE --exclude-dir='__pycache__' "template_catalog|specializor|precommit|codespace_spec" app tests || true
+grep -RniE --exclude-dir='__pycache__' "Tenon|SimuHire|recruiter|simulation|Fit Profile|Fit Score" app tests || true
+grep -RniE --exclude-dir='__pycache__' "GithubClient\\(|from app.integrations.github.client import GithubClient|app.integrations.github.client" app tests || true
+```
 
-### Data-request deletion hook
+Summary:
 
-Seeded Candidate session A and B under the same Trial.
+- Retired-term hits remain in pre-existing migrations, schema compatibility code, and test assertions.
+- Negative assertion tests intentionally mention retired terms to prove absence.
+- No new active #307 demo path uses retired Winoe v3 or template-era concepts.
+- `GithubClient` hits are expected in the real provider, factory, runners, and tests.
 
-Ran `purge_candidate_session_media_for_data_request(...)` for Candidate session A only.
+## Risks / Follow-Ups
 
-Observed:
-- Candidate session A media purged.
-- Candidate session A transcript redacted.
-- Candidate session A audit reason `data_request`.
-- Candidate session A audit actor `operator`.
-- Candidate session A audit actor id `privacy-qa-operator`.
-- Candidate session B media remained uploaded.
-- Candidate session B transcript remained untouched.
-- Candidate session B had no audit row.
-- Rerun for Candidate session A returned no additional purge work.
+- Demo mode is deterministic by design, so it is appropriate for rehearsals but not for validating live GitHub behavior.
+- The fake provider covers the empty-repo from-scratch flow required for the v4 pivot, not the retired template-generation path.
+- Future changes to the real GitHub provisioning contract should be reflected in the fake provider to keep demo and production behavior aligned.
 
-## Security / privacy
+## Acceptance Criteria Checklist
 
-Verified #306 manual QA logs and audit rows do not contain:
-- signed URLs
-- access tokens
-- storage credentials
-- raw transcript body
-- raw transcript segments
-- full exception traces in operator-facing output
+- [x] `DEMO_MODE=true` switches GitHub integration to a fake provider outside production.
+- [x] Fake provider returns deterministic repo URLs, Codespace URLs, and workflow run metadata.
+- [x] Fake provider simulates empty repo creation, devcontainer commit, collaborator add, Codespace create, workflow dispatch, and artifact download.
+- [x] Candidate Day 2/3 can render a plausible workspace view in demo mode without hitting real GitHub.
+- [x] Evidence Trail in demo mode shows realistic fake commit SHAs, diff summaries, and test results.
+- [x] Demo mode is clearly distinguished from production.
+- [x] Demo mode cannot be enabled in production.
+- [x] Existing real GitHub provider remains the default and is unmodified.
+- [x] The original issue’s template-generation wording is retired by the v4 pivot.
+- [x] The implemented scope is empty-repo from-scratch provisioning.
 
-## Terminology check
-
-Changed-file terminology scan passed with zero hits for retired terms.
-
-## Notes / limitations
-
-- No app-level periodic scheduler/cron cadence exists in this repo.
-- This PR provides the registered shared worker handler, operator/admin trigger path, and script trigger path.
-- Deployment cadence for invoking the idempotent purge job remains an ops concern.
-
-## Risk
-
-Low-to-medium.
-
-The purge path touches privacy-sensitive media and Evidence Trail artifacts, so the risk is primarily around data deletion correctness and auditability. Manual QA covered success, rerun idempotency, missing storage, operator/system actor semantics, and scoped data-request deletion.
-
-## Rollback
-
-Revert this PR and run Alembic downgrade according to repo migration conventions if needed. Existing media records are only purged when the purge job/operator path runs; the migration itself adds metadata/audit structures and backfills retention timestamps.
-
-Fixes #306
+Fixes #307

--- a/tests/config/test_config_demo_mode_env_values_utils.py
+++ b/tests/config/test_config_demo_mode_env_values_utils.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+from tests.config.config_test_utils import *
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        ("true", True),
+        ("1", True),
+        ("false", False),
+        ("0", False),
+    ],
+)
+def test_demo_mode_env_values_parse_as_expected(monkeypatch, env_value, expected):
+    monkeypatch.setenv("WINOE_DEMO_MODE", env_value)
+    settings = Settings(_env_file=None, ENV="test")
+
+    assert settings.DEMO_MODE is expected
+    assert settings.demo_mode_enabled is expected
+
+
+@pytest.mark.parametrize(
+    ("env_key", "env_value"),
+    [
+        ("WINOE_ENV", "production"),
+        ("ENV", "production"),
+    ],
+)
+def test_demo_mode_is_disabled_in_production_even_when_requested(
+    monkeypatch, env_key, env_value
+):
+    monkeypatch.setenv("WINOE_DEMO_MODE", "true")
+    monkeypatch.setenv(env_key, env_value)
+
+    settings = Settings(
+        _env_file=None,
+        AUTH0_DOMAIN="example.auth0.com",
+        AUTH0_API_AUDIENCE="https://api.example.com",
+        CORS_ALLOW_ORIGINS=["https://frontend.winoe.ai"],
+    )
+
+    assert settings.is_production_environment() is True
+    assert settings.DEMO_MODE is True
+    assert settings.demo_mode_enabled is False
+
+
+@pytest.mark.parametrize("raw_value", ["false", "0", "", None])
+def test_demo_mode_enabled_rejects_stringy_falsey_overrides(raw_value):
+    settings = Settings(
+        _env_file=None,
+        ENV="test",
+        AUTH0_DOMAIN="example.auth0.com",
+        AUTH0_API_AUDIENCE="https://api.example.com",
+        CORS_ALLOW_ORIGINS=["https://frontend.winoe.ai"],
+    )
+    object.__setattr__(settings, "DEMO_MODE", raw_value)
+
+    assert settings.demo_mode_enabled is False

--- a/tests/integrations/github/test_integrations_github_fake_provider_client.py
+++ b/tests/integrations/github/test_integrations_github_fake_provider_client.py
@@ -1,0 +1,413 @@
+from __future__ import annotations
+
+import base64
+import io
+import json
+from types import SimpleNamespace
+from zipfile import ZipFile
+
+import pytest
+
+from app.config import settings
+from app.integrations.github import GithubActionsRunner
+from app.integrations.github.client import GithubError
+from app.integrations.github.integrations_github_factory_client import (
+    get_github_provisioning_client,
+)
+from app.integrations.github.integrations_github_fake_provider_client import (
+    FakeGithubClient,
+)
+from app.submissions.services.submissions_services_submissions_workspace_bootstrap_service import (
+    bootstrap_empty_candidate_repo,
+)
+from app.submissions.services.use_cases.submissions_services_use_cases_submissions_use_cases_submit_diff_service import (
+    build_diff_summary,
+)
+
+
+def _scenario_version() -> SimpleNamespace:
+    return SimpleNamespace(
+        project_brief_md=(
+            "# Project Brief\n\n"
+            "## Business Context\n\n"
+            "Build a scheduling workflow from an empty repository."
+        ),
+        storyline_md="Candidate builds the system from scratch.",
+    )
+
+
+@pytest.mark.asyncio
+async def test_provider_selection_defaults_to_real_provider_outside_demo_mode(
+    monkeypatch,
+):
+    monkeypatch.setattr(settings, "ENV", "local")
+    monkeypatch.setattr(settings, "DEMO_MODE", False)
+
+    fake_called = {"count": 0}
+
+    def fake_demo_singleton():
+        fake_called["count"] += 1
+        raise AssertionError("fake provider should not be selected by default")
+
+    monkeypatch.setattr(
+        "app.integrations.github.integrations_github_factory_client.get_fake_github_client",
+        fake_demo_singleton,
+    )
+
+    real_marker = object()
+    monkeypatch.setattr(
+        "app.integrations.github.integrations_github_factory_client._real_github_client_singleton",
+        lambda: real_marker,
+    )
+
+    client = get_github_provisioning_client()
+    assert client is real_marker
+    assert fake_called["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_provider_selection_honors_demo_mode_and_production_override(monkeypatch):
+    monkeypatch.setattr(settings, "ENV", "local")
+    monkeypatch.setattr(settings, "DEMO_MODE", True)
+
+    called = {"real": False}
+
+    def fake_real_singleton():
+        called["real"] = True
+        return object()
+
+    monkeypatch.setattr(
+        "app.integrations.github.integrations_github_factory_client._real_github_client_singleton",
+        fake_real_singleton,
+    )
+
+    client = get_github_provisioning_client()
+    assert isinstance(client, FakeGithubClient)
+    assert called["real"] is False
+
+    monkeypatch.setattr(settings, "ENV", "production")
+
+    fake_called = {"count": 0}
+
+    def fake_demo_singleton():
+        fake_called["count"] += 1
+        raise AssertionError("fake provider should not be selected in production")
+
+    monkeypatch.setattr(
+        "app.integrations.github.integrations_github_factory_client.get_fake_github_client",
+        fake_demo_singleton,
+    )
+
+    real_marker = object()
+
+    def production_real_singleton():
+        return real_marker
+
+    monkeypatch.setattr(
+        "app.integrations.github.integrations_github_factory_client._real_github_client_singleton",
+        production_real_singleton,
+    )
+
+    client = get_github_provisioning_client()
+    assert client is real_marker
+    assert fake_called["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_fake_provider_covers_workspace_branch_and_artifact_state():
+    client = FakeGithubClient()
+    repo_full_name = "winoe-ai-demo/demo-workspace"
+
+    created = await client.create_empty_repo(
+        owner="winoe-ai-demo",
+        repo_name="demo-workspace",
+        private=True,
+    )
+    assert created["full_name"] == repo_full_name
+    assert created["default_branch"] == "main"
+    assert created["html_url"] == "https://github.com/winoe-ai-demo/demo-workspace"
+
+    archived = await client.archive_repo(repo_full_name)
+    assert archived["archived"] is True
+    unarchived = await client.unarchive_repo(repo_full_name)
+    assert unarchived["archived"] is False
+
+    collaborator = await client.add_collaborator(repo_full_name, "demo-user")
+    assert collaborator["user"]["login"] == "demo-user"
+    removed = await client.remove_collaborator(repo_full_name, "demo-user")
+    assert removed["removed"] is True
+
+    with pytest.raises(GithubError, match="Branch not found"):
+        await client.get_branch(repo_full_name, "main")
+    with pytest.raises(GithubError, match="File not found"):
+        await client.get_file_contents(repo_full_name, "README.md")
+
+    seed = await client.create_or_update_file(
+        repo_full_name,
+        "README.md",
+        content="# demo workspace\n",
+        message="Seed README",
+        branch="main",
+    )
+    assert seed["commit"]["message"] == "Seed README"
+
+    file_contents = await client.get_file_contents(repo_full_name, "README.md")
+    assert base64.b64decode(file_contents["content"]).decode("utf-8") == (
+        "# demo workspace\n"
+    )
+
+    branch_payload = await client.get_branch(repo_full_name, "main")
+    assert branch_payload["name"] == "main"
+    ref_payload = await client.get_ref(repo_full_name, "refs/heads/main")
+    assert ref_payload["object"]["sha"] == branch_payload["commit"]["sha"]
+
+    updated_ref = await client.update_ref(
+        repo_full_name,
+        ref="refs/heads/main",
+        sha=seed["commit"]["sha"],
+        force=True,
+    )
+    assert updated_ref["force"] is True
+
+    blob = await client.create_blob(repo_full_name, content="print('hello')\n")
+    tree = await client.create_tree(
+        repo_full_name,
+        tree=[
+            {
+                "path": "src/app.py",
+                "mode": "100644",
+                "type": "blob",
+                "sha": blob["sha"],
+            }
+        ],
+        base_tree=seed["commit"]["tree"]["sha"],
+    )
+    commit = await client.create_commit(
+        repo_full_name,
+        message="Add app module",
+        tree=tree["sha"],
+        parents=[seed["commit"]["sha"]],
+    )
+    commit_payload = await client.get_commit(repo_full_name, commit["sha"])
+    assert commit_payload["message"] == "Add app module"
+    assert commit_payload["parents"] == [{"sha": seed["commit"]["sha"]}]
+    assert (
+        await client.get_commit(
+            repo_full_name, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+        )
+    )["message"] == "demo commit"
+
+    commits = await client.list_commits(repo_full_name, sha=commit["sha"])
+    assert len(commits) == 1
+    assert commits[0]["sha"] == commit["sha"]
+
+    compare_from_commits = await client.get_compare(
+        repo_full_name,
+        seed["commit"]["sha"],
+        commit["sha"],
+    )
+    assert compare_from_commits["ahead_by"] == 1
+    assert compare_from_commits["files"][0]["filename"] == "src/app.py"
+
+    compare_unknown = await client.get_compare(
+        "winoe-ai-demo/empty-compare",
+        "missing-base",
+        "missing-head",
+    )
+    assert compare_unknown["files"]
+    assert compare_unknown["base_commit"]["sha"] == "missing-base"
+
+    codespace = await client.create_codespace(
+        repo_full_name,
+        ref="main",
+        devcontainer_path=".devcontainer/devcontainer.json",
+    )
+    assert codespace["name"].startswith("demo-workspace-main-")
+    assert codespace["web_url"].startswith(
+        "https://codespaces.demo.winoe.ai/demo-workspace?ref=main"
+    )
+    same_codespace = await client.get_codespace(repo_full_name, codespace["name"])
+    assert same_codespace["state"] == "available"
+    with pytest.raises(GithubError, match="Codespace not found"):
+        await client.get_codespace(repo_full_name, "wrong-codespace")
+
+    await client.trigger_workflow_dispatch(
+        repo_full_name,
+        "winoe-evidence-capture.yml",
+        ref="main",
+        inputs={"candidateSessionId": 11, "notes": None},
+    )
+
+    runs = await client.list_workflow_runs(
+        repo_full_name,
+        "winoe-evidence-capture.yml",
+        branch="main",
+    )
+    assert len(runs) == 1
+    run = await client.get_workflow_run(repo_full_name, runs[0].id)
+    assert run.head_sha
+    assert run.status == "completed"
+
+    with pytest.raises(GithubError, match="Workflow run not found"):
+        await client.get_workflow_run(repo_full_name, run.id + 1)
+
+    artifacts = await client.list_artifacts(repo_full_name, run.id)
+    assert len(artifacts) == 9
+    assert artifacts[0]["workflow_run"]["id"] == run.id
+
+    with pytest.raises(GithubError, match="Artifact not found"):
+        await client.download_artifact_zip(repo_full_name, 999_999)
+
+    artifact_zip = await client.download_artifact_zip(
+        repo_full_name, artifacts[0]["id"]
+    )
+    with ZipFile(io.BytesIO(artifact_zip)) as archive:
+        payload_name = archive.namelist()[0]
+        payload = json.loads(archive.read(payload_name))
+
+    assert payload_name == "commit_metadata.json"
+    assert payload["head_commit"]
+    assert payload["commits"][0]["message"] == "Initialize empty Trial workspace"
+    assert (
+        payload["commits"][0]["files_changed"][0] == ".devcontainer/devcontainer.json"
+    )
+
+    timeline_zip = await client.download_artifact_zip(
+        repo_full_name, artifacts[1]["id"]
+    )
+    with ZipFile(io.BytesIO(timeline_zip)) as archive:
+        payload = json.loads(archive.read("file_creation_timeline.json"))
+    assert payload["files"][0]["message"] == "Initialize empty Trial workspace"
+    assert payload["best_effort"] is False
+
+    test_results_zip = await client.download_artifact_zip(
+        repo_full_name, artifacts[5]["id"]
+    )
+    with ZipFile(io.BytesIO(test_results_zip)) as archive:
+        payload = json.loads(archive.read("test_results.json"))
+    assert payload["summary"]["suite"] == "demo-rehearsal"
+    assert payload["summary"]["status"] in {"passed", "failed"}
+
+    lint_results_zip = await client.download_artifact_zip(
+        repo_full_name, artifacts[7]["id"]
+    )
+    with ZipFile(io.BytesIO(lint_results_zip)) as archive:
+        payload = json.loads(archive.read("lint_results.json"))
+    assert payload["summary"]["status"] == "passed"
+
+    manifest_zip = await client.download_artifact_zip(
+        repo_full_name, artifacts[8]["id"]
+    )
+    with ZipFile(io.BytesIO(manifest_zip)) as archive:
+        payload = json.loads(archive.read("evidence_manifest.json"))
+    assert payload["generated_artifacts"] == [
+        "winoe-commit-metadata",
+        "winoe-file-creation-timeline",
+        "winoe-repo-tree-summary",
+        "winoe-dependency-manifests",
+        "winoe-test-detection",
+        "winoe-test-results",
+        "winoe-lint-detection",
+        "winoe-lint-results",
+        "winoe-evidence-manifest",
+    ]
+
+    with pytest.raises(GithubError, match="This path is not supported in demo mode"):
+        await client.generate_repo_from_template(
+            template_full_name="template/unused",
+            new_repo_name="demo",
+        )
+
+
+@pytest.mark.asyncio
+async def test_fake_provider_is_deterministic_for_same_inputs_and_distinct_for_other_inputs():
+    async def _bootstrap(client: FakeGithubClient, candidate_id: int):
+        result = await bootstrap_empty_candidate_repo(
+            github_client=client,
+            candidate_session=SimpleNamespace(id=candidate_id),
+            trial=SimpleNamespace(id=3, title="Scheduling Trial"),
+            scenario_version=_scenario_version(),
+            task=SimpleNamespace(id=2, title="Implementation"),
+            repo_prefix="candidate-",
+            destination_owner="winoe-workspaces",
+        )
+        return result
+
+    client_one = FakeGithubClient()
+    client_two = FakeGithubClient()
+
+    first = await _bootstrap(client_one, 7)
+    second = await _bootstrap(client_two, 7)
+    third = await _bootstrap(FakeGithubClient(), 8)
+
+    assert first.repo_full_name == second.repo_full_name
+    assert first.codespace_url == second.codespace_url
+    assert first.bootstrap_commit_sha == second.bootstrap_commit_sha
+    assert first.repo_full_name != third.repo_full_name
+    assert first.codespace_url != third.codespace_url
+    assert len(first.bootstrap_commit_sha or "") == 40
+    assert len(first.codespace_url or "") > 0
+
+
+@pytest.mark.asyncio
+async def test_fake_provider_supports_offline_workspace_and_actions_flow(monkeypatch):
+    monkeypatch.setattr(settings, "ENV", "local")
+    monkeypatch.setattr(settings, "DEMO_MODE", True)
+
+    real_factory_called = {"count": 0}
+
+    def _real_factory_blocked():
+        real_factory_called["count"] += 1
+        raise AssertionError(
+            "real GitHub client should not be constructed in demo mode"
+        )
+
+    monkeypatch.setattr(
+        "app.integrations.github.integrations_github_factory_client._real_github_client_singleton",
+        _real_factory_blocked,
+    )
+
+    client = get_github_provisioning_client()
+    assert isinstance(client, FakeGithubClient)
+    assert real_factory_called["count"] == 0
+
+    result = await bootstrap_empty_candidate_repo(
+        github_client=client,
+        candidate_session=SimpleNamespace(id=11),
+        trial=SimpleNamespace(id=3, title="Scheduling Trial"),
+        scenario_version=_scenario_version(),
+        task=SimpleNamespace(id=2, title="Implementation"),
+        repo_prefix="candidate-",
+        destination_owner="winoe-workspaces",
+    )
+
+    runner = GithubActionsRunner(
+        client,
+        workflow_file="winoe-evidence-capture.yml",
+        poll_interval_seconds=0.0,
+        max_poll_seconds=0.1,
+    )
+    run_result = await runner.dispatch_and_wait(
+        repo_full_name=result.repo_full_name,
+        ref="main",
+        inputs={"candidateSessionId": "11"},
+    )
+
+    compare_json = await build_diff_summary(
+        client,
+        result,
+        "main",
+        run_result.head_sha or "",
+    )
+    compare = json.loads(compare_json or "{}")
+
+    assert run_result.status in {"passed", "failed"}
+    assert run_result.run_id > 0
+    assert run_result.html_url and "/actions/runs/" in run_result.html_url
+    assert run_result.raw and isinstance(run_result.raw.get("summary"), dict)
+    assert "evidenceArtifacts" in (run_result.raw.get("summary") or {})
+    assert compare["files"]
+    assert any(file["filename"] == "src/app.py" for file in compare["files"])
+    assert "template_catalog" not in compare_json.lower()
+    assert "precommit" not in compare_json.lower()
+    assert "specializor" not in compare_json.lower()

--- a/tests/integrations/github/test_integrations_github_fake_provider_client_logging_utils.py
+++ b/tests/integrations/github/test_integrations_github_fake_provider_client_logging_utils.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import logging
+
+from app.integrations.github.integrations_github_fake_provider_client import (
+    get_fake_github_client,
+)
+
+
+def test_fake_provider_logs_demo_mode_warning(caplog):
+    get_fake_github_client.cache_clear()
+
+    with caplog.at_level(logging.WARNING):
+        client = get_fake_github_client()
+
+    assert client is not None
+    assert "DEMO MODE ACTIVE: using fake GitHub provider" in caplog.text
+
+    get_fake_github_client.cache_clear()

--- a/tests/security/test_issue_303_trial_candidate_isolation.py
+++ b/tests/security/test_issue_303_trial_candidate_isolation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime
 
 import httpx
@@ -64,6 +65,16 @@ def _assert_safe_error(response, *forbidden_values: str | None) -> None:
     for value in forbidden_values:
         if value:
             assert value not in body
+
+
+@asynccontextmanager
+async def _client_for(app):
+    transport = httpx.ASGITransport(app=app)
+    async with httpx.AsyncClient(
+        transport=transport,
+        base_url="http://testserver",
+    ) as client:
+        yield client
 
 
 @pytest.mark.asyncio
@@ -448,7 +459,7 @@ async def test_cors_allows_configured_frontend_origin(monkeypatch):
     _configure_security_settings(monkeypatch, env="prod")
     cors_app = _csrf_app()
 
-    async with httpx.AsyncClient(app=cors_app, base_url="http://testserver") as client:
+    async with _client_for(cors_app) as client:
         response = await client.get(
             "/api/demo",
             headers={"Origin": "https://frontend.winoe.ai"},
@@ -466,7 +477,7 @@ async def test_cors_rejects_untrusted_origin(monkeypatch):
     _configure_security_settings(monkeypatch, env="prod")
     cors_app = _csrf_app()
 
-    async with httpx.AsyncClient(app=cors_app, base_url="http://testserver") as client:
+    async with _client_for(cors_app) as client:
         response = await client.get(
             "/api/demo",
             headers={"Origin": "https://evil.example"},
@@ -482,7 +493,7 @@ async def test_cors_preflight_is_not_permissive_for_untrusted_origin(monkeypatch
     _configure_security_settings(monkeypatch, env="prod")
     cors_app = _csrf_app()
 
-    async with httpx.AsyncClient(app=cors_app, base_url="http://testserver") as client:
+    async with _client_for(cors_app) as client:
         response = await client.options(
             "/api/demo",
             headers={
@@ -512,7 +523,7 @@ async def test_cross_origin_state_changing_cookie_request_is_rejected(monkeypatc
     _configure_security_settings(monkeypatch, env="prod")
     csrf_app = _csrf_app()
 
-    async with httpx.AsyncClient(app=csrf_app, base_url="http://testserver") as client:
+    async with _client_for(csrf_app) as client:
         response = await client.post(
             "/api/demo",
             headers={"Origin": "https://evil.example", "Cookie": "session=abc"},
@@ -531,7 +542,7 @@ async def test_same_origin_state_changing_cookie_request_is_allowed(monkeypatch)
     _configure_security_settings(monkeypatch, env="prod")
     csrf_app = _csrf_app()
 
-    async with httpx.AsyncClient(app=csrf_app, base_url="http://testserver") as client:
+    async with _client_for(csrf_app) as client:
         response = await client.post(
             "/api/demo",
             headers={

--- a/tests/shared/http/dependencies/test_shared_http_dependencies_github_native_service.py
+++ b/tests/shared/http/dependencies/test_shared_http_dependencies_github_native_service.py
@@ -4,11 +4,30 @@ from app.shared.http.dependencies import (
 )
 
 
-def test_actions_runner_singleton_reused_and_custom_client_gets_new_runner():
+def test_actions_runner_singleton_reused_and_custom_client_gets_new_runner(monkeypatch):
+    github_native._github_client_singleton.cache_clear()
+    github_native._actions_runner_singleton.cache_clear()
+
+    factory_calls = {"count": 0}
+
+    real_factory = github_native.get_github_provisioning_client
+
+    def counting_factory():
+        factory_calls["count"] += 1
+        return real_factory()
+
+    monkeypatch.setattr(
+        github_native, "get_github_provisioning_client", counting_factory
+    )
+
     github_native._github_client_singleton.cache_clear()
     github_native._actions_runner_singleton.cache_clear()
 
     default_client = github_native.get_github_client()
+    assert factory_calls["count"] == 1
+    assert github_native.get_github_client() is default_client
+    assert factory_calls["count"] == 1
+
     runner1 = github_native.get_actions_runner(default_client)
     runner2 = github_native.get_actions_runner(default_client)
 
@@ -23,6 +42,15 @@ def test_actions_runner_singleton_reused_and_custom_client_gets_new_runner():
     custom_client = GithubClient(
         base_url="https://api.github.com", token="custom-token", default_org="org"
     )
+    runner_calls = {"count": 0}
+    real_runner_class = github_native.GithubActionsRunner
+
+    class CountingRunner(real_runner_class):
+        def __init__(self, *args, **kwargs):
+            runner_calls["count"] += 1
+            super().__init__(*args, **kwargs)
+
+    monkeypatch.setattr(github_native, "GithubActionsRunner", CountingRunner)
     custom_runner1 = github_native.get_actions_runner(custom_client)
     custom_runner2 = github_native.get_actions_runner(custom_client)
 
@@ -30,6 +58,7 @@ def test_actions_runner_singleton_reused_and_custom_client_gets_new_runner():
     assert custom_runner2.client is custom_client
     # Custom clients should not use the global singleton cache.
     assert custom_runner1 is not custom_runner2
+    assert runner_calls["count"] == 2
 
     github_native._github_client_singleton.cache_clear()
     github_native._actions_runner_singleton.cache_clear()

--- a/tests/shared/http/routes/test_shared_http_health_routes.py
+++ b/tests/shared/http/routes/test_shared_http_health_routes.py
@@ -1,13 +1,22 @@
+from contextlib import asynccontextmanager
+
 import pytest
-from httpx import AsyncClient
+from httpx import ASGITransport, AsyncClient
 
 from app.main import app
 from app.shared.http import shared_http_readiness_service as readiness_service
 
 
+@asynccontextmanager
+async def _client_for(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+
+
 @pytest.mark.asyncio
 async def test_health():
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    async with _client_for(app) as ac:
         res = await ac.get("/health")
         assert res.status_code == 200
         assert res.json() == {"status": "ok"}
@@ -16,6 +25,7 @@ async def test_health():
 @pytest.mark.asyncio
 async def test_ready_returns_200_when_all_checks_pass(monkeypatch):
     payload = {
+        "demoMode": False,
         "status": "ready",
         "checkedAt": "2026-01-01T00:00:00Z",
         "checks": {
@@ -67,7 +77,7 @@ async def test_ready_returns_200_when_all_checks_pass(monkeypatch):
         fake_build_readiness_payload,
     )
 
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    async with _client_for(app) as ac:
         res = await ac.get("/ready")
         assert res.status_code == 200
         assert res.json() == payload
@@ -76,6 +86,7 @@ async def test_ready_returns_200_when_all_checks_pass(monkeypatch):
 @pytest.mark.asyncio
 async def test_ready_returns_503_when_any_check_fails(monkeypatch):
     payload = {
+        "demoMode": False,
         "status": "not_ready",
         "checkedAt": "2026-01-01T00:00:00Z",
         "checks": {
@@ -97,7 +108,7 @@ async def test_ready_returns_503_when_any_check_fails(monkeypatch):
         fake_build_readiness_payload,
     )
 
-    async with AsyncClient(app=app, base_url="http://test") as ac:
+    async with _client_for(app) as ac:
         res = await ac.get("/ready")
         assert res.status_code == 503
         assert res.json() == payload

--- a/tests/shared/http/test_shared_http_readiness_service.py
+++ b/tests/shared/http/test_shared_http_readiness_service.py
@@ -110,6 +110,93 @@ def test_inspect_schema_reports_missing_table_and_fk(monkeypatch):
     assert "candidate_sessions" in result.data["missingTables"]
 
 
+def test_inspect_schema_reports_missing_foreign_keys_when_tables_exist(monkeypatch):
+    inspector = _FakeSchemaInspector(
+        [
+            "candidate_sessions",
+            "jobs",
+            "scenario_versions",
+            "tasks",
+            "trials",
+            "worker_heartbeats",
+        ],
+        {
+            "candidate_sessions": [
+                {
+                    "constrained_columns": ["trial_id"],
+                    "referred_table": "trials",
+                    "referred_columns": ["id"],
+                }
+            ],
+            "scenario_versions": [],
+            "tasks": [],
+        },
+    )
+    monkeypatch.setattr(readiness_service, "inspect", lambda _conn: inspector)
+
+    result = readiness_service._inspect_schema(object())
+
+    assert result.status == "not_ready"
+    assert result.code == "schema_mismatch"
+    assert "missingForeignKeys" in result.data
+    assert "candidate_sessions" in result.data["missingForeignKeys"]
+    assert "scenario_versions" in result.data["missingForeignKeys"]
+    assert "tasks" in result.data["missingForeignKeys"]
+
+
+def test_utc_now_and_aggregate_status_normalize_inputs():
+    naive_now = datetime(2026, 4, 27, 12, 0)
+    aware_now = datetime(2026, 4, 27, 12, 0, tzinfo=UTC)
+
+    normalized_naive = readiness_service._utc_now(naive_now)
+    normalized_aware = readiness_service._utc_now(aware_now)
+    all_skipped = readiness_service._aggregate_status(
+        [
+            readiness_service.ReadinessCheck(status="skipped", code="a", detail="a"),
+            readiness_service.ReadinessCheck(status="skipped", code="b", detail="b"),
+        ]
+    )
+    mixed_status = readiness_service._aggregate_status(
+        [
+            readiness_service.ReadinessCheck(status="ready", code="a", detail="a"),
+            readiness_service.ReadinessCheck(status="skipped", code="b", detail="b"),
+        ]
+    )
+
+    assert normalized_naive.tzinfo is UTC
+    assert normalized_aware.tzinfo is UTC
+    assert all_skipped == "skipped"
+    assert mixed_status == "ready"
+
+
+@pytest.mark.asyncio
+async def test_check_ai_readiness_aggregates_resolvers_and_status(monkeypatch):
+    monkeypatch.setattr(readiness_service.settings, "OPENAI_API_KEY", "test-openai")
+    monkeypatch.setattr(
+        readiness_service.settings, "ANTHROPIC_API_KEY", "test-anthropic"
+    )
+    monkeypatch.setattr(
+        readiness_service,
+        "_AI_FEATURE_RESOLVERS",
+        {
+            "scenarioGeneration": lambda: SimpleNamespace(
+                runtime_mode="demo", provider="openai"
+            ),
+            "transcription": lambda: SimpleNamespace(
+                runtime_mode="real", provider="anthropic"
+            ),
+        },
+    )
+
+    result = await readiness_service.check_ai_readiness()
+
+    assert result.status == "ready"
+    assert result.code == "ai_providers_ready"
+    assert set(result.data["checks"]) == {"scenarioGeneration", "transcription"}
+    assert result.data["checks"]["scenarioGeneration"]["status"] == "skipped"
+    assert result.data["checks"]["transcription"]["status"] == "ready"
+
+
 @pytest.mark.asyncio
 async def test_check_database_readiness_returns_specific_schema_failure(monkeypatch):
     class _BrokenConnection:
@@ -188,7 +275,7 @@ def test_check_github_readiness_covers_demo_and_configured_modes(monkeypatch):
     github_cfg = SimpleNamespace(
         GITHUB_TOKEN="",
         GITHUB_ORG="",
-        GITHUB_TEMPLATE_OWNER="",
+        GITHUB_TEMPLATE_OWNER="legacy-template-owner",
         GITHUB_API_BASE="https://api.github.com",
     )
     monkeypatch.setattr(readiness_service.settings, "DEMO_MODE", True)
@@ -212,6 +299,24 @@ def test_check_github_readiness_covers_demo_and_configured_modes(monkeypatch):
     ready = readiness_service._check_github_readiness()
     assert ready.status == "ready"
     assert ready.code == "provider_ready"
+
+
+def test_check_github_readiness_skips_demo_mode_even_with_legacy_template_owner(
+    monkeypatch,
+):
+    github_cfg = SimpleNamespace(
+        GITHUB_TOKEN="token",
+        GITHUB_ORG="winoe-ai",
+        GITHUB_TEMPLATE_OWNER="legacy-template-owner",
+        GITHUB_API_BASE="https://api.github.com",
+    )
+    monkeypatch.setattr(readiness_service.settings, "DEMO_MODE", True)
+    monkeypatch.setattr(readiness_service.settings, "github", github_cfg)
+
+    skipped = readiness_service._check_github_readiness()
+
+    assert skipped.status == "skipped"
+    assert skipped.code == "demo_mode"
 
 
 def test_check_email_readiness_covers_all_provider_modes(monkeypatch):
@@ -448,6 +553,7 @@ async def test_build_readiness_payload_aggregates_status_and_checked_at(monkeypa
     )
 
     assert payload["status"] == "not_ready"
+    assert payload["demoMode"] is False
     assert payload["checkedAt"] == "2026-01-01T00:00:00Z"
     assert payload["checks"]["worker"]["status"] == "not_ready"
     assert payload["checks"]["worker"]["data"] == {"ageSeconds": 200}
@@ -491,6 +597,7 @@ async def test_build_readiness_payload_returns_ready_when_all_checks_ready(monke
     )
 
     assert payload["status"] == "ready"
+    assert payload["demoMode"] is False
     assert set(payload["checks"]) == {
         "database",
         "worker",

--- a/tests/shared/jobs/handlers/test_shared_jobs_handlers_github_workflow_artifact_parse_build_actions_runner_returns_configured_runner_and_client_handler.py
+++ b/tests/shared/jobs/handlers/test_shared_jobs_handlers_github_workflow_artifact_parse_build_actions_runner_returns_configured_runner_and_client_handler.py
@@ -2,11 +2,19 @@ from __future__ import annotations
 
 import pytest
 
+from app.integrations.github.integrations_github_fake_provider_client import (
+    FakeGithubClient,
+    get_fake_github_client,
+)
 from tests.shared.jobs.handlers.shared_jobs_handlers_github_workflow_artifact_parse_utils import *
 
 
 @pytest.mark.asyncio
-async def test_build_actions_runner_returns_configured_runner_and_client():
+async def test_build_actions_runner_returns_configured_runner_and_client(monkeypatch):
+    monkeypatch.setattr(parse_handler.settings, "ENV", "local")
+    monkeypatch.setattr(parse_handler.settings, "DEMO_MODE", True)
+    get_fake_github_client.cache_clear()
+
     runner, github_client = parse_handler._build_actions_runner()
     try:
         assert (
@@ -16,5 +24,6 @@ async def test_build_actions_runner_returns_configured_runner_and_client():
         assert runner.workflow_file == "winoe-evidence-capture.yml"
         assert runner.poll_interval_seconds == 2.0
         assert runner.max_poll_seconds == 90.0
+        assert isinstance(github_client, FakeGithubClient)
     finally:
         await github_client.aclose()

--- a/tests/shared/middleware/shared_http_csrf_cors_hardening_test_utils.py
+++ b/tests/shared/middleware/shared_http_csrf_cors_hardening_test_utils.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import logging
+from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
-from httpx import AsyncClient
+from httpx import ASGITransport
+from httpx import AsyncClient as _AsyncClient
 
 import app.shared.http.shared_http_middleware_http_middleware as middleware_http
 from app.config import settings
@@ -55,6 +57,17 @@ def _csrf_app() -> FastAPI:
     configure_csrf_protection(app)
     configure_cors(app)
     return app
+
+
+@asynccontextmanager
+async def AsyncClient(*, app: FastAPI, base_url: str = "http://testserver", **kwargs):
+    transport = ASGITransport(app=app)
+    async with _AsyncClient(
+        transport=transport,
+        base_url=base_url,
+        **kwargs,
+    ) as client:
+        yield client
 
 
 __all__ = [name for name in globals() if not name.startswith("__")]

--- a/tests/shared/middleware/test_shared_request_limits_middleware.py
+++ b/tests/shared/middleware/test_shared_request_limits_middleware.py
@@ -1,6 +1,8 @@
+from contextlib import asynccontextmanager
+
 import pytest
 from fastapi import FastAPI, Request
-from httpx import AsyncByteStream, AsyncClient
+from httpx import ASGITransport, AsyncByteStream, AsyncClient
 
 from app.shared.utils.shared_utils_request_limits_utils import (
     RequestSizeLimitMiddleware,
@@ -19,6 +21,13 @@ class ChunkStream(AsyncByteStream):
         return None
 
 
+@asynccontextmanager
+async def _client_for(app):
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://testserver") as client:
+        yield client
+
+
 def _limit_test_app(max_body_bytes: int) -> FastAPI:
     app = FastAPI()
 
@@ -34,7 +43,7 @@ def _limit_test_app(max_body_bytes: int) -> FastAPI:
 @pytest.mark.asyncio
 async def test_request_size_limit_blocks_large_body_with_content_length():
     app = _limit_test_app(max_body_bytes=10)
-    async with AsyncClient(app=app, base_url="http://testserver") as client:
+    async with _client_for(app) as client:
         resp = await client.post("/upload", content=b"x" * 20)
     assert resp.status_code == 413
     assert resp.json()["detail"] == "Request body too large"
@@ -44,7 +53,7 @@ async def test_request_size_limit_blocks_large_body_with_content_length():
 async def test_request_size_limit_blocks_streaming_body_without_content_length():
     app = _limit_test_app(max_body_bytes=10)
     stream = ChunkStream([b"x" * 8, b"y" * 8])
-    async with AsyncClient(app=app, base_url="http://testserver") as client:
+    async with _client_for(app) as client:
         resp = await client.post("/upload", content=stream)
     assert resp.status_code == 413
     assert resp.json()["detail"] == "Request body too large"


### PR DESCRIPTION
## Summary

Added production-safe `DEMO_MODE` support for deterministic fake GitHub provisioning used for Winoe AI local and YC rehearsal flows.

The real GitHub provider remains the default and is unchanged. Demo mode is blocked in production, and the fake provider returns stable repo URLs, Codespace URLs, workflow metadata, commit SHAs, compare data, and artifact outputs so Candidate Day 2/3 workspace views and Evidence Trail paths can render without touching real GitHub.

The original issue’s template-generation wording is retired by the v4 pivot. This implementation simulates empty-repo from-scratch provisioning instead.

## Why this matters

Winoe AI rehearsals need to be fast, repeatable, and safe. Before this change, demo runs could create real repositories, Codespaces, and workflow runs, which made rehearsals slow, expensive, and fragile.

This update makes it possible to rehearse a full Trial, Project Brief, Candidate workspace, and Evidence Trail flow locally or in YC-facing demo environments without external GitHub side effects.

## Implementation Details

- Added `DEMO_MODE` config support in `app/config/`.
- Added a fake GitHub provider alongside the real provider in `app/integrations/github/`.
- Wired provisioning through a provider factory so workspace bootstrap, workflow artifact parsing, and readiness checks all respect demo mode.
- Kept the real `GithubClient` as the default path.
- Added safe production override behavior so `WINOE_ENV=production` disables demo mode even if `DEMO_MODE=true`.
- Added deterministic demo data generation for:
  - empty repository creation
  - devcontainer/workspace bootstrap
  - collaborator add
  - Codespace create/get
  - workflow dispatch
  - workflow run metadata
  - artifact list/download
  - compare/diff metadata

## Production Safety

- `DEMO_MODE=true` only activates the fake provider outside production.
- `ENV=production` or `WINOE_ENV=production` overrides `DEMO_MODE` and keeps the real provider active.
- Readiness exposes a safe `demoMode` state and skips GitHub readiness in demo mode.
- The demo-mode warning is logged without exposing secrets.

## Demo Behavior

The fake provider is deterministic for stable demo inputs. The same candidate/session inputs produce the same repo URL, Codespace URL, workflow run metadata, fake SHAs, and artifact names.

Representative QA samples:

- Candidate `7`
  - repo: `winoe-workspaces/candidate-7`
  - Codespace URL: `https://codespaces.demo.winoe.ai/candidate-7?ref=main`
  - bootstrap SHA: `b2ebae120faea7c5b6f4d24f1679331c2180d4d6`
- Candidate `8`
  - repo: `winoe-workspaces/candidate-8`
  - Codespace URL: `https://codespaces.demo.winoe.ai/candidate-8?ref=main`
  - bootstrap SHA: `7d61e3332aa39d289027ea5bcc0e88e02fafbc37`
- Candidate `11`
  - repo: `winoe-workspaces/candidate-11`
  - Codespace URL: `https://codespaces.demo.winoe.ai/candidate-11?ref=main`
  - bootstrap SHA: `1d01f9a8daff9e31c5e2164a61235393abb35131`
  - workflow run: `97838170`
  - workflow run URL: `https://github.com/winoe-workspaces/candidate-11/actions/runs/97838170`

Different candidate/session inputs produce distinct stable values, so separate rehearsals remain plausible while still being repeatable.

## Evidence Trail Behavior

Demo mode produces realistic Evidence Trail artifacts for a from-scratch workspace build, including commit history, file creation timeline, repo tree summary, dependency manifests, test detection, test results, lint detection, lint results, and the evidence manifest.

Evidence artifact examples:

- `winoe-commit-metadata`
- `winoe-file-creation-timeline`
- `winoe-repo-tree-summary`
- `winoe-dependency-manifests`
- `winoe-test-detection`
- `winoe-test-results`
- `winoe-lint-detection`
- `winoe-lint-results`
- `winoe-evidence-manifest`

Representative evidence snippets:

- first commit message: `Initialize empty Trial workspace`
- first commit files:
  - `.devcontainer/devcontainer.json`
  - `README.md`
  - `.gitignore`
  - `.github/workflows/winoe-evidence-capture.yml`
- repo tree sample:
  - `.devcontainer/devcontainer.json`
  - `.gitignore`
  - `.github/workflows/winoe-evidence-capture.yml`
  - `README.md`
  - `docs/runbook.md`
- test results summary:
  - `status: passed`
  - `suite: demo-rehearsal`
- lint results summary:
  - `status: passed`
  - `suite: lint`

The workflow artifact parse path now uses the provider factory, so demo mode does not bypass fake GitHub when parsing Evidence Trail artifacts.

## Tests / QA

### Full quality gate

- `python3 -m pytest ; echo "PYTEST_EXIT_CODE=$?"`
  - Exit code: `0`
  - Result: `1876 passed, 1 skipped`
  - Coverage: `96.46%`
  - `coverage.xml` written
  - Shell printed `PYTEST_EXIT_CODE=0`

### Wrapper / precommit-equivalent

- `./precommit.sh ; echo "PRECOMMIT_EXIT_CODE=$?"`
  - Exit code: `0`
  - Result: `✅ All pre-commit checks passed!`

### Lint / format

- `.venv/bin/ruff check . ; echo "RUFF_CHECK_EXIT_CODE=$?"`
  - Exit code: `0`
- `.venv/bin/ruff format --check . ; echo "RUFF_FORMAT_EXIT_CODE=$?"`
  - Exit code: `0`

### Focused #307 tests

```bash
python3 -m pytest --no-cov \
  tests/integrations/github/test_integrations_github_fake_provider_client.py \
  tests/submissions/services/test_submissions_workspace_bootstrap_service.py \
  tests/shared/http/test_shared_http_readiness_service.py \
  tests/config/test_config_demo_mode_env_values_utils.py \
  tests/shared/http/dependencies/test_shared_http_dependencies_github_native_service.py \
  tests/shared/jobs/handlers/test_shared_jobs_handlers_github_workflow_artifact_parse_build_actions_runner_returns_configured_runner_and_client_handler.py \
  ; echo "FOCUSED_EXIT_CODE=$?"
```

- Exit code: `0`
- `36 passed`

### Manual QA evidence

- Local non-production + `DEMO_MODE=true` returns `FakeGithubClient`.
- Local non-production + `DEMO_MODE=false` returns real `GithubClient`.
- Production / `WINOE_ENV=production` + `DEMO_MODE=true` suppresses the fake provider and returns real `GithubClient`.
- Demo-mode warning is safe and does not expose secrets.
- Same stable inputs return the same repo URL, Codespace URL, workflow metadata, fake SHAs, and artifact names.
- Different candidate/session inputs produce distinct stable values.
- Day 2/3 workspace bootstrap works using the fake provider without real GitHub calls.
- Artifact parse / Evidence Trail path uses the fake provider in demo mode.
- Readiness payload exposes `demoMode: true` in local demo mode and `demoMode: false` under the production override.

## Grep Verification

Commands run:

```bash
grep -RniE --exclude-dir='__pycache__' "template_catalog|specializor|precommit|codespace_spec" app tests || true
grep -RniE --exclude-dir='__pycache__' "Tenon|SimuHire|recruiter|simulation|Fit Profile|Fit Score" app tests || true
grep -RniE --exclude-dir='__pycache__' "GithubClient\\(|from app.integrations.github.client import GithubClient|app.integrations.github.client" app tests || true
```

Summary:

- Retired-term hits remain in pre-existing migrations, schema compatibility code, and test assertions.
- Negative assertion tests intentionally mention retired terms to prove absence.
- No new active #307 demo path uses retired Winoe v3 or template-era concepts.
- `GithubClient` hits are expected in the real provider, factory, runners, and tests.

## Risks / Follow-Ups

- Demo mode is deterministic by design, so it is appropriate for rehearsals but not for validating live GitHub behavior.
- The fake provider covers the empty-repo from-scratch flow required for the v4 pivot, not the retired template-generation path.
- Future changes to the real GitHub provisioning contract should be reflected in the fake provider to keep demo and production behavior aligned.

## Acceptance Criteria Checklist

- [x] `DEMO_MODE=true` switches GitHub integration to a fake provider outside production.
- [x] Fake provider returns deterministic repo URLs, Codespace URLs, and workflow run metadata.
- [x] Fake provider simulates empty repo creation, devcontainer commit, collaborator add, Codespace create, workflow dispatch, and artifact download.
- [x] Candidate Day 2/3 can render a plausible workspace view in demo mode without hitting real GitHub.
- [x] Evidence Trail in demo mode shows realistic fake commit SHAs, diff summaries, and test results.
- [x] Demo mode is clearly distinguished from production.
- [x] Demo mode cannot be enabled in production.
- [x] Existing real GitHub provider remains the default and is unmodified.
- [x] The original issue’s template-generation wording is retired by the v4 pivot.
- [x] The implemented scope is empty-repo from-scratch provisioning.

Fixes #307
