### PR TITLE
Task 4: Trial Creation Flow + Generation Loading + Frontend v4 Cleanup

### DIFF
--- a/app/shared/http/shared_http_router_registry_service.py
+++ b/app/shared/http/shared_http_router_registry_service.py
@@ -22,6 +22,9 @@ from app.shared.http.routes import (
 )
 from app.shared.http.routes import shared_http_routes_health_routes as health
 from app.shared.http.routes import shared_http_routes_jobs_routes as jobs
+from app.trials.routes.trials_routes.trials_routes_trials_routes_trials_v4_routes import (
+    router as trials_v4_router,
+)
 
 
 def register_routers(app: FastAPI) -> None:
@@ -39,6 +42,7 @@ def register_routers(app: FastAPI) -> None:
             tags=["admin"],
         )
     app.include_router(trials.router, prefix=f"{prefix}", tags=["trials"])
+    app.include_router(trials_v4_router, prefix=f"{prefix}", tags=["trials"])
     app.include_router(
         candidate_sessions.router, prefix=f"{prefix}/candidate", tags=["candidate"]
     )

--- a/app/trials/repositories/trials_repositories_trials_trial_model.py
+++ b/app/trials/repositories/trials_repositories_trials_trial_model.py
@@ -1,6 +1,7 @@
 """Application module for trials repositories trials trial model workflows."""
 
 from datetime import datetime, time
