### PR TITLE
Ensure no legacy Tenon GitHub org/repo names appear in demo-visible evidence

### DIFF
--- a/app/candidates/candidate_sessions/services/candidates_candidate_sessions_services_candidates_candidate_sessions_review_service.py
+++ b/app/candidates/candidate_sessions/services/candidates_candidate_sessions_services_candidates_candidate_sessions_review_service.py
@@ -28,6 +28,7 @@ from app.integrations.storage_media import (
 from app.media.repositories.recordings import repository as recordings_repo
 from app.media.repositories.transcripts import repository as transcripts_repo
 from app.shared.auth.principal import Principal
+from app.shared.branding import sanitize_legacy_github_payload
 from app.shared.database.shared_database_models_model import Submission, Task
 from app.shared.time.shared_time_now_service import utcnow as shared_utcnow
 from app.submissions.presentation import present_detail
@@ -99,6 +100,7 @@ async def build_candidate_completed_review(
             transcript=transcript,
             recording_download_url=recording_download_url,
         )
+        payload = sanitize_legacy_github_payload(payload)
         artifacts.append(_build_artifact(task=task, payload=payload))
 
     completed_at = candidate_session.completed_at or resolved_now

--- a/app/evaluations/services/evaluations_services_evaluations_winoe_report_composer_service.py
+++ b/app/evaluations/services/evaluations_services_evaluations_winoe_report_composer_service.py
@@ -9,6 +9,7 @@ from typing import Any
 from app.evaluations.repositories.evaluations_repositories_evaluations_core_model import (
     EvaluationRun,
 )
+from app.shared.branding import sanitize_legacy_github_payload
 
 from .evaluations_services_evaluations_winoe_report_composer_day_scores_service import (
     _compose_day_scores,
@@ -120,11 +121,12 @@ def build_ready_payload(run: EvaluationRun) -> dict[str, Any]:
     generated_at = _normalize_datetime(
         run.generated_at or run.completed_at or run.started_at
     )
-    return {
+    payload = {
         "status": "ready",
         "generatedAt": generated_at,
         "report": compose_report(run),
     }
+    return sanitize_legacy_github_payload(payload)
 
 
 __all__ = [

--- a/app/shared/branding/__init__.py
+++ b/app/shared/branding/__init__.py
@@ -1,0 +1,9 @@
+from app.shared.branding.legacy_github_reference_sanitizer import (
+    sanitize_legacy_github_payload,
+    sanitize_legacy_github_reference,
+)
+
+__all__ = [
+    "sanitize_legacy_github_payload",
+    "sanitize_legacy_github_reference",
+]

--- a/app/shared/branding/legacy_github_reference_sanitizer.py
+++ b/app/shared/branding/legacy_github_reference_sanitizer.py
@@ -1,0 +1,132 @@
+"""Utilities for sanitizing legacy Tenon GitHub references at response boundaries."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from datetime import date, datetime
+from typing import Any
+from urllib.parse import urlsplit
+
+_LEGACY_OWNER = "tenon-hire-dev"
+_WINOE_OWNER = "winoe-ai-repos"
+_LEGACY_WORKSPACE_PREFIX = "tenon-ws-"
+_WINOE_WORKSPACE_PREFIX = "winoe-ws-"
+_LEGACY_TEMPLATE_PREFIX = "tenon-template-"
+_TEMPLATE_REDACTION = "[redacted template repo]"
+_GITHUB_URL_REDACTION = "[legacy GitHub link removed]"
+_URL_LIKE_KEY_NAMES = {
+    "url",
+    "repourl",
+    "repositoryurl",
+    "workflowurl",
+    "commiturl",
+    "diffurl",
+    "htmlurl",
+    "downloadurl",
+}
+
+_TEMPLATE_REPO_RE = re.compile(r"\btenon-template-[A-Za-z0-9_.-]+\b")
+_GITHUB_URL_RE = re.compile(r"https://github\.com/[^\s\"'<>]+")
+
+
+def sanitize_legacy_github_reference(value: str | None) -> str | None:
+    """Return a demo-safe GitHub reference string."""
+    if value is None:
+        return None
+    if not isinstance(value, str):  # pragma: no cover - defensive guard
+        return value
+
+    text = value.strip()
+    if not text:
+        return text
+
+    text = _GITHUB_URL_RE.sub(_sanitize_github_url_match, text)
+    text = _TEMPLATE_REPO_RE.sub(_TEMPLATE_REDACTION, text)
+    text = text.replace(_LEGACY_OWNER, _WINOE_OWNER)
+    text = text.replace(_LEGACY_WORKSPACE_PREFIX, _WINOE_WORKSPACE_PREFIX)
+    return text
+
+
+def sanitize_legacy_github_payload(payload: Any) -> Any:
+    """Recursively sanitize legacy GitHub references inside JSON-like payloads."""
+    if payload is None or isinstance(payload, bool | int | float | datetime | date):
+        return payload
+    if isinstance(payload, str):
+        return sanitize_legacy_github_reference(payload)
+    if isinstance(payload, Mapping):
+        sanitized: dict[Any, Any] = {}
+        for key, value in payload.items():
+            sanitized[key] = _sanitize_mapping_value(key, value)
+        return sanitized
+    if isinstance(payload, list):
+        return [sanitize_legacy_github_payload(item) for item in payload]
+    if isinstance(payload, tuple):
+        return tuple(sanitize_legacy_github_payload(item) for item in payload)
+    return payload
+
+
+def _sanitize_mapping_value(key: Any, value: Any) -> Any:
+    if _is_url_like_key(key) and isinstance(value, str):
+        stripped = value.strip()
+        if stripped and _contains_legacy_github_reference(stripped):
+            return None
+    return sanitize_legacy_github_payload(value)
+
+
+def _is_url_like_key(key: Any) -> bool:
+    if not isinstance(key, str):
+        return False
+    normalized = key.strip()
+    if not normalized:
+        return False
+    lower_key = normalized.lower()
+    return lower_key in _URL_LIKE_KEY_NAMES or lower_key.endswith("url")
+
+
+def _contains_legacy_github_reference(value: str) -> bool:
+    if _LEGACY_OWNER in value:
+        return True
+    if _LEGACY_WORKSPACE_PREFIX in value or _LEGACY_TEMPLATE_PREFIX in value:
+        return True
+    match = _GITHUB_URL_RE.search(value)
+    if not match:
+        return False
+    split_url = urlsplit(match.group(0))
+    if split_url.netloc.lower() not in {"github.com", "www.github.com"}:
+        return False
+    parts = [part for part in split_url.path.split("/") if part]
+    if len(parts) < 2:
+        return False
+    owner, repo = parts[0], parts[1]
+    return (
+        owner == _LEGACY_OWNER
+        or repo.startswith(_LEGACY_WORKSPACE_PREFIX)
+        or repo.startswith(_LEGACY_TEMPLATE_PREFIX)
+    )
+
+
+def _sanitize_github_url_match(match: re.Match[str]) -> str:
+    url = match.group(0)
+    split_url = urlsplit(url)
+    if split_url.netloc.lower() not in {"github.com", "www.github.com"}:
+        return url
+    parts = [part for part in split_url.path.split("/") if part]
+    if len(parts) < 2:
+        return url
+
+    owner, repo = parts[0], parts[1]
+    if owner == _LEGACY_OWNER:
+        return _GITHUB_URL_REDACTION
+    if repo.startswith(_LEGACY_WORKSPACE_PREFIX):
+        return _GITHUB_URL_REDACTION
+    if repo.startswith(_LEGACY_TEMPLATE_PREFIX):
+        return _GITHUB_URL_REDACTION
+
+    return url
+
+
+__all__ = [
+    "sanitize_legacy_github_payload",
+    "sanitize_legacy_github_reference",
+]

--- a/app/submissions/presentation/submissions_presentation_submissions_detail_presenter_utils.py
+++ b/app/submissions/presentation/submissions_presentation_submissions_detail_presenter_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from app.shared.branding import sanitize_legacy_github_payload
 from app.submissions.presentation.submissions_presentation_submissions_commit_basis_utils import (
     resolve_commit_basis,
 )
@@ -67,7 +68,7 @@ def present_detail(
     transcript_payload = build_transcript_payload(
         transcript, transcript_job=transcript_job
     )
-    return {
+    payload = {
         "submissionId": sub.id,
         "candidateSessionId": cs.id,
         "task": build_task_payload(task),
@@ -95,3 +96,4 @@ def present_detail(
             supplemental_materials=supplemental_materials,
         ),
     }
+    return sanitize_legacy_github_payload(payload)

--- a/app/submissions/presentation/submissions_presentation_submissions_list_presenter_utils.py
+++ b/app/submissions/presentation/submissions_presentation_submissions_list_presenter_utils.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from app.shared.branding import sanitize_legacy_github_payload
 from app.submissions.presentation.submissions_presentation_submissions_commit_basis_utils import (
     resolve_commit_basis,
 )
@@ -58,7 +59,7 @@ def present_list_item(sub, task, *, day_audit=None):
         and not test_results.get("workflowUrl")
     ):
         test_results["workflowUrl"] = workflow_url
-    return {
+    payload = {
         "submissionId": sub.id,
         "candidateSessionId": sub.candidate_session_id,
         "taskId": sub.task_id,
@@ -78,3 +79,4 @@ def present_list_item(sub, task, *, day_audit=None):
         "diffSummary": diff_summary,
         "testResults": test_results,
     }
+    return sanitize_legacy_github_payload(payload)

--- a/pr.md
+++ b/pr.md
@@ -1,239 +1,153 @@
 ## Summary
 
-This PR adds a deterministic YC demo seed/reset path that creates a complete golden-path Winoe dataset:
+- Added centralized backend sanitization for legacy Tenon GitHub references in demo-visible evidence payloads.
+- Sanitized submission detail/list, candidate review, and Winoe Report / Evidence Trail response boundaries.
+- Preserved raw/internal stored evidence while ensuring demo-visible payloads do not expose `tenon-hire-dev`, `tenon-ws-*`, or `tenon-template-*`.
+- Avoided unsafe GitHub link rewriting: legacy URL-like fields are returned as `null`/`None` instead of guessed Winoe URLs, while non-legacy URLs are preserved.
 
-- one demo Talent Partner
-- one demo company
-- one from-scratch Tech Trial
-- a realistic Project Brief
-- two completed Candidate sessions
-- all 5 Trial days submitted for both Candidates
-- a fake GitHub empty-repo/devcontainer/README bootstrap path
-- Winoe Reports with Winoe Scores, day scores, reviewer reports, strengths, concerns, and Evidence Trail citations
-- candidate comparison / Benchmarks readiness
-- founder-facing `YC_DEMO_CHECKLIST.md`
+## Strategy
 
-Final commands:
+This PR uses centralized response-boundary sanitization.
 
-```bash
-poetry run python -m scripts.seed_demo --github-provider fake --reset-db
-./scripts/seed_demo.sh --github-provider fake --reset-db
-```
+Chosen strategy:
+- No destructive database backfill.
+- No demo-seed-only assumption.
+- No scattered manual `.replace()` calls.
+- No invented Winoe GitHub URLs.
 
-## Why
-
-This closes the YC/demo gap by making demo data regenerable deterministically. Live rehearsals no longer require manual setup, which reduces the risk of stale data, missing reports, or terminology leaks and gives the team a repeatable way to show the full Winoe loop end to end.
+Why:
+- Existing raw evidence may still contain historical legacy GitHub references.
+- Blindly rewriting stored GitHub URLs could break links if replacement repos do not exist.
+- Centralized response-boundary sanitization protects demo-visible surfaces while preserving internal evidence integrity.
 
 ## Implementation Details
 
-- New demo seed service: `app/demo/services/yc_demo_seed_service.py`
-- CLI entrypoint: `scripts/seed_demo.py`
-- Shell wrapper: `scripts/seed_demo.sh`
-- Checklist: `YC_DEMO_CHECKLIST.md`
-- Tests: `tests/demo/services/test_demo_yc_seed_service.py`
+- Added centralized sanitizer under `app/shared/branding`.
+- Sanitizer recursively walks JSON-like payloads without mutating the source object.
+- Display repo labels are rebranded:
+  - `tenon-hire-dev/tenon-ws-*` → `winoe-ai-repos/winoe-ws-*`
+- Retired template references are removed/redacted.
+- Legacy GitHub URLs in URL-like fields are nulled instead of converted to fake links.
+- Non-legacy URLs remain unchanged.
+- Sanitization is applied at demo-visible response boundaries:
+  - submission detail presenter
+  - submission list presenter
+  - candidate completed review service
+  - Winoe Report ready payload composer
 
-Important behavior:
+## Link Safety
 
-- fake provider works without real GitHub credentials
-- real provider validates required config and fails before reset when config is missing
-- normal reruns refresh only demo-scoped records
-- `--reset-db` performs explicit full database reset
-- production-like destructive reset is blocked
-- non-demo rows are preserved on normal reruns
-- wrapper forwards CLI args
-- seed reports are persisted through the normal Winoe Report/report-fetch shape
-
-## QA Evidence
-
-### Migration
-
-```bash
-./runBackend.sh migrate
-```
-
-Result: passed.
-
-### Seed Runs
-
-```bash
-poetry run python -m scripts.seed_demo --github-provider fake --reset-db
-poetry run python -m scripts.seed_demo --github-provider fake --reset-db
-./scripts/seed_demo.sh --github-provider fake --reset-db
-poetry run python -m scripts.seed_demo --github-provider fake
-```
-
-Result: passed.
-
-Deterministic output:
+This PR intentionally does **not** convert legacy URLs like:
 
 ```text
-YC demo seed ready: company_id=1, trial_id=1, candidate_session_ids=[1, 2], repos=['winoe-ai-demo/yc-demo-candidate-avery-chen', 'winoe-ai-demo/yc-demo-candidate-jordan-patel']
+https://github.com/tenon-hire-dev/tenon-ws-1-coding
 ```
 
-The normal non-reset rerun preserved the non-demo sentinel company/user.
-
-### Database Verification
-
-Final verified counts:
-
-- 1 demo company
-- 1 demo Talent Partner
-- 1 Trial
-- 2 candidate sessions
-- 10 submissions
-- 2 Winoe Reports
-- 2 evaluation runs
-- 10 day scores
-- 10 reviewer reports
-- 2 recordings
-- 2 transcripts
-- 2 workspaces
-- 2 workspace groups
-
-Additional verification:
-
-- both Candidate sessions are completed
-- both have `completed_at`
-- both are tied to the same Trial
-- Candidate A score is higher than Candidate B score
-
-### Winoe Report Verification
-
-Service path used:
+into guessed URLs like:
 
 ```text
-fetch_winoe_report(...)
+https://github.com/winoe-ai-repos/winoe-ws-1-coding
 ```
 
-Candidate A:
+unless existence can be proven.
 
-- name: Avery Chen
-- report status: ready
-- Winoe Score: 0.91
-- day scores: 5
-- reviewer reports: 5
-- evidence citations: 10
-- citations point to persisted artifacts: yes
+Instead:
 
-Candidate B:
+- URL-like fields containing legacy GitHub references become `null`.
+- Display fields still show Winoe-branded repo names.
+- Non-legacy GitHub URLs are preserved.
 
-- name: Jordan Patel
-- report status: ready
-- Winoe Score: 0.74
-- day scores: 5
-- reviewer reports: 5
-- evidence citations: 10
-- citations point to persisted artifacts: yes
+This prevents demo-visible legacy branding without creating broken clickable links.
 
-### Candidate Comparison / Benchmarks Verification
+## QA
 
-Service used:
-
-```text
-list_candidates_compare_summary(...)
-```
-
-Verified:
-
-- `cohortSize=2`
-- both candidates present
-- both evaluated
-- both `winoeReportStatus=ready`
-- scores: `0.91` and `0.74`
-- result stayed scoped to the seeded Trial
-
-### GitHub Provider Safety
-
-Fake provider:
-
-- passed
-- works with `WINOE_GITHUB_ORG` and `WINOE_GITHUB_TOKEN` blanked
-- deterministic repo names
-- no fallback to real provider
-- uses `FakeGithubClient`
-
-Real provider blank-config check:
+### Focused tests
 
 ```bash
-WINOE_GITHUB_ORG= WINOE_GITHUB_TOKEN= poetry run python -m scripts.seed_demo --github-provider real --reset-db
-```
-
-Result: failed as expected before reset with:
-
-```text
-RuntimeError: Real GitHub provider mode requires WINOE_GITHUB_ORG and WINOE_GITHUB_TOKEN.
-```
-
-No silent fallback was observed.
-
-### Terminology Verification
-
-Denylist grep command:
-
-```bash
-rg -n -i 'tenon|simuhire|recruiter|simulation|fit profile|fit_profile|fit score|fit_score|template_catalog|precommit|specializor|codespace specification|codespace_spec|starter code|pre-populated codebase' app/demo/services/yc_demo_seed_service.py scripts/seed_demo.py scripts/seed_demo.sh tests/demo/services/test_demo_yc_seed_service.py YC_DEMO_CHECKLIST.md
-```
-
-Result: no matches.
-
-Compatibility references that remain are limited to existing schema fields:
-
-- `scenario_template = ""`
-- `template_key`
-- `template_repo_full_name=None`
-
-No seeded narrative content, checklist text, Project Brief text, Winoe Report text, Evidence Trail text, or Candidate artifact text uses retired terminology.
-
-### Focused Tests
-
-```bash
-poetry run ruff check app/demo/services/yc_demo_seed_service.py scripts/seed_demo.py tests/demo/services/test_demo_yc_seed_service.py
-poetry run pytest -q tests/core/test_core_migration_preservation_utils.py -o addopts=""
-poetry run pytest -q tests/demo/services/test_demo_yc_seed_service.py -o addopts=""
-```
-
-Results:
-
-- ruff passed
-- core migration preservation checks passed
-- demo seed service tests passed: `10 passed`
-
-### Quality Gate
-
-```bash
-bash precommit.sh
+poetry run pytest --no-cov -q \
+  tests/shared/branding/test_shared_branding_legacy_github_reference_sanitizer.py \
+  tests/submissions/presentation/test_submissions_detail_presenter_utils.py \
+  tests/submissions/presentation/test_submissions_list_presenter_utils.py \
+  tests/candidates/candidate_sessions/services/test_candidates_candidate_sessions_review_service.py \
+  tests/evaluations/services/test_evaluations_winoe_report_composer_service.py
 ```
 
 Result:
 
 ```text
-1887 passed, 14 warnings
-Required test coverage of 96% reached. Total coverage: 96.07%
+15 passed
+```
+
+### Grep verification
+
+```bash
+grep -RIn --exclude-dir=.git --exclude-dir=.venv --exclude-dir=__pycache__ \
+  "tenon-hire-dev\|tenon-ws-\|tenon-template-" app || true
+```
+
+Result:
+
+- only intentional matches remain in the centralized sanitizer module.
+
+### Sanitizer direct verification
+
+Direct script verified:
+
+- `tenon-hire-dev/tenon-ws-1-coding` displays as `winoe-ai-repos/winoe-ws-1-coding`
+- legacy URL-like fields become `None`
+- non-legacy URLs are preserved
+- nested payloads are sanitized recursively
+- no source payload mutation occurs
+
+### Full precommit / regression
+
+```bash
+bash ./precommit.sh
+```
+
+Result:
+
+```text
+================ 1896 passed, 13 warnings in 1124.60s (0:18:44) ================
 ✅ All pre-commit checks passed!
 ```
 
+## Manual QA Coverage
+
+Verified through focused service/presenter tests and direct sanitizer execution:
+
+- Submission detail payload:
+  - no `tenon-hire-dev`
+  - no `tenon-ws-`
+  - no `tenon-template-`
+  - legacy URL fields are `null`
+  - display repo names are Winoe-branded
+
+- Submission list payload:
+  - no legacy GitHub org/repo names
+  - nested test result URL fields are nulled when legacy
+  - display repo names are Winoe-branded
+
+- Candidate review payload:
+  - sanitizer applied directly at the response boundary
+  - no legacy GitHub org/repo names
+  - raw submission data remains unchanged
+
+- Winoe Report / Evidence Trail payload:
+  - no legacy GitHub org/repo names
+  - legacy evidence URL fields are nulled
+  - non-legacy evidence URLs are preserved
+  - raw report JSON is not mutated
+
+## Not Performed
+
+- Live authenticated backend endpoint walkthrough was not performed.
+- This is acceptable for this PR because the affected response builders/services are covered directly, and full regression passed.
+
 ## Risks / Follow-ups
 
-- Real GitHub provider live repo creation was not fully exercised with valid credentials in this QA pass.
-- Real provider now fails before reset when required config is blank or missing, but invalid non-empty GitHub access can still fail later during repo creation; a stronger repo-access dry-run can be a future hardening item.
-- Existing legacy schema fields such as `template_key` remain because removing them is outside #308 and belongs to the broader rebrand/pivot cleanup.
+- Any future response path that exposes GitHub repo metadata must use the centralized sanitizer or another shared response-boundary mechanism.
+- Broader removal of retired template/Specializor/precommit code remains scoped to #316.
+- Broader rebrand cleanup remains scoped to #302.
 
-## Acceptance Checklist
-
-- [x] Single seed command creates complete demo dataset
-- [x] Wrapper command works
-- [x] Full reset path works
-- [x] Normal demo-scoped rerun works
-- [x] Non-demo data preserved on normal rerun
-- [x] Talent Partner seeded
-- [x] Trial seeded
-- [x] Two candidate sessions seeded
-- [x] All five days submitted for both candidates
-- [x] Winoe Reports generated
-- [x] Winoe Scores populated
-- [x] Evidence Trail citations linked
-- [x] Fake GitHub provider works
-- [x] Real provider missing-config path fails safely
-- [x] `YC_DEMO_CHECKLIST.md` added
-- [x] Retired terminology denied in seeded/demo files
-- [x] Precommit passes
+Fixes #309

--- a/tests/candidates/candidate_sessions/services/test_candidates_candidate_sessions_review_service.py
+++ b/tests/candidates/candidate_sessions/services/test_candidates_candidate_sessions_review_service.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+import pytest
+
+from app.candidates.candidate_sessions.services import (
+    candidates_candidate_sessions_services_candidates_candidate_sessions_review_service as review_service,
+)
+
+
+@pytest.mark.asyncio
+async def test_build_candidate_completed_review_sanitizes_workspace_artifacts(
+    monkeypatch,
+):
+    candidate_session = SimpleNamespace(
+        id=1,
+        status="completed",
+        completed_at=datetime(2026, 3, 20, 12, 0, tzinfo=UTC),
+        candidate_timezone="America/New_York",
+        day_windows_json=[],
+        trial_id=2,
+        trial=SimpleNamespace(
+            id=2, title="Winoe Trial", role="Backend Engineer", company_id=3
+        ),
+        scenario_version=SimpleNamespace(),
+    )
+    task = SimpleNamespace(
+        id=21, day_index=2, type="code", title="Repo Task", prompt="Prompt"
+    )
+    submission = SimpleNamespace(
+        id=11,
+        candidate_session_id=1,
+        task_id=21,
+        submitted_at=datetime(2026, 3, 20, 12, 0, tzinfo=UTC),
+        test_output=None,
+        diff_summary_json=None,
+        code_repo_path="tenon-hire-dev/tenon-ws-1-coding",
+        workflow_run_id="44",
+        commit_sha="abc123",
+        content_text="notes",
+        content_json={"repo": "tenon-hire-dev/tenon-template-legacy"},
+    )
+
+    async def _fetch_by_token(*_a, **_k):
+        return candidate_session
+
+    async def _load_tasks(*_a, **_k):
+        return [task]
+
+    async def _load_submissions(*_a, **_k):
+        return {task.id: submission}
+
+    async def _list_day_audits(*_a, **_k):
+        return []
+
+    async def _resolve_candidate_media(*_a, **_k):
+        return None, None, None
+
+    monkeypatch.setattr(review_service, "fetch_by_token", _fetch_by_token)
+    monkeypatch.setattr(
+        review_service, "ensure_candidate_ownership", lambda *_a, **_k: False
+    )
+    monkeypatch.setattr(review_service, "_load_tasks", _load_tasks)
+    monkeypatch.setattr(review_service, "_load_submissions", _load_submissions)
+    monkeypatch.setattr(review_service.cs_repo, "list_day_audits", _list_day_audits)
+    monkeypatch.setattr(
+        review_service, "_resolve_candidate_media", _resolve_candidate_media
+    )
+
+    result = await review_service.build_candidate_completed_review(
+        db=SimpleNamespace(commit=lambda: None, refresh=lambda *_a, **_k: None),
+        token="candidate-token-123456",
+        principal=SimpleNamespace(),
+        now=datetime(2026, 3, 20, 12, 0, tzinfo=UTC),
+    )
+
+    artifact = result.artifacts[0].model_dump()
+    serialized = json.dumps(result.model_dump(), default=str)
+    assert "tenon-hire-dev" not in serialized
+    assert "tenon-ws-" not in serialized
+    assert "tenon-template-" not in serialized
+    assert submission.code_repo_path == "tenon-hire-dev/tenon-ws-1-coding"
+    assert artifact["repoFullName"] == "winoe-ai-repos/winoe-ws-1-coding"
+    assert artifact["workflowUrl"] is None
+    assert artifact["commitUrl"] is None
+    assert artifact["diffUrl"] is None

--- a/tests/evaluations/services/test_evaluations_winoe_report_composer_service.py
+++ b/tests/evaluations/services/test_evaluations_winoe_report_composer_service.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import json
+from copy import deepcopy
 from datetime import UTC, datetime
 from types import SimpleNamespace
 
@@ -108,6 +110,7 @@ async def test_build_ready_payload_uses_persisted_run_shape(async_session):
     serialized = WinoeReportStatusResponse(**payload).model_dump()
     serialized_evidence = serialized["report"]["dayScores"][0]["evidence"][0]
     assert serialized_evidence["dimensionKey"] == "development_process"
+    assert serialized_evidence["url"] == "https://github.com/acme/repo/commit/abc123"
 
     transcript_evidence = report["dayScores"][1]["evidence"][0]
     assert transcript_evidence["kind"] == "transcript"
@@ -143,6 +146,86 @@ def test_build_ready_payload_translates_persisted_lean_hire_recommendation():
 
     payload = build_ready_payload(run)
     assert payload["report"]["recommendation"] == "mixed_signal"
+
+
+def test_build_ready_payload_sanitizes_legacy_github_refs_without_mutating_raw_report():
+    raw_report_json = {
+        "overallWinoeScore": 0.58,
+        "note": "https://github.com/tenon-hire-dev/tenon-ws-9-coding",
+        "template": "tenon-template-legacy",
+        "nested": [
+            {
+                "repo": "tenon-hire-dev/tenon-ws-9-coding",
+                "url": "https://github.com/tenon-hire-dev/tenon-template-legacy",
+            }
+        ],
+    }
+    run = SimpleNamespace(
+        overall_winoe_score=0.58,
+        recommendation="hire",
+        confidence=0.61,
+        raw_report_json=deepcopy(raw_report_json),
+        scenario_version_id=1,
+        day_scores=[
+            SimpleNamespace(
+                day_index=2,
+                score=0.58,
+                rubric_results_json={"signal": 0.58},
+                evidence_pointers_json=[
+                    {
+                        "kind": "commit",
+                        "ref": "abc123",
+                        "url": "https://github.com/tenon-hire-dev/tenon-ws-9-coding/commit/abc123",
+                    },
+                    {
+                        "kind": "commit",
+                        "ref": "abc123",
+                        "url": "https://github.com/tenon-hire-dev/tenon-template-legacy",
+                    },
+                ],
+            )
+        ],
+        reviewer_reports=[
+            SimpleNamespace(
+                id=1,
+                day_index=2,
+                reviewer_agent_key="codeImplementationReviewer",
+                submission_kind="code",
+                score=0.58,
+                dimensional_scores_json={"quality": 0.58},
+                evidence_citations_json=[
+                    {
+                        "kind": "commit",
+                        "ref": "abc123",
+                        "url": "https://github.com/tenon-hire-dev/tenon-ws-9-coding/commit/abc123",
+                    }
+                ],
+                assessment_text="legacy repo evidence",
+                strengths_json=[],
+                risks_json=[],
+                raw_output_json={"summary": "tenon-template-legacy"},
+            )
+        ],
+        metadata_json={"rubricSnapshots": []},
+        model_name="fit-evaluator",
+        model_version="2026-03-12",
+        prompt_version="winoe-report-v1",
+        rubric_version="rubric-v3",
+        generated_at=datetime(2026, 3, 12, 12, 3, tzinfo=UTC),
+        completed_at=datetime(2026, 3, 12, 12, 3, tzinfo=UTC),
+        started_at=datetime(2026, 3, 12, 12, 0, tzinfo=UTC),
+    )
+
+    payload = build_ready_payload(run)
+    assert "tenon-hire-dev" not in json.dumps(payload, default=str)
+    assert "tenon-ws-" not in json.dumps(payload, default=str)
+    assert "tenon-template-" not in json.dumps(payload, default=str)
+    assert run.raw_report_json == raw_report_json
+    assert payload["report"]["dayScores"][0]["evidence"][0]["url"] is None
+    assert payload["report"]["dayScores"][0]["evidence"][1]["url"] is None
+    assert (
+        payload["report"]["reviewerReports"][0]["evidenceCitations"][0]["url"] is None
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/shared/branding/test_shared_branding_legacy_github_reference_sanitizer.py
+++ b/tests/shared/branding/test_shared_branding_legacy_github_reference_sanitizer.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+import json
+from copy import deepcopy
+from datetime import UTC, datetime
+
+from app.shared.branding.legacy_github_reference_sanitizer import (
+    sanitize_legacy_github_payload,
+    sanitize_legacy_github_reference,
+)
+
+
+def test_sanitize_legacy_github_reference_rewrites_workspace_owner_and_repo():
+    assert (
+        sanitize_legacy_github_reference("tenon-hire-dev/tenon-ws-1-coding")
+        == "winoe-ai-repos/winoe-ws-1-coding"
+    )
+
+
+def test_sanitize_legacy_github_reference_redacts_workspace_urls():
+    assert (
+        sanitize_legacy_github_reference(
+            "https://github.com/tenon-hire-dev/tenon-ws-1-coding/commit/abc123"
+        )
+        == "[legacy GitHub link removed]"
+    )
+
+
+def test_sanitize_legacy_github_reference_redacts_template_urls_and_names():
+    assert sanitize_legacy_github_reference("tenon-template-legacy") == (
+        "[redacted template repo]"
+    )
+    assert (
+        sanitize_legacy_github_reference(
+            "https://github.com/tenon-hire-dev/tenon-template-legacy"
+        )
+        == "[legacy GitHub link removed]"
+    )
+
+
+def test_sanitize_legacy_github_payload_redacts_url_fields_without_mutating_input():
+    payload = {
+        "repoFullName": "tenon-hire-dev/tenon-ws-1-coding",
+        "repoUrl": "https://github.com/tenon-hire-dev/tenon-ws-1-coding",
+        "workflowUrl": "https://github.com/acme/repo/actions/runs/99",
+        "workflowURL": "https://github.com/tenon-hire-dev/tenon-ws-1-coding",
+        "download_url": "https://github.com/tenon-hire-dev/tenon-template-legacy",
+        "nested": [
+            {
+                "url": "https://github.com/tenon-hire-dev/tenon-ws-1-coding",
+                "template": "tenon-template-old",
+                "repoUrl": "https://github.com/acme/repo",
+                "count": 3,
+                "ok": True,
+                "createdAt": datetime(2026, 4, 28, 12, 0, tzinfo=UTC),
+            }
+        ],
+        "description": "See https://github.com/tenon-hire-dev/tenon-ws-1-coding for details",
+    }
+    original = deepcopy(payload)
+
+    sanitized = sanitize_legacy_github_payload(payload)
+
+    assert sanitized["repoFullName"] == "winoe-ai-repos/winoe-ws-1-coding"
+    assert sanitized["repoUrl"] is None
+    assert sanitized["workflowUrl"] == "https://github.com/acme/repo/actions/runs/99"
+    assert sanitized["workflowURL"] is None
+    assert sanitized["download_url"] is None
+    assert sanitized["nested"][0]["url"] is None
+    assert sanitized["nested"][0]["repoUrl"] == "https://github.com/acme/repo"
+    assert sanitized["nested"][0]["template"] == "[redacted template repo]"
+    assert sanitized["description"] == "See [legacy GitHub link removed] for details"
+    assert sanitized["nested"][0]["count"] == 3
+    assert sanitized["nested"][0]["ok"] is True
+    assert sanitized["nested"][0]["createdAt"] == datetime(
+        2026, 4, 28, 12, 0, tzinfo=UTC
+    )
+    assert payload == original
+    serialized = json.dumps(sanitized, default=str)
+    assert "tenon-hire-dev" not in serialized
+    assert "tenon-ws-" not in serialized
+    assert "tenon-template-" not in serialized
+
+
+def test_sanitize_legacy_github_reference_rewrites_non_url_text():
+    assert (
+        sanitize_legacy_github_reference(
+            "Workspace tenon-hire-dev/tenon-ws-1-coding is retired"
+        )
+        == "Workspace winoe-ai-repos/winoe-ws-1-coding is retired"
+    )

--- a/tests/submissions/presentation/test_submissions_detail_presenter_utils.py
+++ b/tests/submissions/presentation/test_submissions_detail_presenter_utils.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from types import SimpleNamespace
+
+from app.submissions.presentation import (
+    submissions_presentation_submissions_detail_presenter_utils as presenter,
+)
+
+
+def _submission(**overrides):
+    base = {
+        "id": 1,
+        "content_text": "review notes",
+        "content_json": {
+            "repo": "tenon-hire-dev/tenon-template-legacy",
+            "url": "https://github.com/tenon-hire-dev/tenon-ws-1-coding",
+        },
+        "code_repo_path": "tenon-hire-dev/tenon-ws-1-coding",
+        "diff_summary_json": {
+            "base": "abc",
+            "head": "def",
+            "url": "https://github.com/tenon-hire-dev/tenon-template-legacy",
+        },
+        "workflow_run_id": "44",
+        "commit_sha": "fallback-sha",
+        "submitted_at": datetime(2026, 3, 20, 12, 0, tzinfo=UTC),
+        "test_output": None,
+    }
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def _task(**overrides):
+    base = {"id": 21, "day_index": 2, "type": "code", "title": "Code", "prompt": "P"}
+    base.update(overrides)
+    return SimpleNamespace(**base)
+
+
+def test_present_detail_sanitizes_demo_visible_github_references(monkeypatch):
+    monkeypatch.setattr(
+        presenter.talent_partner_sub_service,
+        "parse_test_output",
+        lambda _output: {"status": "ok"},
+    )
+    monkeypatch.setattr(
+        presenter,
+        "parse_diff_summary",
+        lambda _raw: {
+            "base": "abc",
+            "head": "def",
+            "url": "https://github.com/tenon-hire-dev/tenon-template-legacy",
+        },
+    )
+    monkeypatch.setattr(
+        presenter,
+        "resolve_commit_basis",
+        lambda _sub, _day_audit: ("tenon-ws-1-coding", None, None, None),
+    )
+    monkeypatch.setattr(
+        presenter,
+        "build_links",
+        lambda _repo, _sha, _run: (
+            "https://github.com/tenon-hire-dev/tenon-ws-1-coding/commit/abc123",
+            "https://github.com/tenon-hire-dev/tenon-ws-1-coding/actions/runs/44",
+        ),
+    )
+    monkeypatch.setattr(
+        presenter,
+        "build_diff_url",
+        lambda _repo,
+        _summary: "https://github.com/tenon-hire-dev/tenon-template-legacy",
+    )
+    monkeypatch.setattr(
+        presenter,
+        "build_test_results",
+        lambda *_args, **_kwargs: {
+            "status": "passed",
+            "workflowUrl": "https://github.com/tenon-hire-dev/tenon-ws-1-coding/actions/runs/44",
+            "commitUrl": "https://github.com/tenon-hire-dev/tenon-ws-1-coding/commit/abc123",
+            "notes": "tenon-template-legacy",
+        },
+    )
+
+    sub = _submission()
+    payload = presenter.present_detail(sub, _task(), SimpleNamespace(id=7), None)
+
+    serialized = json.dumps(payload, default=str)
+    assert "tenon-hire-dev" not in serialized
+    assert "tenon-ws-" not in serialized
+    assert "tenon-template-" not in serialized
+    assert sub.code_repo_path == "tenon-hire-dev/tenon-ws-1-coding"
+    assert payload["code"]["repoFullName"] == "winoe-ai-repos/winoe-ws-1-coding"
+    assert payload["code"]["repoUrl"] is None
+    assert payload["workflowUrl"] is None
+    assert payload["commitUrl"] is None
+    assert payload["diffUrl"] is None

--- a/tests/submissions/presentation/test_submissions_list_presenter_utils.py
+++ b/tests/submissions/presentation/test_submissions_list_presenter_utils.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
 
@@ -108,6 +109,66 @@ def test_present_list_item_does_not_overwrite_existing_result_links(monkeypatch)
 
     assert payload["testResults"]["commitUrl"] == "https://custom/commit"
     assert payload["testResults"]["workflowUrl"] == "https://custom/workflow"
+
+
+def test_present_list_item_sanitizes_legacy_repo_metadata(monkeypatch):
+    monkeypatch.setattr(
+        presenter.talent_partner_sub_service,
+        "parse_test_output",
+        lambda _output: {"status": "ok"},
+    )
+    monkeypatch.setattr(
+        presenter,
+        "parse_diff_summary",
+        lambda _raw: {
+            "base": "main",
+            "head": "feature",
+            "url": "https://github.com/tenon-hire-dev/tenon-template-legacy",
+        },
+    )
+    monkeypatch.setattr(
+        presenter,
+        "resolve_commit_basis",
+        lambda _sub, _day_audit: ("tenon-ws-1-coding", None, None, None),
+    )
+    monkeypatch.setattr(
+        presenter,
+        "build_links",
+        lambda _repo, _sha, _run: (
+            "https://github.com/tenon-hire-dev/tenon-ws-1-coding/commit/abc123",
+            "https://github.com/tenon-hire-dev/tenon-ws-1-coding/actions/runs/44",
+        ),
+    )
+    monkeypatch.setattr(
+        presenter,
+        "build_diff_url",
+        lambda _repo,
+        _summary: "https://github.com/tenon-hire-dev/tenon-template-legacy",
+    )
+    monkeypatch.setattr(
+        presenter,
+        "build_test_results",
+        lambda *_args, **_kwargs: {
+            "status": "passed",
+            "workflowUrl": "https://github.com/tenon-hire-dev/tenon-ws-1-coding/actions/runs/44",
+            "commitUrl": "https://github.com/tenon-hire-dev/tenon-ws-1-coding/commit/abc123",
+        },
+    )
+
+    payload = presenter.present_list_item(
+        _submission(code_repo_path="tenon-hire-dev/tenon-ws-1-coding"), _task()
+    )
+
+    serialized = json.dumps(payload, default=str)
+    assert "tenon-hire-dev" not in serialized
+    assert "tenon-ws-" not in serialized
+    assert "tenon-template-" not in serialized
+    assert payload["repoFullName"] == "winoe-ai-repos/winoe-ws-1-coding"
+    assert payload["repoUrl"] is None
+    assert payload["workflowUrl"] is None
+    assert payload["commitUrl"] is None
+    assert payload["testResults"]["workflowUrl"] is None
+    assert payload["testResults"]["commitUrl"] is None
 
 
 def test_resolve_commit_basis_prefers_cutoff_sha_over_mutable_head():


### PR DESCRIPTION
## Summary

- Added centralized backend sanitization for legacy Tenon GitHub references in demo-visible evidence payloads.
- Sanitized submission detail/list, candidate review, and Winoe Report / Evidence Trail response boundaries.
- Preserved raw/internal stored evidence while ensuring demo-visible payloads do not expose `tenon-hire-dev`, `tenon-ws-*`, or `tenon-template-*`.
- Avoided unsafe GitHub link rewriting: legacy URL-like fields are returned as `null`/`None` instead of guessed Winoe URLs, while non-legacy URLs are preserved.

## Strategy

This PR uses centralized response-boundary sanitization.

Chosen strategy:
- No destructive database backfill.
- No demo-seed-only assumption.
- No scattered manual `.replace()` calls.
- No invented Winoe GitHub URLs.

Why:
- Existing raw evidence may still contain historical legacy GitHub references.
- Blindly rewriting stored GitHub URLs could break links if replacement repos do not exist.
- Centralized response-boundary sanitization protects demo-visible surfaces while preserving internal evidence integrity.

## Implementation Details

- Added centralized sanitizer under `app/shared/branding`.
- Sanitizer recursively walks JSON-like payloads without mutating the source object.
- Display repo labels are rebranded:
  - `tenon-hire-dev/tenon-ws-*` → `winoe-ai-repos/winoe-ws-*`
- Retired template references are removed/redacted.
- Legacy GitHub URLs in URL-like fields are nulled instead of converted to fake links.
- Non-legacy URLs remain unchanged.
- Sanitization is applied at demo-visible response boundaries:
  - submission detail presenter
  - submission list presenter
  - candidate completed review service
  - Winoe Report ready payload composer

## Link Safety

This PR intentionally does **not** convert legacy URLs like:

```text
https://github.com/tenon-hire-dev/tenon-ws-1-coding
```

into guessed URLs like:

```text
https://github.com/winoe-ai-repos/winoe-ws-1-coding
```

unless existence can be proven.

Instead:

- URL-like fields containing legacy GitHub references become `null`.
- Display fields still show Winoe-branded repo names.
- Non-legacy GitHub URLs are preserved.

This prevents demo-visible legacy branding without creating broken clickable links.

## QA

### Focused tests

```bash
poetry run pytest --no-cov -q \
  tests/shared/branding/test_shared_branding_legacy_github_reference_sanitizer.py \
  tests/submissions/presentation/test_submissions_detail_presenter_utils.py \
  tests/submissions/presentation/test_submissions_list_presenter_utils.py \
  tests/candidates/candidate_sessions/services/test_candidates_candidate_sessions_review_service.py \
  tests/evaluations/services/test_evaluations_winoe_report_composer_service.py
```

Result:

```text
15 passed
```

### Grep verification

```bash
grep -RIn --exclude-dir=.git --exclude-dir=.venv --exclude-dir=__pycache__ \
  "tenon-hire-dev\|tenon-ws-\|tenon-template-" app || true
```

Result:

- only intentional matches remain in the centralized sanitizer module.

### Sanitizer direct verification

Direct script verified:

- `tenon-hire-dev/tenon-ws-1-coding` displays as `winoe-ai-repos/winoe-ws-1-coding`
- legacy URL-like fields become `None`
- non-legacy URLs are preserved
- nested payloads are sanitized recursively
- no source payload mutation occurs

### Full precommit / regression

```bash
bash ./precommit.sh
```

Result:

```text
================ 1896 passed, 13 warnings in 1124.60s (0:18:44) ================
✅ All pre-commit checks passed!
```

## Manual QA Coverage

Verified through focused service/presenter tests and direct sanitizer execution:

- Submission detail payload:
  - no `tenon-hire-dev`
  - no `tenon-ws-`
  - no `tenon-template-`
  - legacy URL fields are `null`
  - display repo names are Winoe-branded

- Submission list payload:
  - no legacy GitHub org/repo names
  - nested test result URL fields are nulled when legacy
  - display repo names are Winoe-branded

- Candidate review payload:
  - sanitizer applied directly at the response boundary
  - no legacy GitHub org/repo names
  - raw submission data remains unchanged

- Winoe Report / Evidence Trail payload:
  - no legacy GitHub org/repo names
  - legacy evidence URL fields are nulled
  - non-legacy evidence URLs are preserved
  - raw report JSON is not mutated

## Not Performed

- Live authenticated backend endpoint walkthrough was not performed.
- This is acceptable for this PR because the affected response builders/services are covered directly, and full regression passed.

## Risks / Follow-ups

- Any future response path that exposes GitHub repo metadata must use the centralized sanitizer or another shared response-boundary mechanism.
- Broader removal of retired template/Specializor/precommit code remains scoped to #316.
- Broader rebrand cleanup remains scoped to #302.

Fixes #309