+from typing import Any
 
 from sqlalchemy import (
     JSON,
@@ -72,7 +73,7 @@ class Trial(Base, TimestampMixin):
     focus: Mapped[str] = mapped_column(
         Text, nullable=False, server_default="", default=""
     )
-    company_context: Mapped[dict[str, str] | None] = mapped_column(JSON, nullable=True)
+    company_context: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
     company_rubric_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     ai_prompt_overrides_json: Mapped[dict | None] = mapped_column(JSON, nullable=True)
     ai_notice_version: Mapped[str] = mapped_column(

--- a/app/trials/routes/trials_routes/trials_routes_trials_routes_trials_v4_routes.py
+++ b/app/trials/routes/trials_routes/trials_routes_trials_routes_trials_v4_routes.py
@@ -1,0 +1,76 @@
+"""Talent Partner Trial creation v4 routes (from-scratch flow)."""
+
+from __future__ import annotations
+
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, status
+from fastapi.responses import StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.shared.auth.shared_auth_current_user_utils import get_current_user
+from app.shared.auth.shared_auth_roles_utils import ensure_talent_partner_or_none
+from app.shared.database import async_session_maker, get_session
+from app.trials import services as trial_service
+from app.trials.schemas.trials_schemas_trials_v4_schema import (
+    TrialCreateV4Request,
+    TrialCreateV4Response,
+)
+from app.trials.services.trials_services_trials_generation_progress_sse_service import (
+    trial_generation_progress_events,
+)
+
+router = APIRouter(prefix="/v1/trials")
+
+
+@router.post(
+    "",
+    response_model=TrialCreateV4Response,
+    status_code=status.HTTP_202_ACCEPTED,
+)
+async def create_trial_v4(
+    payload: TrialCreateV4Request,
+    db: Annotated[AsyncSession, Depends(get_session)],
+    user: Annotated[Any, Depends(get_current_user)],
+):
+    """Create a Trial using the v4 from-scratch contract."""
+    ensure_talent_partner_or_none(user)
+    create_body = payload.to_trial_create()
+    sim, _created_tasks, scenario_job = await trial_service.create_trial_with_tasks(
+        db, create_body, user
+    )
+    return TrialCreateV4Response(
+        trial_id=str(sim.id),
+        job_id=str(scenario_job.id),
+        status="generating",
+    )
+
+
+@router.get("/{trial_id}/generation-progress")
+async def trial_generation_progress(
+    trial_id: int,
+    user: Annotated[Any, Depends(get_current_user)],
+):
+    """Stream drafting progress for a Trial (SSE)."""
+    ensure_talent_partner_or_none(user)
+
+    async def body():
+        async for chunk in trial_generation_progress_events(
+            session_maker=async_session_maker,
+            trial_id=trial_id,
+            company_id=int(user.company_id),
+        ):
+            yield chunk
+
+    return StreamingResponse(
+        body(),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache, no-transform",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+__all__ = ["router"]

--- a/app/trials/schemas/trials_schemas_trials_ai_models_schema.py
+++ b/app/trials/schemas/trials_schemas_trials_ai_models_schema.py
@@ -46,6 +46,22 @@ class TrialCompanyContext(BaseModel):
         min_length=1,
         max_length=MAX_COMPANY_CONTEXT_VALUE_CHARS,
     )
+    evaluation_focus_areas: list[str] | None = Field(
+        default=None,
+        alias="evaluationFocusAreas",
+    )
+
+    @field_validator("evaluation_focus_areas")
+    @classmethod
+    def _validate_evaluation_focus_areas(
+        cls, value: list[str] | None
+    ) -> list[str] | None:
+        if not value:
+            return None
+        cleaned = [str(item).strip() for item in value if str(item).strip()]
+        if not cleaned:
+            return None
+        return cleaned[:24]
 
     @model_serializer(mode="plain")
     def _serialize(self):
@@ -56,6 +72,8 @@ class TrialCompanyContext(BaseModel):
             data["productArea"] = self.product_area
         if self.preferred_language_framework is not None:
             data["preferredLanguageFramework"] = self.preferred_language_framework
+        if self.evaluation_focus_areas:
+            data["evaluationFocusAreas"] = list(self.evaluation_focus_areas)
         return data
 
 

--- a/app/trials/schemas/trials_schemas_trials_v4_schema.py
+++ b/app/trials/schemas/trials_schemas_trials_v4_schema.py
@@ -1,0 +1,86 @@
+"""Schemas for Talent Partner Trial creation API v4."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from app.trials.schemas.trials_schemas_trials_ai_models_schema import (
+    TrialCompanyContext,
+)
+from app.trials.schemas.trials_schemas_trials_create_schema import TrialCreate
+from app.trials.schemas.trials_schemas_trials_limits_schema import (
+    _ALLOWED_ROLE_LEVELS,
+    MAX_FOCUS_NOTES_CHARS,
+    normalize_role_level,
+)
+
+
+class TrialCreateV4Request(BaseModel):
+    """Talent Partner Trial creation (v4 from-scratch flow)."""
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+    role_title: str = Field(..., min_length=1, max_length=200)
+    seniority: str = Field(
+        ...,
+        min_length=1,
+        max_length=100,
+    )
+    preferred_language_framework: str | None = Field(
+        default=None,
+        min_length=1,
+        max_length=500,
+    )
+    focus_notes: str = Field(
+        ...,
+        min_length=1,
+        max_length=MAX_FOCUS_NOTES_CHARS,
+    )
+    evaluation_focus_areas: list[str] | None = Field(default=None, max_length=24)
+
+    @field_validator("seniority")
+    @classmethod
+    def _validate_seniority(cls, value: str) -> str:
+        normalized = normalize_role_level(value)
+        if normalized not in _ALLOWED_ROLE_LEVELS:
+            allowed = ", ".join(sorted(_ALLOWED_ROLE_LEVELS))
+            raise ValueError(f"seniority must be one of: {allowed}")
+        return normalized
+
+    def to_trial_create(self) -> TrialCreate:
+        """Map v4 payload to the internal TrialCreate model."""
+        role_title = self.role_title.strip()
+        focus = self.focus_notes.strip()
+        pref = (
+            self.preferred_language_framework.strip()
+            if self.preferred_language_framework
+            else None
+        )
+        company_context: TrialCompanyContext | None = None
+        if self.evaluation_focus_areas:
+            company_context = TrialCompanyContext(
+                evaluation_focus_areas=list(self.evaluation_focus_areas),
+            )
+        return TrialCreate(
+            title=role_title,
+            role=role_title,
+            seniority=self.seniority,
+            focus=focus,
+            preferred_language_framework=pref,
+            company_context=company_context,
+        )
+
+
+class TrialCreateV4Response(BaseModel):
+    """Minimal response after Trial drafting is queued."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    trial_id: str
+    job_id: str
+    status: Literal["generating"] = "generating"
+
+
+__all__ = ["TrialCreateV4Request", "TrialCreateV4Response"]

--- a/app/trials/services/trials_services_trials_generation_progress_sse_service.py
+++ b/app/trials/services/trials_services_trials_generation_progress_sse_service.py
@@ -1,0 +1,223 @@
+"""Server-Sent Events stream for Trial scenario generation progress."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import AsyncIterator, Awaitable, Callable
+from time import monotonic
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from app.shared.database.shared_database_models_model import Job, Trial
+from app.shared.jobs.repositories.shared_jobs_repositories_models_repository import (
+    JOB_STATUS_DEAD_LETTER,
+)
+from app.trials.repositories.trials_repositories_trials_trial_model import (
+    TRIAL_STATUS_GENERATING,
+    TRIAL_STATUS_READY_FOR_REVIEW,
+)
+from app.trials.services.trials_services_trials_scenario_generation_constants import (
+    SCENARIO_GENERATION_JOB_TYPE,
+)
+
+_CONTEXT_LINES: dict[int, list[str]] = {
+    0: [
+        "Reviewing role context...",
+        "Understanding seniority expectations...",
+    ],
+    1: [
+        "Shaping a realistic from-scratch project...",
+        "Keeping the scope achievable inside a 5-day Trial...",
+    ],
+    2: [
+        "Determining evaluation dimensions...",
+        "Weighting criteria against your focus areas...",
+    ],
+    3: [
+        "Mapping deliverables to each day...",
+        "Checking that the work reveals real execution signal...",
+    ],
+    4: [
+        "Preparing Evidence Trail capture...",
+        "Making sure artifacts can support every score...",
+    ],
+    5: [
+        "Verifying Project Brief consistency...",
+        "Running final structural checks...",
+    ],
+}
+
+LoaderFn = Callable[[int, int], Awaitable[tuple[Any | None, Any | None]]]
+ClockFn = Callable[[], float]
+SleepFn = Callable[[float], Awaitable[None]]
+
+
+def _sse(event: str, data: dict) -> bytes:
+    return (
+        f"event: {event}\ndata: {json.dumps(data, separators=(',', ':'))}\n\n".encode()
+    )
+
+
+def _line_for_step(step: int, tick: int) -> str:
+    lines = _CONTEXT_LINES.get(step, ["Working…"])
+    return lines[tick % len(lines)]
+
+
+async def _default_load_trial_and_job(
+    session_maker: async_sessionmaker[AsyncSession],
+    trial_id: int,
+    company_id: int,
+) -> tuple[Trial | None, Job | None]:
+    async with session_maker() as db:
+        trial = (
+            await db.execute(select(Trial).where(Trial.id == trial_id))
+        ).scalar_one_or_none()
+        if trial is None or trial.company_id != company_id:
+            return None, None
+        job = (
+            await db.execute(
+                select(Job)
+                .where(
+                    Job.job_type == SCENARIO_GENERATION_JOB_TYPE,
+                    Job.correlation_id == f"trial:{trial_id}",
+                )
+                .order_by(Job.created_at.desc())
+                .limit(1)
+            )
+        ).scalar_one_or_none()
+        return trial, job
+
+
+async def trial_generation_progress_events(
+    *,
+    session_maker: async_sessionmaker[AsyncSession] | None = None,
+    trial_id: int,
+    company_id: int,
+    load_trial_and_job: LoaderFn | None = None,
+    clock: ClockFn = monotonic,
+    sleep: SleepFn = asyncio.sleep,
+    poll_interval_seconds: float = 0.45,
+    line_refresh_seconds: float = 3.0,
+    timeout_seconds: float = 900.0,
+    job_missing_grace_seconds: float = 120.0,
+) -> AsyncIterator[bytes]:
+    """Yield SSE frames until drafting completes, fails, or times out.
+
+    ``load_trial_and_job``, ``clock`` and ``sleep`` are injectable so the
+    service can be exercised in tests without sleeping real seconds.
+    """
+    if load_trial_and_job is None:
+        if session_maker is None:
+            raise ValueError(
+                "Either load_trial_and_job or session_maker must be provided."
+            )
+
+        async def _bound_loader(t_id: int, c_id: int):
+            return await _default_load_trial_and_job(session_maker, t_id, c_id)
+
+        load_trial_and_job = _bound_loader
+
+    started = clock()
+    tick = 0
+    active_step = 0
+    step_status: dict[int, str] = {}
+    last_line_emit = started
+
+    yield _sse(
+        "step",
+        {
+            "step": 0,
+            "status": "active",
+            "context_line": _line_for_step(0, tick),
+        },
+    )
+    step_status[0] = "active"
+
+    while clock() - started < timeout_seconds:
+        trial, job = await load_trial_and_job(trial_id, company_id)
+        if trial is None:
+            yield _sse("failed", {"message": "Trial not found."})
+            return
+
+        trial_status = str(getattr(trial, "status", "") or "")
+
+        if trial_status == TRIAL_STATUS_READY_FOR_REVIEW:
+            for s in range(6):
+                if step_status.get(s) != "done":
+                    yield _sse("step", {"step": s, "status": "done"})
+                    step_status[s] = "done"
+            yield _sse("complete", {"trial_id": str(trial.id)})
+            return
+
+        if job is not None and getattr(job, "status", None) == JOB_STATUS_DEAD_LETTER:
+            yield _sse(
+                "failed",
+                {
+                    "message": (
+                        "Winoe could not finish drafting this Trial. "
+                        "Try again with a little more role context."
+                    ),
+                },
+            )
+            return
+
+        if trial_status != TRIAL_STATUS_GENERATING:
+            yield _sse(
+                "failed",
+                {"message": "This Trial is no longer being drafted."},
+            )
+            return
+
+        elapsed = clock() - started
+        if job is None and elapsed > job_missing_grace_seconds:
+            yield _sse(
+                "failed",
+                {"message": "Generation job was not found for this Trial."},
+            )
+            return
+
+        target_step = min(5, int(elapsed // 2.0))
+        while active_step < target_step and active_step < 5:
+            yield _sse("step", {"step": active_step, "status": "done"})
+            step_status[active_step] = "done"
+            active_step += 1
+            tick += 1
+            yield _sse(
+                "step",
+                {
+                    "step": active_step,
+                    "status": "active",
+                    "context_line": _line_for_step(active_step, tick),
+                },
+            )
+            step_status[active_step] = "active"
+            last_line_emit = clock()
+
+        if (
+            step_status.get(active_step) == "active"
+            and clock() - last_line_emit >= line_refresh_seconds
+        ):
+            tick += 1
+            yield _sse(
+                "step",
+                {
+                    "step": active_step,
+                    "status": "active",
+                    "context_line": _line_for_step(active_step, tick),
+                },
+            )
+            last_line_emit = clock()
+
+        await sleep(poll_interval_seconds)
+        tick += 1
+
+    yield _sse(
+        "failed",
+        {"message": "Drafting is taking longer than expected. Please try again later."},
+    )
+
+
+__all__ = ["trial_generation_progress_events"]

--- a/pr.md
+++ b/pr.md
@@ -1,57 +1,30 @@
-# Task 3: TP Dashboard + App Shell + Command Palette
+# Task 4: Talent Partner Trial Creation API (v4)
 
 ## Summary
 
-Task 3 is fully implemented and verified end-to-end locally. This includes Talent Partner dashboard and app shell support from backend APIs, command palette Trial data wiring support, deterministic local QA auth/bootstrap path, seeded Task 3 QA data, dashboard auth handoff fix, completed Trial status + score range support, and idempotent/FK-safe local seed purge handling.
+- Added v4 Trial creation endpoint: `POST /api/v1/trials`.
+- Added Trial generation progress SSE endpoint: `GET /api/v1/trials/{trial_id}/generation-progress`.
+- v4 creation accepts role title, seniority, optional preferred language/framework, focus notes, and optional evaluation focus areas.
+- v4 creation returns `202 Accepted` with `{ trial_id, job_id, status: "generating" }`.
+- Added targeted schema, route, and SSE service tests.
+- Refactored SSE service for injectable timing/loading to keep tests fast and deterministic.
 
-## Scope (Backend)
+## Validation
 
-- Fixed dashboard BFF/backend dev bypass compatibility using `x-dev-user-email` handoff behavior.
-- Added `completed` Trial lifecycle status support and migration updates.
-- Added list API support for `scoreRange`.
-- Added local Task 3 QA seed script support.
-- Implemented FK-safe, idempotent local seed purge behavior.
-- Added regression tests for:
-  - seed idempotency
-  - Submission FK dependency handling
-  - unrelated Trial preservation
-  - production guard behavior
+- `poetry run pytest tests/trials -q --no-cov` — pass
+- `./precommit.sh` — pass
+- Backend precommit full test suite — pass, 96.07% coverage
+- Backend compatibility grep — remaining hits documented as internal/legacy, not v4 API exposure
 
-## QA Evidence (Iteration 8)
+## Real Local QA Evidence
 
-- Verdict: **QA PASS**
-- Artifact root: `qa_verifications/task-3-tp-dashboard-app-shell-command-palette/20260507-005607`
-- `/api/dashboard`: `200` and includes:
-  - `Senior Backend Engineer`
-  - `QA Awaiting Candidate Trial`
-  - `QA Completed Cohort Trial`
-- Browser QA: `browser-results.json` reports `failed=0`, `ok=true`
-- Lighthouse:
-  - `/login`: `98`
-  - authenticated `/dashboard/trials`: `96`
-- Candidate boundary: **PASS**
-- Dark mode: **PASS**
-- Responsive: **PASS**
+- Backend readiness: pass (`GET /ready` 200)
+- `POST /api/v1/trials`: pass, returns 202
+- `GET /api/v1/trials/{trial_id}/generation-progress`: pass (SSE from browser via frontend BFF)
+- v4 response excludes legacy fields: pass (create body and client contract per Task 4)
+- Artifact folder: `winoe-ai-frontend/qa_verifications/task-4-trial-creation-flow/20260512-131043/` (screenshots, `qa-report.md`, readiness JSON)
 
-## Validation Commands
+## Notes
 
-- `poetry run alembic upgrade head` — PASS
-- `poetry run python scripts/seed_task3_qa.py --talent-partner-email talent_partner1@local.test` — PASS (run twice sequentially)
-- `poetry run pytest --no-cov tests/demo/services/test_demo_task3_local_qa_seed_service.py` — PASS
-- `./precommit.sh` — PASS
-
-## Compliance Scan
-
-- No forbidden retired terminology hits in `src`.
-- No `bg-blue|text-indigo|bg-purple` hits.
-- Hex literals are limited to `src/app/globals.css` design-token/global CSS usage.
-- Tailwind raw color utility hits are pre-existing legacy usage outside changed Task 3 files and were not introduced by this work.
-
-## Risk / Rollout Notes
-
-- Local QA path is intentionally local-only and production-guarded.
-- Seed script refuses production.
-- Auth0 production flow is not weakened.
-- Remaining raw utility-class cleanup is broader legacy cleanup and not a Task 3 blocker.
-
-Task 3 is implemented and verified end-to-end for the local QA gate. Ready for PR review.
+- Existing internal compatibility fields remain outside the v4 response contract.
+- Do not expose template/stack fields in the new v4 API.

--- a/tests/trials/routes/test_trials_v4_create_routes.py
+++ b/tests/trials/routes/test_trials_v4_create_routes.py
@@ -1,0 +1,148 @@
+"""Route tests for the Talent Partner Trial v4 from-scratch create endpoint."""
+
+from __future__ import annotations
+
+import pytest
+
+from app.shared.auth.shared_auth_current_user_utils import get_current_user
+from app.shared.database.shared_database_models_model import Company, User
+
+
+@pytest.mark.asyncio
+async def test_trial_v4_create_returns_202_with_minimal_response_shape(
+    async_client, async_session, auth_header_factory
+):
+    company = Company(name="Acme v4")
+    async_session.add(company)
+    await async_session.flush()
+    talent_partner = User(
+        name="TalentPartner v4",
+        email="tp-v4@example.com",
+        role="talent_partner",
+        company_id=company.id,
+        password_hash=None,
+    )
+    async_session.add(talent_partner)
+    await async_session.commit()
+
+    response = await async_client.post(
+        "/api/v1/trials",
+        json={
+            "role_title": "Backend Engineer",
+            "seniority": "mid",
+            "preferred_language_framework": "Python + FastAPI",
+            "focus_notes": "Build internal automation APIs",
+            "evaluation_focus_areas": ["API design"],
+        },
+        headers=auth_header_factory(talent_partner),
+    )
+
+    assert response.status_code == 202
+    body = response.json()
+    assert set(body.keys()) == {"trial_id", "job_id", "status"}
+    assert body["status"] == "generating"
+    assert body["trial_id"]
+    assert body["job_id"]
+    # Make sure no legacy fields leak.
+    for legacy in (
+        "id",
+        "title",
+        "role",
+        "scenarioGenerationJobId",
+        "tasks",
+        "templateKey",
+        "templateRepository",
+    ):
+        assert legacy not in body, f"Legacy field {legacy!r} should not appear"
+
+
+@pytest.mark.asyncio
+async def test_trial_v4_create_rejects_retired_tech_stack_field(
+    async_client, async_session, auth_header_factory
+):
+    company = Company(name="Acme v4 reject")
+    async_session.add(company)
+    await async_session.flush()
+    talent_partner = User(
+        name="TalentPartner v4 reject",
+        email="tp-v4-reject@example.com",
+        role="talent_partner",
+        company_id=company.id,
+        password_hash=None,
+    )
+    async_session.add(talent_partner)
+    await async_session.commit()
+
+    response = await async_client.post(
+        "/api/v1/trials",
+        json={
+            "role_title": "Backend Engineer",
+            "seniority": "mid",
+            "focus_notes": "Build APIs",
+            "tech_stack": "Node.js",
+        },
+        headers=auth_header_factory(talent_partner),
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_trial_v4_create_rejects_retired_template_repository_field(
+    async_client, async_session, auth_header_factory
+):
+    company = Company(name="Acme v4 reject template")
+    async_session.add(company)
+    await async_session.flush()
+    talent_partner = User(
+        name="TalentPartner v4 reject template",
+        email="tp-v4-reject-tpl@example.com",
+        role="talent_partner",
+        company_id=company.id,
+        password_hash=None,
+    )
+    async_session.add(talent_partner)
+    await async_session.commit()
+
+    response = await async_client.post(
+        "/api/v1/trials",
+        json={
+            "role_title": "Backend Engineer",
+            "seniority": "mid",
+            "focus_notes": "Build APIs",
+            "template_repository": "winoe-ai/legacy",
+        },
+        headers=auth_header_factory(talent_partner),
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_trial_v4_create_forbidden_for_non_talent_partner(
+    async_client, async_session, override_dependencies
+):
+    company = Company(name="CandidateCo v4")
+    async_session.add(company)
+    await async_session.flush()
+    candidate_user = User(
+        name="Candidate v4",
+        email="candidate-v4@example.com",
+        role="candidate",
+        company_id=company.id,
+        password_hash=None,
+    )
+    async_session.add(candidate_user)
+    await async_session.commit()
+
+    async def override_get_current_user():
+        return candidate_user
+
+    with override_dependencies({get_current_user: override_get_current_user}):
+        response = await async_client.post(
+            "/api/v1/trials",
+            json={
+                "role_title": "Backend Engineer",
+                "seniority": "mid",
+                "focus_notes": "Build APIs",
+            },
+        )
+        assert response.status_code == 403

--- a/tests/trials/schemas/test_trials_v4_schema.py
+++ b/tests/trials/schemas/test_trials_v4_schema.py
@@ -1,0 +1,149 @@
+"""Schema tests for the Talent Partner Trial v4 from-scratch API."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from app.trials.schemas.trials_schemas_trials_v4_schema import (
+    TrialCreateV4Request,
+    TrialCreateV4Response,
+)
+
+
+def test_trial_create_v4_accepts_valid_payload():
+    payload = TrialCreateV4Request(
+        role_title="Backend Engineer",
+        seniority="mid",
+        preferred_language_framework="Python + FastAPI",
+        focus_notes="Build async pipelines",
+        evaluation_focus_areas=["API design", "Testing discipline"],
+    )
+    assert payload.role_title == "Backend Engineer"
+    assert payload.seniority == "mid"
+    assert payload.preferred_language_framework == "Python + FastAPI"
+    assert payload.focus_notes == "Build async pipelines"
+    assert payload.evaluation_focus_areas == ["API design", "Testing discipline"]
+
+
+def test_trial_create_v4_trims_role_focus_and_preferred_lf():
+    create = TrialCreateV4Request(
+        role_title="  Backend Engineer  ",
+        seniority="mid",
+        preferred_language_framework="  Python + FastAPI  ",
+        focus_notes="  Build async pipelines  ",
+    ).to_trial_create()
+    assert create.title == "Backend Engineer"
+    assert create.role == "Backend Engineer"
+    assert create.focus == "Build async pipelines"
+    assert create.preferred_language_framework == "Python + FastAPI"
+
+
+def test_trial_create_v4_rejects_retired_tech_stack_field():
+    with pytest.raises(ValidationError):
+        TrialCreateV4Request.model_validate(
+            {
+                "role_title": "Backend Engineer",
+                "seniority": "mid",
+                "focus_notes": "Build APIs",
+                "tech_stack": "Node.js, PostgreSQL",
+            }
+        )
+
+
+def test_trial_create_v4_rejects_retired_template_key_field():
+    with pytest.raises(ValidationError):
+        TrialCreateV4Request.model_validate(
+            {
+                "role_title": "Backend Engineer",
+                "seniority": "mid",
+                "focus_notes": "Build APIs",
+                "template_key": "python-fastapi",
+            }
+        )
+
+
+def test_trial_create_v4_rejects_retired_template_repository_field():
+    with pytest.raises(ValidationError):
+        TrialCreateV4Request.model_validate(
+            {
+                "role_title": "Backend Engineer",
+                "seniority": "mid",
+                "focus_notes": "Build APIs",
+                "template_repository": "winoe-ai/legacy",
+            }
+        )
+
+
+def test_trial_create_v4_rejects_missing_focus_notes():
+    with pytest.raises(ValidationError):
+        TrialCreateV4Request.model_validate(
+            {
+                "role_title": "Backend Engineer",
+                "seniority": "mid",
+            }
+        )
+
+
+def test_trial_create_v4_normalizes_seniority_case():
+    payload = TrialCreateV4Request(
+        role_title="Backend Engineer",
+        seniority="  Senior  ",
+        focus_notes="Build APIs",
+    )
+    assert payload.seniority == "senior"
+
+
+def test_trial_create_v4_rejects_invalid_seniority():
+    with pytest.raises(ValidationError):
+        TrialCreateV4Request(
+            role_title="Backend Engineer",
+            seniority="wizard",
+            focus_notes="Build APIs",
+        )
+
+
+def test_trial_create_v4_evaluation_focus_areas_serialized_in_company_context():
+    create = TrialCreateV4Request(
+        role_title="Backend Engineer",
+        seniority="mid",
+        focus_notes="Build APIs",
+        evaluation_focus_areas=["API design", "Testing discipline"],
+    ).to_trial_create()
+    assert create.company_context is not None
+    serialized = create.company_context.model_dump()
+    assert serialized.get("evaluationFocusAreas") == [
+        "API design",
+        "Testing discipline",
+    ]
+
+
+def test_trial_create_v4_no_company_context_when_no_focus_areas():
+    create = TrialCreateV4Request(
+        role_title="Backend Engineer",
+        seniority="mid",
+        focus_notes="Build APIs",
+    ).to_trial_create()
+    assert create.company_context is None
+
+
+def test_trial_create_v4_response_default_status_is_generating():
+    response = TrialCreateV4Response(trial_id="1", job_id="job-1")
+    payload = response.model_dump()
+    assert payload == {
+        "trial_id": "1",
+        "job_id": "job-1",
+        "status": "generating",
+    }
+
+
+def test_trial_create_v4_response_rejects_unknown_fields():
+    with pytest.raises(ValidationError):
+        TrialCreateV4Response.model_validate(
+            {
+                "trial_id": "1",
+                "job_id": "job-1",
+                "status": "generating",
+                "legacy_id": "old",
+            }
+        )

--- a/tests/trials/services/test_trials_generation_progress_sse_service.py
+++ b/tests/trials/services/test_trials_generation_progress_sse_service.py
@@ -22,8 +22,14 @@ from app.trials.repositories.trials_repositories_trials_trial_model import (
     TRIAL_STATUS_TERMINATED,
 )
 from app.trials.services.trials_services_trials_generation_progress_sse_service import (
+    _line_for_step,
     trial_generation_progress_events,
 )
+from app.trials.services.trials_services_trials_scenario_generation_constants import (
+    SCENARIO_GENERATION_JOB_TYPE,
+)
+from tests.shared.factories import create_job, create_talent_partner, create_trial
+from tests.shared.fixtures.shared_fixtures_session_patch_utils import _session_maker
 
 
 def _parse_sse(frame: bytes) -> tuple[str, dict]:
@@ -264,3 +270,143 @@ async def test_sse_requires_session_maker_when_loader_omitted():
             company_id=1,
         )
         await gen.__anext__()
+
+
+def test_line_for_step_unknown_step_uses_working_fallback():
+    assert _line_for_step(99, 0) == "Working…"
+
+
+@pytest.mark.asyncio
+async def test_sse_advances_steps_as_virtual_elapsed_time_grows():
+    clock = _VirtualClock()
+
+    async def loader(_t, _c):
+        return (
+            SimpleNamespace(id=1, company_id=1, status=TRIAL_STATUS_GENERATING),
+            SimpleNamespace(status=JOB_STATUS_RUNNING),
+        )
+
+    events: list[tuple[str, dict]] = []
+    async for frame in trial_generation_progress_events(
+        trial_id=1,
+        company_id=1,
+        load_trial_and_job=loader,
+        clock=clock.time,
+        sleep=clock.sleep,
+        poll_interval_seconds=0.5,
+        timeout_seconds=6.0,
+    ):
+        events.append(_parse_sse(frame))
+
+    active_steps = [
+        d["step"]
+        for e, d in events
+        if e == "step" and d.get("status") == "active" and "step" in d
+    ]
+    assert max(active_steps) >= 1
+
+
+@pytest.mark.asyncio
+async def test_sse_refreshes_context_line_for_active_step():
+    clock = _VirtualClock()
+
+    async def loader(_t, _c):
+        return (
+            SimpleNamespace(id=1, company_id=1, status=TRIAL_STATUS_GENERATING),
+            SimpleNamespace(status=JOB_STATUS_RUNNING),
+        )
+
+    lines: list[str] = []
+    async for frame in trial_generation_progress_events(
+        trial_id=1,
+        company_id=1,
+        load_trial_and_job=loader,
+        clock=clock.time,
+        sleep=clock.sleep,
+        poll_interval_seconds=0.4,
+        line_refresh_seconds=1.0,
+        timeout_seconds=3.5,
+    ):
+        event, data = _parse_sse(frame)
+        if (
+            event == "step"
+            and data.get("step") == 0
+            and data.get("status") == "active"
+            and "context_line" in data
+        ):
+            lines.append(data["context_line"])
+
+    assert len(lines) >= 2
+
+
+@pytest.mark.asyncio
+async def test_sse_session_maker_default_loader_loads_trial_and_job(async_session):
+    from app.shared.database.shared_database_models_model import Company
+
+    clock = _VirtualClock()
+    talent = await create_talent_partner(async_session, email="sse-db-loader@test.com")
+    trial, _tasks = await create_trial(async_session, created_by=talent)
+    trial.status = TRIAL_STATUS_GENERATING
+    company = await async_session.get(Company, talent.company_id)
+    assert company is not None
+    await create_job(
+        async_session,
+        company=company,
+        job_type=SCENARIO_GENERATION_JOB_TYPE,
+        status=JOB_STATUS_RUNNING,
+        correlation_id=f"trial:{trial.id}",
+    )
+    await async_session.commit()
+
+    session_maker = _session_maker(async_session)
+    events: list[tuple[str, dict]] = []
+    async for frame in trial_generation_progress_events(
+        session_maker=session_maker,
+        trial_id=trial.id,
+        company_id=talent.company_id,
+        clock=clock.time,
+        sleep=clock.sleep,
+        timeout_seconds=0.6,
+        poll_interval_seconds=0.15,
+    ):
+        events.append(_parse_sse(frame))
+
+    assert events[0][0] == "step"
+    assert not any(e == "failed" and "not found" in d.get("message", "").lower() for e, d in events)
+
+
+@pytest.mark.asyncio
+async def test_sse_session_maker_default_loader_trial_not_found_for_wrong_company(
+    async_session,
+):
+    from app.shared.database.shared_database_models_model import Company
+
+    clock = _VirtualClock()
+    talent = await create_talent_partner(async_session, email="sse-db-wrong-co@test.com")
+    trial, _tasks = await create_trial(async_session, created_by=talent)
+    trial.status = TRIAL_STATUS_GENERATING
+    company = await async_session.get(Company, talent.company_id)
+    assert company is not None
+    await create_job(
+        async_session,
+        company=company,
+        job_type=SCENARIO_GENERATION_JOB_TYPE,
+        status=JOB_STATUS_RUNNING,
+        correlation_id=f"trial:{trial.id}",
+    )
+    await async_session.commit()
+
+    session_maker = _session_maker(async_session)
+    events: list[tuple[str, dict]] = []
+    async for frame in trial_generation_progress_events(
+        session_maker=session_maker,
+        trial_id=trial.id,
+        company_id=talent.company_id + 9_999_999,
+        clock=clock.time,
+        sleep=clock.sleep,
+        timeout_seconds=0.2,
+        poll_interval_seconds=0.05,
+    ):
+        events.append(_parse_sse(frame))
+
+    assert events[-1] == ("failed", {"message": "Trial not found."})

--- a/tests/trials/services/test_trials_generation_progress_sse_service.py
+++ b/tests/trials/services/test_trials_generation_progress_sse_service.py
@@ -1,0 +1,266 @@
+"""Tests for the Trial scenario generation progress SSE service.
+
+The service is driven via injectable ``load_trial_and_job``, ``clock`` and
+``sleep`` callables so the tests can advance virtual time without actually
+sleeping real seconds.
+"""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from app.shared.jobs.repositories.shared_jobs_repositories_models_repository import (
+    JOB_STATUS_DEAD_LETTER,
+    JOB_STATUS_RUNNING,
+)
+from app.trials.repositories.trials_repositories_trials_trial_model import (
+    TRIAL_STATUS_GENERATING,
+    TRIAL_STATUS_READY_FOR_REVIEW,
+    TRIAL_STATUS_TERMINATED,
+)
+from app.trials.services.trials_services_trials_generation_progress_sse_service import (
+    trial_generation_progress_events,
+)
+
+
+def _parse_sse(frame: bytes) -> tuple[str, dict]:
+    text = frame.decode()
+    lines = [line for line in text.split("\n") if line]
+    event = next(line for line in lines if line.startswith("event: "))
+    data = next(line for line in lines if line.startswith("data: "))
+    return event.removeprefix("event: "), json.loads(data.removeprefix("data: "))
+
+
+class _VirtualClock:
+    """Deterministic clock + async-sleep replacement for SSE tests."""
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def time(self) -> float:
+        return self.now
+
+    async def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+@pytest.mark.asyncio
+async def test_sse_initial_event_emits_step_zero_active():
+    clock = _VirtualClock()
+
+    async def loader(_t, _c):
+        # Return a generating Trial so the loop continues briefly.
+        return (
+            SimpleNamespace(id=1, company_id=1, status=TRIAL_STATUS_GENERATING),
+            SimpleNamespace(status=JOB_STATUS_RUNNING),
+        )
+
+    gen = trial_generation_progress_events(
+        trial_id=1,
+        company_id=1,
+        load_trial_and_job=loader,
+        clock=clock.time,
+        sleep=clock.sleep,
+        timeout_seconds=0.1,
+    )
+
+    first = await gen.__anext__()
+    event, data = _parse_sse(first)
+    assert event == "step"
+    assert data["step"] == 0
+    assert data["status"] == "active"
+    assert "context_line" in data
+    await gen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_sse_ready_for_review_emits_done_steps_then_complete():
+    clock = _VirtualClock()
+
+    async def loader(_t, _c):
+        return (
+            SimpleNamespace(id=42, company_id=7, status=TRIAL_STATUS_READY_FOR_REVIEW),
+            None,
+        )
+
+    events: list[tuple[str, dict]] = []
+    async for frame in trial_generation_progress_events(
+        trial_id=42,
+        company_id=7,
+        load_trial_and_job=loader,
+        clock=clock.time,
+        sleep=clock.sleep,
+    ):
+        events.append(_parse_sse(frame))
+
+    types = [e for e, _ in events]
+    assert types[0] == "step"
+    assert types[-1] == "complete"
+    # Six step-done events between initial active and complete.
+    done_steps = [
+        d["step"] for e, d in events if e == "step" and d.get("status") == "done"
+    ]
+    assert sorted(done_steps) == [0, 1, 2, 3, 4, 5]
+    _, complete_data = events[-1]
+    assert complete_data == {"trial_id": "42"}
+
+
+@pytest.mark.asyncio
+async def test_sse_dead_letter_job_emits_failed():
+    clock = _VirtualClock()
+
+    async def loader(_t, _c):
+        return (
+            SimpleNamespace(id=2, company_id=1, status=TRIAL_STATUS_GENERATING),
+            SimpleNamespace(status=JOB_STATUS_DEAD_LETTER),
+        )
+
+    events: list[tuple[str, dict]] = []
+    async for frame in trial_generation_progress_events(
+        trial_id=2,
+        company_id=1,
+        load_trial_and_job=loader,
+        clock=clock.time,
+        sleep=clock.sleep,
+    ):
+        events.append(_parse_sse(frame))
+
+    assert events[-1][0] == "failed"
+    assert "could not finish drafting" in events[-1][1]["message"].lower()
+
+
+@pytest.mark.asyncio
+async def test_sse_missing_trial_emits_failed():
+    clock = _VirtualClock()
+
+    async def loader(_t, _c):
+        return (None, None)
+
+    events: list[tuple[str, dict]] = []
+    async for frame in trial_generation_progress_events(
+        trial_id=99,
+        company_id=1,
+        load_trial_and_job=loader,
+        clock=clock.time,
+        sleep=clock.sleep,
+    ):
+        events.append(_parse_sse(frame))
+
+    assert events[-1] == ("failed", {"message": "Trial not found."})
+
+
+@pytest.mark.asyncio
+async def test_sse_wrong_company_ownership_emits_failed():
+    """The default loader treats a Trial with a different company_id as missing.
+
+    Tests cover this branch by returning ``(None, None)`` to mirror that
+    contract (the loader is the canonical place where ownership is enforced).
+    """
+    clock = _VirtualClock()
+
+    async def loader(_t, _c):
+        # The real loader returns (None, None) when company_id mismatches.
+        return (None, None)
+
+    events: list[tuple[str, dict]] = []
+    async for frame in trial_generation_progress_events(
+        trial_id=99,
+        company_id=2,  # mismatching company
+        load_trial_and_job=loader,
+        clock=clock.time,
+        sleep=clock.sleep,
+    ):
+        events.append(_parse_sse(frame))
+
+    assert events[-1][0] == "failed"
+    assert events[-1][1]["message"] == "Trial not found."
+
+
+@pytest.mark.asyncio
+async def test_sse_non_generating_trial_emits_failed():
+    clock = _VirtualClock()
+
+    async def loader(_t, _c):
+        return (
+            SimpleNamespace(id=3, company_id=1, status=TRIAL_STATUS_TERMINATED),
+            None,
+        )
+
+    events: list[tuple[str, dict]] = []
+    async for frame in trial_generation_progress_events(
+        trial_id=3,
+        company_id=1,
+        load_trial_and_job=loader,
+        clock=clock.time,
+        sleep=clock.sleep,
+    ):
+        events.append(_parse_sse(frame))
+
+    assert events[-1] == (
+        "failed",
+        {"message": "This Trial is no longer being drafted."},
+    )
+
+
+@pytest.mark.asyncio
+async def test_sse_missing_job_after_grace_period_emits_failed():
+    clock = _VirtualClock()
+
+    async def loader(_t, _c):
+        return (
+            SimpleNamespace(id=4, company_id=1, status=TRIAL_STATUS_GENERATING),
+            None,
+        )
+
+    events: list[tuple[str, dict]] = []
+    async for frame in trial_generation_progress_events(
+        trial_id=4,
+        company_id=1,
+        load_trial_and_job=loader,
+        clock=clock.time,
+        sleep=clock.sleep,
+        job_missing_grace_seconds=0.0,
+    ):
+        events.append(_parse_sse(frame))
+
+    assert events[-1][0] == "failed"
+    assert events[-1][1]["message"] == "Generation job was not found for this Trial."
+
+
+@pytest.mark.asyncio
+async def test_sse_times_out_when_generation_never_completes():
+    clock = _VirtualClock()
+
+    async def loader(_t, _c):
+        return (
+            SimpleNamespace(id=5, company_id=1, status=TRIAL_STATUS_GENERATING),
+            SimpleNamespace(status=JOB_STATUS_RUNNING),
+        )
+
+    events: list[tuple[str, dict]] = []
+    async for frame in trial_generation_progress_events(
+        trial_id=5,
+        company_id=1,
+        load_trial_and_job=loader,
+        clock=clock.time,
+        sleep=clock.sleep,
+        timeout_seconds=1.0,
+        poll_interval_seconds=0.5,
+    ):
+        events.append(_parse_sse(frame))
+
+    assert events[-1][0] == "failed"
+    assert "Drafting is taking longer" in events[-1][1]["message"]
+
+
+@pytest.mark.asyncio
+async def test_sse_requires_session_maker_when_loader_omitted():
+    with pytest.raises(ValueError):
+        gen = trial_generation_progress_events(
+            trial_id=1,
+            company_id=1,
+        )
+        await gen.__anext__()

--- a/tests/trials/services/test_trials_generation_progress_sse_service.py
+++ b/tests/trials/services/test_trials_generation_progress_sse_service.py
@@ -372,7 +372,9 @@ async def test_sse_session_maker_default_loader_loads_trial_and_job(async_sessio
         events.append(_parse_sse(frame))
 
     assert events[0][0] == "step"
-    assert not any(e == "failed" and "not found" in d.get("message", "").lower() for e, d in events)
+    assert not any(
+        e == "failed" and "not found" in d.get("message", "").lower() for e, d in events
+    )
 
 
 @pytest.mark.asyncio
@@ -382,7 +384,9 @@ async def test_sse_session_maker_default_loader_trial_not_found_for_wrong_compan
     from app.shared.database.shared_database_models_model import Company
 
     clock = _VirtualClock()
-    talent = await create_talent_partner(async_session, email="sse-db-wrong-co@test.com")
+    talent = await create_talent_partner(
+        async_session, email="sse-db-wrong-co@test.com"
+    )
     trial, _tasks = await create_trial(async_session, created_by=talent)
     trial.status = TRIAL_STATUS_GENERATING
     company = await async_session.get(Company, talent.company_id)

--- a/tests/trials/services/test_trials_invite_preprovision_service.py
+++ b/tests/trials/services/test_trials_invite_preprovision_service.py
@@ -76,7 +76,9 @@ async def test_preprovision_skips_second_task_when_workspace_key_repeats(
         "is_code_task",
         lambda _t: True,
     )
-    monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_REPO_PREFIX", "pfx")
+    monkeypatch.setattr(
+        preprovision_module.settings.github, "GITHUB_REPO_PREFIX", "pfx"
+    )
     monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_ORG", "org")
 
     tp = await create_talent_partner(async_session, email="preprov-unit1@test.com")
@@ -124,7 +126,9 @@ async def test_preprovision_passes_workspace_resolution_for_fresh_session(
         "is_code_task",
         lambda _t: True,
     )
-    monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_REPO_PREFIX", "pfx")
+    monkeypatch.setattr(
+        preprovision_module.settings.github, "GITHUB_REPO_PREFIX", "pfx"
+    )
     monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_ORG", "org")
 
     tp = await create_talent_partner(async_session, email="preprov-unit2@test.com")
@@ -174,7 +178,9 @@ async def test_preprovision_does_not_list_repo_when_not_marked_created(
         "is_code_task",
         lambda _t: True,
     )
-    monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_REPO_PREFIX", "pfx")
+    monkeypatch.setattr(
+        preprovision_module.settings.github, "GITHUB_REPO_PREFIX", "pfx"
+    )
     monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_ORG", "org")
 
     tp = await create_talent_partner(async_session, email="preprov-unit3@test.com")
@@ -228,7 +234,9 @@ async def test_preprovision_attaches_partial_repo_names_on_later_failure(
         "resolve_workspace_key_for_task",
         lambda t: f"wk-{t.id}",
     )
-    monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_REPO_PREFIX", "pfx")
+    monkeypatch.setattr(
+        preprovision_module.settings.github, "GITHUB_REPO_PREFIX", "pfx"
+    )
     monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_ORG", "org")
 
     tp = await create_talent_partner(async_session, email="preprov-unit4@test.com")
@@ -276,7 +284,9 @@ async def test_preprovision_skips_when_task_is_not_code(async_session, monkeypat
         "is_code_task",
         lambda _t: False,
     )
-    monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_REPO_PREFIX", "pfx")
+    monkeypatch.setattr(
+        preprovision_module.settings.github, "GITHUB_REPO_PREFIX", "pfx"
+    )
     monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_ORG", "org")
 
     tp = await create_talent_partner(async_session, email="preprov-unit5@test.com")
@@ -323,7 +333,9 @@ async def test_preprovision_skips_when_github_username_missing(
         "is_code_task",
         lambda _t: True,
     )
-    monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_REPO_PREFIX", "pfx")
+    monkeypatch.setattr(
+        preprovision_module.settings.github, "GITHUB_REPO_PREFIX", "pfx"
+    )
     monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_ORG", "org")
 
     tp = await create_talent_partner(async_session, email="preprov-unit6@test.com")

--- a/tests/trials/services/test_trials_invite_preprovision_service.py
+++ b/tests/trials/services/test_trials_invite_preprovision_service.py
@@ -1,0 +1,351 @@
+"""Unit tests for ``preprovision_workspaces`` coverage paths."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC, datetime
+from functools import wraps
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+import app.trials.services.trials_services_trials_invite_preprovision_service as preprovision_module
+from app.submissions.services.submissions_services_submissions_workspace_provision_service import (
+    ensure_workspace as _real_ensure_workspace,
+)
+from app.trials.services.trials_services_trials_invite_preprovision_service import (
+    preprovision_workspaces,
+)
+from tests.shared.factories import (
+    create_candidate_session,
+    create_talent_partner,
+    create_trial,
+)
+
+EnsureImpl = Callable[..., Awaitable[object]]
+
+
+def _install_ensure_workspace_stub(monkeypatch: Any, impl: EnsureImpl) -> None:
+    """Keep ``inspect.signature(ensure_workspace)`` so preprovision adds optional kwargs."""
+
+    @wraps(_real_ensure_workspace)
+    async def stub(
+        db,
+        *,
+        candidate_session,
+        trial=None,
+        scenario_version=None,
+        task,
+        github_client,
+        github_username,
+        repo_prefix,
+        destination_owner,
+        now,
+        workspace_resolution=None,
+        commit=True,
+        hydrate_bundle=True,
+        bootstrap_empty_repo=False,
+    ):
+        params = {k: v for k, v in locals().items() if k != "db"}
+        return await impl(db, params)
+
+    monkeypatch.setattr(
+        preprovision_module.submission_service,
+        "ensure_workspace",
+        stub,
+    )
+
+
+@pytest.mark.asyncio
+async def test_preprovision_skips_second_task_when_workspace_key_repeats(
+    async_session, monkeypatch
+):
+    ensure_calls: list[int] = []
+
+    async def impl(_db, params):
+        ensure_calls.append(params["task"].id)
+        return SimpleNamespace(
+            repo_full_name="org/repo-a",
+            _provisioned_repo_created=True,
+        )
+
+    _install_ensure_workspace_stub(monkeypatch, impl)
+    monkeypatch.setattr(
+        preprovision_module.submission_service,
+        "is_code_task",
+        lambda _t: True,
+    )
+    monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_REPO_PREFIX", "pfx")
+    monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_ORG", "org")
+
+    tp = await create_talent_partner(async_session, email="preprov-unit1@test.com")
+    trial, tasks = await create_trial(async_session, created_by=tp)
+    day2 = next(t for t in tasks if t.day_index == 2)
+    day3 = next(t for t in tasks if t.day_index == 3)
+    day2.type = "code"
+    day3.type = "code"
+    cs = await create_candidate_session(
+        async_session,
+        trial=trial,
+        invite_email="c1@test.com",
+    )
+    cs.github_username = "octocat"
+    await async_session.commit()
+
+    names = await preprovision_workspaces(
+        async_session,
+        cs,
+        trial,
+        None,
+        [day2, day3],
+        github_client=SimpleNamespace(),
+        now=datetime.now(UTC),
+        fresh_candidate_session=False,
+    )
+
+    assert ensure_calls == [day2.id]
+    assert names == ["org/repo-a"]
+
+
+@pytest.mark.asyncio
+async def test_preprovision_passes_workspace_resolution_for_fresh_session(
+    async_session, monkeypatch
+):
+    captured: list[dict] = []
+
+    async def impl(_db, params):
+        captured.append(params)
+        return SimpleNamespace(repo_full_name=None, _provisioned_repo_created=False)
+
+    _install_ensure_workspace_stub(monkeypatch, impl)
+    monkeypatch.setattr(
+        preprovision_module.submission_service,
+        "is_code_task",
+        lambda _t: True,
+    )
+    monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_REPO_PREFIX", "pfx")
+    monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_ORG", "org")
+
+    tp = await create_talent_partner(async_session, email="preprov-unit2@test.com")
+    trial, tasks = await create_trial(async_session, created_by=tp)
+    day2 = next(t for t in tasks if t.day_index == 2)
+    day2.type = "code"
+    cs = await create_candidate_session(
+        async_session,
+        trial=trial,
+        invite_email="c2@test.com",
+    )
+    cs.github_username = "octocat"
+    await async_session.commit()
+
+    await preprovision_workspaces(
+        async_session,
+        cs,
+        trial,
+        None,
+        [day2],
+        github_client=SimpleNamespace(),
+        now=datetime.now(UTC),
+        fresh_candidate_session=True,
+    )
+
+    assert len(captured) == 1
+    kwargs = captured[0]
+    assert kwargs["commit"] is False
+    assert kwargs["hydrate_bundle"] is False
+    assert kwargs["workspace_resolution"] is not None
+    assert kwargs["workspace_resolution"].workspace_key == "coding"
+
+
+@pytest.mark.asyncio
+async def test_preprovision_does_not_list_repo_when_not_marked_created(
+    async_session, monkeypatch
+):
+    async def impl(_db, _params):
+        return SimpleNamespace(
+            repo_full_name="org/existing",
+            _provisioned_repo_created=False,
+        )
+
+    _install_ensure_workspace_stub(monkeypatch, impl)
+    monkeypatch.setattr(
+        preprovision_module.submission_service,
+        "is_code_task",
+        lambda _t: True,
+    )
+    monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_REPO_PREFIX", "pfx")
+    monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_ORG", "org")
+
+    tp = await create_talent_partner(async_session, email="preprov-unit3@test.com")
+    trial, tasks = await create_trial(async_session, created_by=tp)
+    day2 = next(t for t in tasks if t.day_index == 2)
+    day2.type = "code"
+    cs = await create_candidate_session(
+        async_session,
+        trial=trial,
+        invite_email="c3@test.com",
+    )
+    cs.github_username = "octocat"
+    await async_session.commit()
+
+    names = await preprovision_workspaces(
+        async_session,
+        cs,
+        trial,
+        None,
+        [day2],
+        github_client=SimpleNamespace(),
+        now=datetime.now(UTC),
+    )
+    assert names == []
+
+
+@pytest.mark.asyncio
+async def test_preprovision_attaches_partial_repo_names_on_later_failure(
+    async_session, monkeypatch
+):
+    calls = 0
+
+    async def impl(_db, params):
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            return SimpleNamespace(
+                repo_full_name="org/first",
+                _provisioned_repo_created=True,
+            )
+        raise ValueError("second task failed")
+
+    _install_ensure_workspace_stub(monkeypatch, impl)
+    monkeypatch.setattr(
+        preprovision_module.submission_service,
+        "is_code_task",
+        lambda _t: True,
+    )
+    monkeypatch.setattr(
+        preprovision_module,
+        "resolve_workspace_key_for_task",
+        lambda t: f"wk-{t.id}",
+    )
+    monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_REPO_PREFIX", "pfx")
+    monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_ORG", "org")
+
+    tp = await create_talent_partner(async_session, email="preprov-unit4@test.com")
+    trial, tasks = await create_trial(async_session, created_by=tp)
+    day2 = next(t for t in tasks if t.day_index == 2)
+    day3 = next(t for t in tasks if t.day_index == 3)
+    day2.type = "code"
+    day3.type = "code"
+    cs = await create_candidate_session(
+        async_session,
+        trial=trial,
+        invite_email="c4@test.com",
+    )
+    cs.github_username = "octocat"
+    await async_session.commit()
+
+    with pytest.raises(ValueError, match="second task failed") as excinfo:
+        await preprovision_workspaces(
+            async_session,
+            cs,
+            trial,
+            None,
+            [day2, day3],
+            github_client=SimpleNamespace(),
+            now=datetime.now(UTC),
+        )
+
+    assert getattr(excinfo.value, "provisioned_repo_full_names", None) == ("org/first",)
+
+
+@pytest.mark.asyncio
+async def test_preprovision_skips_when_task_is_not_code(async_session, monkeypatch):
+    called: list[int] = []
+
+    async def impl(_db, params):
+        called.append(params["task"].id)
+        return SimpleNamespace(
+            repo_full_name="org/x",
+            _provisioned_repo_created=True,
+        )
+
+    _install_ensure_workspace_stub(monkeypatch, impl)
+    monkeypatch.setattr(
+        preprovision_module.submission_service,
+        "is_code_task",
+        lambda _t: False,
+    )
+    monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_REPO_PREFIX", "pfx")
+    monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_ORG", "org")
+
+    tp = await create_talent_partner(async_session, email="preprov-unit5@test.com")
+    trial, tasks = await create_trial(async_session, created_by=tp)
+    day2 = next(t for t in tasks if t.day_index == 2)
+    day2.type = "code"
+    cs = await create_candidate_session(
+        async_session,
+        trial=trial,
+        invite_email="c5@test.com",
+    )
+    cs.github_username = "octocat"
+    await async_session.commit()
+
+    names = await preprovision_workspaces(
+        async_session,
+        cs,
+        trial,
+        None,
+        [day2],
+        github_client=SimpleNamespace(),
+        now=datetime.now(UTC),
+    )
+    assert called == []
+    assert names == []
+
+
+@pytest.mark.asyncio
+async def test_preprovision_skips_when_github_username_missing(
+    async_session, monkeypatch
+):
+    called: list[int] = []
+
+    async def impl(_db, params):
+        called.append(params["task"].id)
+        return SimpleNamespace(
+            repo_full_name="org/x",
+            _provisioned_repo_created=True,
+        )
+
+    _install_ensure_workspace_stub(monkeypatch, impl)
+    monkeypatch.setattr(
+        preprovision_module.submission_service,
+        "is_code_task",
+        lambda _t: True,
+    )
+    monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_REPO_PREFIX", "pfx")
+    monkeypatch.setattr(preprovision_module.settings.github, "GITHUB_ORG", "org")
+
+    tp = await create_talent_partner(async_session, email="preprov-unit6@test.com")
+    trial, tasks = await create_trial(async_session, created_by=tp)
+    day2 = next(t for t in tasks if t.day_index == 2)
+    day2.type = "code"
+    cs = await create_candidate_session(
+        async_session,
+        trial=trial,
+        invite_email="c6@test.com",
+    )
+    cs.github_username = "   "
+    await async_session.commit()
+
+    names = await preprovision_workspaces(
+        async_session,
+        cs,
+        trial,
+        None,
+        [day2],
+        github_client=SimpleNamespace(),
+        now=datetime.now(UTC),
+    )
+    assert called == []
+    assert names == []


### PR DESCRIPTION
## Summary

- Added v4 Trial creation endpoint: `POST /api/v1/trials`.
- Added Trial generation progress SSE endpoint: `GET /api/v1/trials/{trial_id}/generation-progress`.
- v4 creation accepts role title, seniority, optional preferred language/framework, focus notes, and optional evaluation focus areas.
- v4 creation returns `202 Accepted` with `{ trial_id, job_id, status: "generating" }`.
- Added targeted schema, route, and SSE service tests.
- Refactored SSE service for injectable timing/loading to keep tests fast and deterministic.

## Validation

- `poetry run pytest tests/trials -q --no-cov` — pass
- `./precommit.sh` — pass
- Backend precommit full test suite — pass, 96.07% coverage
- Backend compatibility grep — remaining hits documented as internal/legacy, not v4 API exposure

## Real Local QA Evidence

- Backend readiness: pass (`GET /ready` 200)
- `POST /api/v1/trials`: pass, returns 202
- `GET /api/v1/trials/{trial_id}/generation-progress`: pass (SSE from browser via frontend BFF)
- v4 response excludes legacy fields: pass (create body and client contract per Task 4)
- Artifact folder: `winoe-ai-frontend/qa_verifications/task-4-trial-creation-flow/20260512-131043/` (screenshots, `qa-report.md`, readiness JSON)

## Notes

- Existing internal compatibility fields remain outside the v4 response contract.
- Do not expose template/stack fields in the new v4 API.
