### PR TITLE
Task 10: Demo Infrastructure (Fake GitHub Provider + Seed Script + Legacy Cleanup)

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -180,6 +180,9 @@ jobs:
       - name: Install dependencies
         run: poetry install --no-interaction --no-root
 
+      - name: Check demo-visible legacy GitHub refs
+        run: bash scripts/check_no_legacy_demo_refs.sh
+
       - name: Run Alembic migrations
         run: poetry run alembic upgrade heads
 

--- a/YC_DEMO_CHECKLIST.md
+++ b/YC_DEMO_CHECKLIST.md
@@ -1,257 +1,131 @@
-# YC Demo Checklist
-
-## Purpose
-
-This checklist seeds a deterministic Winoe demo dataset that is ready for a live
-Talent Partner walkthrough. It creates one Trial, two completed candidate
-sessions, five days of submitted artifacts for each candidate, and two ready
-Winoe Reports.
-
-## Prerequisites
-
-1. PostgreSQL and the backend environment configured the same way you run the
-   rest of the repository.
-2. `poetry` available locally.
-3. `WINOE_DATABASE_URL` or `WINOE_DATABASE_URL_SYNC` set.
-4. `WINOE_GITHUB_ORG` and `WINOE_GITHUB_TOKEN` set if you want real GitHub
-   provider mode.
-
-## Environment Variables
-
-Use these as needed:
-
-- `DEMO_TALENT_PARTNER_EMAIL`
-- `DEMO_TALENT_PARTNER_NAME`
-- `DEMO_COMPANY_NAME`
-- `DEMO_RESET_DB`
-- `GITHUB_PROVIDER` with `auto`, `fake`, or `real`
-- `WINOE_DEMO_MODE=true` to prefer the fake GitHub provider in local demo mode
-- `WINOE_GITHUB_ORG`
-- `WINOE_GITHUB_TOKEN`
-
-Recommended demo defaults:
-
-- Talent Partner email: `talent.partner.demo@winoe.ai`
-- Company: `Winoe Demo Company`
-
-## One-Command Seed
-
-Run:
-
-```bash
-poetry run python -m scripts.seed_demo
-```
-
-Optional wrapper:
-
-```bash
-./scripts/seed_demo.sh
-```
-
-To force a clean reset of the database before seeding:
-
-```bash
-DEMO_RESET_DB=true poetry run python -m scripts.seed_demo
-```
-
-Fake provider rehearsal command:
-
-```bash
-poetry run python -m scripts.seed_demo --github-provider fake --reset-db
-```
-
-The seed command prints whether it is doing a full database reset or a
-demo-scoped refresh and which GitHub provider mode it is using.
-
-## Start Backend
-
-Use the existing repo commands:
-
-```bash
-./runBackend.sh migrate
-./runBackend.sh api
-```
-
-If you want API and worker together:
-
-```bash
-./runBackend.sh up
-```
-
-If the walkthrough depends on background jobs, start the worker explicitly:
-
-```bash
-./runBackend.sh worker
-```
-
-## GitHub Provider Modes
-
-### Fake Mode
-
-Fake mode is the safest choice for rehearsal.
-
-```bash
-WINOE_DEMO_MODE=true GITHUB_PROVIDER=fake poetry run python -m scripts.seed_demo
-```
-
-Fake mode keeps the repo work local to the process and avoids network calls.
-It does not require `WINOE_GITHUB_ORG` or `WINOE_GITHUB_TOKEN`.
-
-### Real Mode
-
-Real mode uses the configured GitHub org and token.
-
-```bash
-GITHUB_PROVIDER=real poetry run python -m scripts.seed_demo
-```
-
-Use real mode only when the target org and token are ready and the environment
-is not production-like.
-If required GitHub config is missing, the command fails instead of silently
-falling back to fake mode.
-
-## Reset Behavior
-
-- Normal reruns only remove demo-scoped rows and recreate the seeded dataset.
-- `--reset-db` performs a full database reset before seeding.
-- `--reset-db` is blocked in production-like environments.
-- Non-demo rows should survive normal reruns.
-
-## Verify the Seed
-
-1. Check readiness:
-
-```bash
-curl -s http://localhost:8000/health
-curl -s http://localhost:8000/ready
-```
-
-2. Verify the seeded Talent Partner:
-
-```bash
-python - <<'PY'
-import asyncio
-from sqlalchemy import select
-from app.shared.database import async_session_maker
-from app.shared.database.shared_database_models_model import User
-
-async def main():
-    async with async_session_maker() as db:
-        row = await db.scalar(select(User).where(User.email == "talent.partner.demo@winoe.ai"))
-        print(row.id, row.company_id, row.email)
-
-asyncio.run(main())
-PY
-```
-
-3. Verify the Trial:
-
-```bash
-python - <<'PY'
-import asyncio
-from sqlalchemy import select
-from app.shared.database import async_session_maker
-from app.shared.database.shared_database_models_model import Trial
-
-async def main():
-    async with async_session_maker() as db:
-        row = await db.scalar(select(Trial).where(Trial.title == "YC Demo Backend Engineer Trial"))
-        print(row.id, row.status, row.active_scenario_version_id)
-
-asyncio.run(main())
-PY
-```
-
-4. Verify both candidate sessions:
-
-```bash
-python - <<'PY'
-import asyncio
-from sqlalchemy import select
-from app.shared.database import async_session_maker
-from app.shared.database.shared_database_models_model import CandidateSession
-
-async def main():
-    async with async_session_maker() as db:
-        rows = (await db.execute(select(CandidateSession).order_by(CandidateSession.id))).scalars().all()
-        for row in rows:
-            print(row.id, row.candidate_name, row.status, row.completed_at)
-
-asyncio.run(main())
-PY
-```
-
-5. Verify all five days of artifacts:
-
-```bash
-python - <<'PY'
-import asyncio
-from sqlalchemy import func, select
-from app.shared.database import async_session_maker
-from app.shared.database.shared_database_models_model import Submission
-
-async def main():
-    async with async_session_maker() as db:
-        rows = await db.execute(
-            select(Submission.candidate_session_id, func.count())
-            .group_by(Submission.candidate_session_id)
-        )
-        print(rows.all())
-
-asyncio.run(main())
-PY
-```
-
-6. Verify both Winoe Reports:
-
-```bash
-python - <<'PY'
-import asyncio
-from sqlalchemy import select
-from app.shared.database import async_session_maker
-from app.shared.database.shared_database_models_model import WinoeReport
-
-async def main():
-    async with async_session_maker() as db:
-        rows = (await db.execute(select(WinoeReport))).scalars().all()
-        for row in rows:
-            print(row.candidate_session_id, row.generated_at)
-
-asyncio.run(main())
-PY
-```
-
-7. Verify Evidence Trail links by opening the report payload for each candidate
-   and checking the evidence citations point to the persisted submissions,
-   recording, and transcript rows created by the seed.
-
-## YC Demo Walkthrough
-
-1. Open the Talent Partner dashboard.
-2. Open the seeded Trial overview.
-3. Open the two candidate sessions.
-4. Walk through Day 1 through Day 5 artifacts.
-5. Open the Evidence Trail for each report.
-6. Open the Winoe Report for each candidate.
-7. Review the Winoe Score and dimensional sub-scores.
-8. Compare the candidates side by side if the compare view is available.
-9. Close on the evidence-backed hiring decision.
-
-## Troubleshooting
-
-- If the seed command fails, verify the database URL and rerun `./runBackend.sh
-  migrate`.
-- If real GitHub mode fails, confirm the org and token are set.
-- If worker-driven data is missing, start the worker with `./runBackend.sh
-  worker` and reseed.
-- If the seed command reports a production-like environment, rerun it from a
-  local or non-production shell.
-
-## Cleanup
-
-To reseed from scratch in local development, set `DEMO_RESET_DB=true` and rerun
-the seed command.
-
-```bash
-DEMO_RESET_DB=true poetry run python -m scripts.seed_demo
-```
+# YC Demo Day Checklist
+
+## 24 Hours Before
+- Pull the latest `main` on backend and frontend.
+- Run backend migrations:
+  - `./runBackend.sh migrate`
+- Start the frontend once to confirm the app boots cleanly:
+  - `./runFrontend.sh`
+- Seed the demo data:
+  - `export WINOE_ENV=local`
+  - `export WINOE_DEMO_MODE=true`
+  - `./scripts/seed_demo.sh`
+- Confirm the backend health check responds:
+  - `curl -fsS http://localhost:8000/health`
+- Confirm the login page opens:
+  - `http://localhost:3000/login`
+- Log in as `demo@winoe.ai`.
+- Confirm the Talent Partner Trials dashboard loads:
+  - `http://localhost:3000/talent-partner/trials`
+- Verify the dashboard shows 3 Trials.
+- Open the completed Trial B row for Sarah Chen.
+- Open the Sarah Chen Winoe Report route and verify all sections render.
+- Verify PDF export works from the Winoe Report page.
+- Verify the command palette, if available, opens and can navigate to Trials and Benchmarks.
+
+## 4 Hours Before
+- Restart backend and frontend services.
+- Re-run the seed script:
+  - `export WINOE_ENV=local`
+  - `export WINOE_DEMO_MODE=true`
+  - `./scripts/seed_demo.sh`
+- Re-open the dashboard and confirm the 3 seeded Trials are present.
+- Open Trial A and Trial C to confirm their states are still correct.
+- Re-open Trial B and confirm the completed Sarah Chen report still renders.
+- Practice the full 8-minute demo flow at the target display resolution.
+- Time the run end-to-end and keep it under 8 minutes.
+
+## 1 Hour Before
+- Disable browser autofill.
+- Disable browser notifications.
+- Close Slack, email, and other distracting apps.
+- Clear the browser cache if the session looks stale.
+- Open these tabs before the audience arrives:
+  - `http://localhost:3000/login`
+  - `http://localhost:3000/talent-partner/trials`
+  - The completed Sarah Chen Winoe Report page
+- Confirm the browser is signed in as `demo@winoe.ai`.
+- Confirm `WINOE_DEMO_MODE=true` is still set in the shell that launched the backend.
+
+## At The Demo
+- Confirm the backend and frontend are both running.
+- Keep HDMI/USB-C adapters and chargers within reach.
+- Have the backup recording ready.
+- Use the login page only if you need to re-establish the session.
+- Start on the Talent Partner Trials dashboard.
+- Call out the Winoe Score and the evidence behind it, not a hiring decision.
+- Stay inside current Winoe terminology only.
+
+## 8-Minute Demo Flow
+1. Login as `demo@winoe.ai`.
+2. Open the Talent Partner Trials dashboard.
+3. Point out the three seeded Trials.
+4. Open Trial A and show the inviting / active state.
+5. Open Trial B and show the completed Sarah Chen candidate.
+6. Open the Sarah Chen Winoe Report.
+7. Walk through the Winoe Score, eight dimensions, and Evidence Trail citations.
+8. Show the PDF export.
+9. Briefly note Trial C as awaiting candidate / invited / not started.
+10. Close with the product story and next step.
+
+## Failure Recovery
+
+### Seed fails
+- Confirm `WINOE_ENV=local`.
+- Confirm `WINOE_DEMO_MODE=true`.
+- Run backend migrations again:
+  - `./runBackend.sh migrate`
+- Re-run the seed script:
+  - `./scripts/seed_demo.sh`
+- If Alembic is still stamped to an old local-only revision, reset the local database or run `alembic stamp head` on the local copy before retrying migrations.
+- If the database still looks wrong, restart the backend and try the seed again.
+- If the demo still cannot be restored quickly, switch to the backup recording.
+
+### Backend fails
+- Stop the backend process.
+- Restart it:
+  - `./runBackend.sh`
+- Check the health endpoint:
+  - `curl -fsS http://localhost:8000/health`
+- If the health endpoint does not recover, inspect the backend logs before retrying the demo.
+
+### Frontend fails
+- Stop the frontend process.
+- Restart it:
+  - `./runFrontend.sh`
+- Refresh the login page after the dev server comes back.
+
+### GitHub real API is accidentally used
+- Stop the demo seed or backend worker immediately.
+- Re-run with the fake provider path:
+  - `export WINOE_DEMO_MODE=true`
+  - `export WINOE_ENV=local`
+  - `./scripts/seed_demo.sh`
+
+### Browser crashes
+- Re-open the login page.
+- Log in again as `demo@winoe.ai`.
+- Return to `http://localhost:3000/talent-partner/trials`.
+
+## Things Not To Demo
+- Candidate-side flows unless explicitly requested.
+- Settings pages.
+- Background job admin screens.
+- Hidden or beta-flagged surfaces.
+- Anything that depends on live external services.
+
+## Notes For The Founder
+- Keep the path deterministic.
+- Re-run the seed before every rehearsal.
+- The seed entrypoint is:
+  - `./scripts/seed_demo.sh`
+- If a local database has a stale Alembic stamp, repair it locally with a reset or `alembic stamp head` before seeding.
+- The demo login is:
+  - `demo@winoe.ai`
+- The dashboard route is:
+  - `http://localhost:3000/talent-partner/trials`
+- The login route is:
+  - `http://localhost:3000/login`
+- The Winoe Score is displayed out of 100 in the UI, while the API stores the unit-interval score.
+- If the dashboard shows stale data, treat it as a blocker and re-seed before the next run.
+- Keep narration evidence-first and inside current Winoe terminology.

--- a/app/ai/prompt_assets/v4/winoe_soul.md
+++ b/app/ai/prompt_assets/v4/winoe_soul.md
@@ -38,19 +38,29 @@
 - Winoe Score
 
 ## Words I Avoid
-- Eliminate
-- Reject
-- Filter out
-- Screen out
-- Discard
-- Recruiter
-- Simulation
+- Exclusionary language
+- Tenon
+- SimuHire
+- recruiter
+- simulation
 - Fit Profile
 - Fit Score
-- Tenon
-- Best candidate
-- Top talent
+- template catalog
+- precommit
+- Codespace Specializor
+- eliminate
+- reject
+- filter out
+- screen out
+- discard
 - A-player
-- Culture fit
-- Metrics
-- KPIs
+- culture fit
+- hiring recommendation language that implies Winoe decides
+- Legacy product terms
+- Vague performance clichés
+- Undisciplined metrics talk
+
+## Governance Note
+- The terms above are forbidden in generated Winoe prose.
+- They may appear only here as internal examples of language Winoe must avoid.
+- Never emit them in Winoe Report output, Evidence Trail narration, or Talent Partner-facing prose.

--- a/app/ai/prompt_assets/v4/winoe_synthesis.md
+++ b/app/ai/prompt_assets/v4/winoe_synthesis.md
@@ -68,10 +68,15 @@ Requirements for the report:
 - Do not omit citations when the narrative makes evaluative statements.
 - Keep the assessment readable for a busy Talent Partner.
 - Keep the tone warm, direct, evidence-first, and anti-black-box.
+- The terms in the persona governance section are forbidden in generated prose only.
+- They may appear in this prompt as internal "do not use" examples, but never in the Winoe Report body.
 
 Persona checks:
-- Do not use forbidden terms in Winoe-generated prose.
-- Do not mention recruiter, Tenon, simulation, Fit Profile, Fit Score, eliminate, reject, filter out, screen out, discard, A-player, or culture fit.
+- Do not use the forbidden terms in Winoe-generated prose.
+- Keep the language aligned with the current Winoe brand and avoid legacy product residue.
+- Do not use language that implies Winoe makes the hiring decision.
+- Explicitly avoid product-visible use of Tenon, SimuHire, recruiter, simulation, Fit Profile, Fit Score, template catalog, precommit, Codespace Specializor, eliminate, reject, filter out, screen out, discard, A-player, and culture fit.
+- Those terms may appear only as forbidden examples inside internal prompt governance, never in generated report prose.
 
 ## Self-Check
 - Verify the report is fully supported by the Evidence Trail.

--- a/app/config/config_settings_validators_config.py
+++ b/app/config/config_settings_validators_config.py
@@ -99,3 +99,11 @@ class SettingsValidationMixin:
         if any("*" in origin for origin in origins):
             raise ValueError("Wildcard CORS origins are not allowed outside local/test")
         return self
+
+    @model_validator(mode="after")
+    def _reject_demo_mode_in_production(self):
+        if bool(self.DEMO_MODE) and self.is_production_environment():
+            raise ValueError(
+                "DEMO_MODE/WINOE_DEMO_MODE cannot be enabled in production."
+            )
+        return self

--- a/app/demo/services/yc_demo_seed_service.py
+++ b/app/demo/services/yc_demo_seed_service.py
@@ -14,7 +14,6 @@ from app.candidates.candidate_sessions.repositories.candidates_candidate_session
     CandidateDayAudit,
 )
 from app.evaluations.repositories.evaluations_repositories_evaluations_core_model import (
-    EVALUATION_RECOMMENDATION_LEAN_HIRE,
     EVALUATION_RECOMMENDATION_STRONG_HIRE,
     EVALUATION_RUN_STATUS_COMPLETED,
     EvaluationDayScore,
@@ -64,6 +63,8 @@ from app.trials.repositories.scenario_versions.trials_repositories_scenario_vers
     ScenarioVersion as TrialScenarioVersion,
 )
 from app.trials.repositories.trials_repositories_trials_trial_status_constants import (
+    TRIAL_STATUS_ACTIVE_INVITING,
+    TRIAL_STATUS_COMPLETED,
     TRIAL_STATUS_GENERATING,
     TRIAL_STATUS_READY_FOR_REVIEW,
 )
@@ -79,18 +80,18 @@ from app.trials.services.trials_services_trials_task_seed_service import (
 class DemoSeedConfig:
     """Configuration for the YC demo seed."""
 
-    talent_partner_email: str = "talent.partner.demo@winoe.ai"
-    talent_partner_name: str = "Winoe Demo Talent Partner"
-    company_name: str = "Winoe Demo Company"
-    trial_title: str = "YC Demo Backend Engineer Trial"
-    trial_role: str = "Backend Engineer"
-    trial_seniority: str = "Senior"
+    talent_partner_email: str = "demo@winoe.ai"
+    talent_partner_name: str = "Demo Partner"
+    company_name: str = "Acme"
+    trial_title: str = "Senior Frontend Engineer Trial"
+    trial_role: str = "Senior Frontend Engineer"
+    trial_seniority: str = "senior"
     trial_focus: str = (
-        "Design and ship a from-scratch backend API for a B2B operations workflow."
+        "Design and ship a from-scratch product surface for a candidate work Trial."
     )
-    trial_preferred_language_framework: str = "Python, FastAPI, PostgreSQL"
+    trial_preferred_language_framework: str = "TypeScript + React"
     git_owner: str = "winoe-ai-demo"
-    repo_prefix: str = "yc-demo-candidate-"
+    repo_prefix: str = "winoe-ws-"
     codespace_workspace_key: str = "coding"
     timezone: str = "America/New_York"
     reset_db: bool = False
@@ -116,6 +117,28 @@ class DemoCandidateProfile:
 
 
 @dataclass(slots=True)
+class DemoInviteCandidateProfile:
+    """Deterministic profile for an invited but not yet started candidate."""
+
+    name: str
+    email: str
+    github_username: str
+
+
+@dataclass(slots=True)
+class DemoTrialProfile:
+    """Seed plan for a demo Trial."""
+
+    title: str
+    role: str
+    seniority: str
+    preferred_language_framework: str
+    focus: str
+    status: str
+    candidates: list[DemoInviteCandidateProfile]
+
+
+@dataclass(slots=True)
 class DemoSeedSummary:
     """High-level summary of the seeded demo dataset."""
 
@@ -123,6 +146,22 @@ class DemoSeedSummary:
     trial_id: int
     candidate_session_ids: list[int]
     repo_full_names: list[str]
+
+
+DEMO_MODE_MARKER = "yc-demo"
+DEMO_TRIAL_TITLES = [
+    "Senior Backend Engineer Trial",
+    "Senior Frontend Engineer Trial",
+    "Staff Engineer Trial",
+]
+DEMO_INVITE_EMAILS = [
+    "marcus.okonjo.demo@winoe.ai",
+    "priya.patel.demo@winoe.ai",
+    "sarah.chen.demo@winoe.ai",
+    "nina.alvarez.demo@winoe.ai",
+]
+DEMO_TALENT_PARTNER_EMAIL = "demo@winoe.ai"
+SARAH_CHEN_DEMO_EMAIL = "sarah.chen.demo@winoe.ai"
 
 
 def _apply_legacy_trial_fields(trial: Trial) -> None:
@@ -144,31 +183,31 @@ def _demo_trial_brief_markdown(config: DemoSeedConfig) -> str:
     return (
         "# Project Brief\n\n"
         "## Business Context\n\n"
-        f"{config.company_name} needs a lightweight internal API for coordinating "
-        "candidate evidence, review notes, and hiring decision prep.\n\n"
+        f"{config.company_name} needs a lightweight system for coordinating "
+        "candidate evidence, review notes, and Trial progression.\n\n"
         "## Product Goal\n\n"
-        "Build a from-scratch backend service that can track an intake workflow, "
-        "surface evidence-backed progress, and support Talent Partner review.\n\n"
+        "Build a from-scratch work Trial experience that keeps every step "
+        "evidence-backed and easy to review.\n\n"
         "## Technical Constraints\n\n"
         "- Start from an empty repository.\n"
         "- Commit a devcontainer so the project is reproducible.\n"
         "- Use clear validation, idempotent writes, and readable API boundaries.\n"
         "- Keep the architecture simple enough to finish in five days.\n\n"
         "## Expected Deliverables\n\n"
-        "- A stable API with create, read, and status endpoints.\n"
+        "- A stable product surface with create, read, and status endpoints.\n"
         "- Tests that prove the core workflow.\n"
         "- Documentation that explains the design and tradeoffs.\n\n"
         "## Risks\n\n"
         "- Overengineering the storage model.\n"
         "- Missing edge-case handling around duplicate requests.\n"
-        "- Treating the demo as a toy instead of a real hiring workflow.\n"
+        "- Treating the demo as a toy instead of a real work Trial.\n"
     )
 
 
 def _demo_scenario_storyline() -> str:
     return (
         "A Talent Partner needs a reliable evidence trail for a five-day "
-        "from-scratch build and wants to compare two candidates with a clear "
+        "from-scratch work Trial and wants to compare candidates with a clear "
         "Winoe Report."
     )
 
@@ -188,55 +227,92 @@ def _demo_task_prompts(tasks: list[Task]) -> list[dict[str, Any]]:
 def _demo_candidate_profiles() -> list[DemoCandidateProfile]:
     return [
         DemoCandidateProfile(
-            label="candidate-a",
-            name="Avery Chen",
-            email="avery.chen.demo@winoe.ai",
-            repo_suffix="avery-chen",
-            overall_score=0.91,
-            confidence=0.88,
-            recommendation="strong_signal",
+            label="sarah-chen",
+            name="Sarah Chen",
+            email="sarah.chen.demo@winoe.ai",
+            repo_suffix="sarah-chen",
+            overall_score=0.78,
+            confidence=0.86,
+            recommendation="positive_signal",
             internal_recommendation=EVALUATION_RECOMMENDATION_STRONG_HIRE,
             strength_points=[
-                "Clear architecture notes with strong API boundaries",
-                "Consistent testing discipline across the build",
-                "Good documentation and handoff clarity",
+                "The repository stays small and readable while still covering the full Trial scope.",
+                "The implementation and tests progress in a disciplined way across the build window.",
+                "The handoff documents the work clearly and keeps the evidence trail easy to follow.",
             ],
             concern_points=[
-                "Would benefit from one more load-focused test",
-                "Day 3 could call out a couple more rollback risks",
+                "A deeper rollback note would make the Day 3 wrap-up stronger.",
+                "The Day 4 demo could call out one more edge case explicitly.",
             ],
             summary_line=(
-                "Avery shows strong from-scratch judgment, with only minor gaps "
-                "around deeper operational hardening."
+                "Sarah shows strong from-scratch judgment, with one or two operational "
+                "gaps that are easy to discuss without weakening the overall signal."
             ),
-            day_scores={1: 0.93, 2: 0.92, 3: 0.91, 4: 0.89, 5: 0.90},
-            test_summary={1: (14, 0), 2: (18, 0), 3: (20, 0)},
+            day_scores={1: 0.79, 2: 0.77, 3: 0.80, 4: 0.78, 5: 0.76},
+            test_summary={1: (16, 0), 2: (20, 0), 3: (22, 0)},
         ),
-        DemoCandidateProfile(
-            label="candidate-b",
-            name="Jordan Patel",
-            email="jordan.patel.demo@winoe.ai",
-            repo_suffix="jordan-patel",
-            overall_score=0.74,
-            confidence=0.76,
-            recommendation="mixed_signal",
-            internal_recommendation=EVALUATION_RECOMMENDATION_LEAN_HIRE,
-            strength_points=[
-                "Delivered a functional backend and a credible review path",
-                "Handoff communication is clear and professional",
-                "Reflection is honest about tradeoffs and next steps",
-            ],
-            concern_points=[
-                "Tests are narrower than the strongest submission",
-                "Implementation notes could be more systematic",
-                "Documentation is useful but less complete",
-            ],
-            summary_line=(
-                "Jordan is credible and productive, but the evidence is thinner "
-                "and the overall story is less disciplined."
+    ]
+
+
+def _demo_invite_candidate_profiles() -> dict[str, list[DemoInviteCandidateProfile]]:
+    return {
+        "active_inviting": [
+            DemoInviteCandidateProfile(
+                name="Marcus Okonjo",
+                email="marcus.okonjo.demo@winoe.ai",
+                github_username="marcusokonjo",
             ),
-            day_scores={1: 0.76, 2: 0.73, 3: 0.72, 4: 0.74, 5: 0.75},
-            test_summary={1: (10, 0), 2: (11, 1), 3: (12, 1)},
+            DemoInviteCandidateProfile(
+                name="Priya Patel",
+                email="priya.patel.demo@winoe.ai",
+                github_username="priyapatel",
+            ),
+        ],
+        "awaiting_candidate": [
+            DemoInviteCandidateProfile(
+                name="Nina Alvarez",
+                email="nina.alvarez.demo@winoe.ai",
+                github_username="ninaalvarez",
+            )
+        ],
+    }
+
+
+def _demo_trial_profiles(config: DemoSeedConfig) -> list[DemoTrialProfile]:
+    invites = _demo_invite_candidate_profiles()
+    return [
+        DemoTrialProfile(
+            title="Senior Backend Engineer Trial",
+            role="Senior Backend Engineer",
+            seniority="senior",
+            preferred_language_framework="Python + FastAPI",
+            focus="Build a reliable backend surface for a five-day evidence-backed Trial.",
+            status="active_inviting",
+            candidates=invites["active_inviting"],
+        ),
+        DemoTrialProfile(
+            title=config.trial_title,
+            role=config.trial_role,
+            seniority=config.trial_seniority,
+            preferred_language_framework=config.trial_preferred_language_framework,
+            focus=config.trial_focus,
+            status="active_inviting",
+            candidates=[
+                DemoInviteCandidateProfile(
+                    name="Sarah Chen",
+                    email="sarah.chen.demo@winoe.ai",
+                    github_username="sarahchen",
+                )
+            ],
+        ),
+        DemoTrialProfile(
+            title="Staff Engineer Trial",
+            role="Staff Engineer",
+            seniority="staff",
+            preferred_language_framework="Go",
+            focus="Keep the architecture minimal while leaving a crisp evidence trail.",
+            status="active_inviting",
+            candidates=invites["awaiting_candidate"],
         ),
     ]
 
@@ -663,8 +739,8 @@ def _evidence_pointers(
                 "excerpt": "Bootstrap commit created the empty repository, devcontainer, and README.",
                 "dayIndex": 1,
                 "sourceLabel": "Day 1 — Design Doc",
-                "dimensionKey": "project_scaffolding_quality",
-                "dimensionLabel": "Project scaffolding quality",
+                "dimensionKey": "scope_control",
+                "dimensionLabel": "Scope control",
             },
         ],
         2: [
@@ -675,8 +751,8 @@ def _evidence_pointers(
                 "excerpt": "Initial implementation kickoff commit.",
                 "dayIndex": 2,
                 "sourceLabel": "Day 2/3 — Code",
-                "dimensionKey": "development_process",
-                "dimensionLabel": "Development process",
+                "dimensionKey": "implementation_discipline",
+                "dimensionLabel": "Implementation discipline",
             },
             {
                 "kind": "tests",
@@ -705,8 +781,8 @@ def _evidence_pointers(
                 "excerpt": "Wrap-up test results show the final pass/fail balance.",
                 "dayIndex": 3,
                 "sourceLabel": "Day 2/3 — Code",
-                "dimensionKey": "development_process",
-                "dimensionLabel": "Development process",
+                "dimensionKey": "dependency_hygiene",
+                "dimensionLabel": "Dependency hygiene",
             },
         ],
         4: [
@@ -727,8 +803,8 @@ def _evidence_pointers(
                 "excerpt": "Handoff transcript and demo summary.",
                 "dayIndex": 4,
                 "sourceLabel": "Day 4 — Handoff + Demo",
-                "dimensionKey": "communication_handoff_demo",
-                "dimensionLabel": "Communication / Handoff + Demo",
+                "dimensionKey": "evidence_trail_traceability",
+                "dimensionLabel": "Evidence trail traceability",
             },
         ],
         5: [
@@ -747,8 +823,8 @@ def _evidence_pointers(
                 "excerpt": "Reflection quality, self-awareness, and next-step realism.",
                 "dayIndex": 5,
                 "sourceLabel": "Day 5 — Reflection",
-                "dimensionKey": "reflection_self_awareness",
-                "dimensionLabel": "Reflection & self-awareness",
+                "dimensionKey": "growth_orientation",
+                "dimensionLabel": "Growth orientation",
             },
         ],
     }
@@ -757,47 +833,94 @@ def _evidence_pointers(
 def _dimensional_scores(
     candidate: DemoCandidateProfile, *, day_index: int
 ) -> dict[str, float]:
-    if candidate.label == "candidate-a":
-        base = {
-            1: {"architecture": 0.95, "planning": 0.93, "communication": 0.94},
-            2: {"implementation": 0.93, "testing": 0.92, "discipline": 0.91},
-            3: {"implementation": 0.92, "testing": 0.93, "docs": 0.90},
-            4: {"communication": 0.91, "judgment": 0.88, "delivery": 0.89},
-            5: {"reflection": 0.90, "self-awareness": 0.89, "tooling": 0.88},
+    if candidate.label != "sarah-chen":
+        return {
+            "architecture": 0.78,
+            "scope_control": 0.76,
+            "implementation_discipline": 0.75,
+            "testing_discipline": 0.74,
+            "code_quality": 0.73,
+            "dependency_hygiene": 0.72,
+            "communication_handoff_demo": 0.76,
+            "reflection_self_awareness": 0.75,
         }
-    else:
-        base = {
-            1: {"architecture": 0.78, "planning": 0.76, "communication": 0.77},
-            2: {"implementation": 0.75, "testing": 0.72, "discipline": 0.73},
-            3: {"implementation": 0.74, "testing": 0.71, "docs": 0.72},
-            4: {"communication": 0.76, "judgment": 0.72, "delivery": 0.73},
-            5: {"reflection": 0.75, "self-awareness": 0.74, "tooling": 0.73},
-        }
+    base = {
+        1: {
+            "architecture": 0.88,
+            "scope_control": 0.86,
+            "planning": 0.87,
+            "evidence_trail_traceability": 0.85,
+            "communication_handoff_demo": 0.84,
+            "documentation": 0.86,
+            "testing_discipline": 0.83,
+            "judgment": 0.85,
+        },
+        2: {
+            "architecture": 0.87,
+            "scope_control": 0.84,
+            "implementation_discipline": 0.88,
+            "testing_discipline": 0.86,
+            "code_quality": 0.85,
+            "dependency_hygiene": 0.84,
+            "communication_handoff_demo": 0.83,
+            "judgment": 0.84,
+        },
+        3: {
+            "architecture": 0.86,
+            "scope_control": 0.85,
+            "implementation_discipline": 0.89,
+            "testing_discipline": 0.87,
+            "code_quality": 0.88,
+            "dependency_hygiene": 0.87,
+            "documentation": 0.86,
+            "evidence_trail_traceability": 0.85,
+        },
+        4: {
+            "architecture": 0.84,
+            "scope_control": 0.83,
+            "communication_handoff_demo": 0.88,
+            "judgment": 0.85,
+            "delivery_clarity": 0.87,
+            "evidence_trail_traceability": 0.86,
+            "documentation": 0.84,
+            "reflection_self_awareness": 0.83,
+        },
+        5: {
+            "architecture": 0.82,
+            "scope_control": 0.84,
+            "reflection_self_awareness": 0.86,
+            "growth_orientation": 0.85,
+            "tooling_judgment": 0.83,
+            "communication_handoff_demo": 0.82,
+            "documentation": 0.81,
+            "evidence_trail_traceability": 0.84,
+        },
+    }
     return base[day_index]
 
 
 def _assessment_text(candidate: DemoCandidateProfile, *, day_index: int) -> str:
-    if candidate.label == "candidate-a":
+    if candidate.label == "sarah-chen":
         assessments = {
-            1: "Clear, practical design with sensible boundaries and low-risk tradeoffs.",
-            2: "Strong kickoff momentum and disciplined setup for a from-scratch build.",
-            3: "Well-finished implementation with good hygiene and useful documentation.",
-            4: "Confident demo delivery with honest caveats and a coherent narrative.",
-            5: "Reflective and specific about tradeoffs, growth areas, and next steps.",
+            1: "The design is practical and keeps the Trial small enough to defend.",
+            2: "The kickoff moves cleanly from plan to execution without noisy scaffolding.",
+            3: "The wrap-up shows disciplined implementation and a tidy closing pass.",
+            4: "The handoff is calm, specific, and anchored in concrete artifacts.",
+            5: "The reflection is honest about the edges and clear about what to improve next.",
         }
     else:
         assessments = {
-            1: "Solid design, though the plan is lighter on operational detail.",
-            2: "Functional implementation kickoff with a narrower testing story.",
-            3: "Useful wrap-up, but the documentation and structure are less complete.",
-            4: "Clear handoff, with less depth on tradeoffs and failure modes.",
-            5: "Honest reflection that identifies real gaps without fully resolving them.",
+            1: "Clear but lightweight design notes with modest detail.",
+            2: "Functional kickoff with enough structure to keep moving.",
+            3: "Useful wrap-up, but the evidence trail is thinner than ideal.",
+            4: "Clear handoff, with fewer concrete artifacts behind the story.",
+            5: "Honest reflection that names the main gaps without overclaiming.",
         }
     return assessments[day_index]
 
 
 def _strengths(candidate: DemoCandidateProfile, *, day_index: int) -> list[str]:
-    if candidate.label == "candidate-a":
+    if candidate.label == "sarah-chen":
         strengths = {
             1: [
                 "The architecture is easy to follow",
@@ -847,7 +970,7 @@ def _strengths(candidate: DemoCandidateProfile, *, day_index: int) -> list[str]:
 
 
 def _concerns(candidate: DemoCandidateProfile, *, day_index: int) -> list[str]:
-    if candidate.label == "candidate-a":
+    if candidate.label == "sarah-chen":
         concerns = {
             1: [
                 "Operational hardening is not fully explored",
@@ -977,27 +1100,301 @@ def _build_report_rows(
     return day_rows, reviewer_rows
 
 
+def _build_demo_report_dimensions(
+    candidate: DemoCandidateProfile,
+) -> list[dict[str, Any]]:
+    if candidate.label != "sarah-chen":
+        return [
+            {
+                "name": "Architecture & Design",
+                "score": 0.78,
+                "justification": "The Trial stays small, practical, and easy to explain.",
+            },
+            {
+                "name": "Problem Understanding",
+                "score": 0.77,
+                "justification": "The work stays anchored to the five-day evidence-backed Trial.",
+            },
+            {
+                "name": "Implementation Quality",
+                "score": 0.76,
+                "justification": "The build shows a steady but modest implementation cadence.",
+            },
+            {
+                "name": "Code Quality",
+                "score": 0.75,
+                "justification": "The repository remains readable and lightweight.",
+            },
+            {
+                "name": "Testing Discipline",
+                "score": 0.74,
+                "justification": "The test story is present, though not especially deep.",
+            },
+            {
+                "name": "Development Process",
+                "score": 0.74,
+                "justification": "The cadence is usable and the handoff remains coherent.",
+            },
+            {
+                "name": "Communication",
+                "score": 0.76,
+                "justification": "The handoff is direct and keeps the narrative readable.",
+            },
+            {
+                "name": "Reflection & Ownership",
+                "score": 0.75,
+                "justification": "The reflection names gaps plainly and stays grounded.",
+            },
+        ]
+    return [
+        {
+            "name": "Architecture & Design",
+            "score": 0.88,
+            "justification": "The Day 1 design doc keeps the scope small, testable, and easy to defend.",
+        },
+        {
+            "name": "Problem Understanding",
+            "score": 0.86,
+            "justification": "The brief and project setup stay tightly aligned to the actual Trial problem.",
+        },
+        {
+            "name": "Implementation Quality",
+            "score": 0.89,
+            "justification": "The Day 2 and Day 3 commits show steady progress without noisy scaffolding.",
+        },
+        {
+            "name": "Code Quality",
+            "score": 0.88,
+            "justification": "The repository stays readable, compact, and easy to audit.",
+        },
+        {
+            "name": "Testing Discipline",
+            "score": 0.87,
+            "justification": "The day-by-day test evidence shows deliberate validation rather than hand-waving.",
+        },
+        {
+            "name": "Development Process",
+            "score": 0.86,
+            "justification": "The implementation cadence, commit history, and docs all point in the same direction.",
+        },
+        {
+            "name": "Communication",
+            "score": 0.88,
+            "justification": "The Day 4 handoff and demo keep the explanation specific and evidence-first.",
+        },
+        {
+            "name": "Reflection & Ownership",
+            "score": 0.84,
+            "justification": "The Day 5 reflection is candid about tradeoffs and the remaining edges.",
+        },
+    ]
+
+
+def _build_demo_report_citations(
+    *,
+    bootstrap_commit_sha: str,
+    day2_commit_sha: str,
+    day3_commit_sha: str,
+) -> list[dict[str, str]]:
+    return [
+        {
+            "dimension": "Architecture & Design",
+            "artifact_type": "design_doc",
+            "artifact_ref": "day1-design-doc.md:L1-L20",
+            "excerpt": "Use a small FastAPI service with one core domain module and a service layer.",
+        },
+        {
+            "dimension": "Architecture & Design",
+            "artifact_type": "commit",
+            "artifact_ref": f"{bootstrap_commit_sha}:README.md:L1-L24",
+            "excerpt": "Bootstrap commit created the empty repository, devcontainer, and README.",
+        },
+        {
+            "dimension": "Problem Understanding",
+            "artifact_type": "brief",
+            "artifact_ref": "project-brief.md:L1-L20",
+            "excerpt": "Build a from-scratch work Trial experience that keeps every step evidence-backed.",
+        },
+        {
+            "dimension": "Problem Understanding",
+            "artifact_type": "submission",
+            "artifact_ref": "day1-design-doc.md:L21-L36",
+            "excerpt": "The design doc spells out the constraints, deliverables, and risks clearly.",
+        },
+        {
+            "dimension": "Implementation Quality",
+            "artifact_type": "commit",
+            "artifact_ref": f"{day2_commit_sha}:src/api/trials.ts:L40-L88",
+            "excerpt": "Initial implementation kickoff commit.",
+        },
+        {
+            "dimension": "Implementation Quality",
+            "artifact_type": "diff",
+            "artifact_ref": f"{day3_commit_sha}:src/services/reporting.py:L12-L76",
+            "excerpt": "Wrap-up commit completed the core workflow and docs.",
+        },
+        {
+            "dimension": "Code Quality",
+            "artifact_type": "diff",
+            "artifact_ref": f"{day3_commit_sha}:src/services/reporting.py:L12-L76",
+            "excerpt": "The code stays readable, compact, and easy to audit.",
+        },
+        {
+            "dimension": "Code Quality",
+            "artifact_type": "submission",
+            "artifact_ref": "day3-wrap-up.md:L8-L20",
+            "excerpt": "Documentation tracks the implementation and the remaining gaps are explicit.",
+        },
+        {
+            "dimension": "Testing Discipline",
+            "artifact_type": "tests",
+            "artifact_ref": "day2-tests.txt:L1-L4",
+            "excerpt": "Kickoff tests established the core workflow shape.",
+        },
+        {
+            "dimension": "Testing Discipline",
+            "artifact_type": "submission",
+            "artifact_ref": "day3-wrap-up.md:L21-L30",
+            "excerpt": "The final pass/fail balance shows the build was checked, not just described.",
+        },
+        {
+            "dimension": "Development Process",
+            "artifact_type": "commit",
+            "artifact_ref": f"{bootstrap_commit_sha}:README.md:L1-L24",
+            "excerpt": "Bootstrap commit created the empty repository, devcontainer, and README.",
+        },
+        {
+            "dimension": "Development Process",
+            "artifact_type": "commit",
+            "artifact_ref": f"{day2_commit_sha}:src/api/trials.ts:L40-L88",
+            "excerpt": "Implementation moved in a disciplined, reviewable sequence.",
+        },
+        {
+            "dimension": "Communication",
+            "artifact_type": "transcript",
+            "artifact_ref": "handoff-demo-transcript.txt:02:14-02:48",
+            "excerpt": "Demo transcript with architecture, tradeoffs, and next steps.",
+        },
+        {
+            "dimension": "Communication",
+            "artifact_type": "submission",
+            "artifact_ref": "day4-handoff-summary.md:L4-L15",
+            "excerpt": "The handoff summary keeps the story tight and evidence-backed.",
+        },
+        {
+            "dimension": "Reflection & Ownership",
+            "artifact_type": "submission",
+            "artifact_ref": "day5-reflection.md:L8-L22",
+            "excerpt": "Reflection essay covering what went well, what was hard, and what changed.",
+        },
+        {
+            "dimension": "Reflection & Ownership",
+            "artifact_type": "submission",
+            "artifact_ref": "day5-reflection.md:L23-L34",
+            "excerpt": "The next-step plan is concrete and honest about the remaining edges.",
+        },
+    ]
+
+
+async def _seed_trial_scaffold(
+    db: AsyncSession,
+    *,
+    company_id: int,
+    created_by: int,
+    title: str,
+    role: str,
+    seniority: str,
+    preferred_language_framework: str,
+    focus: str,
+    status: str,
+    company_name: str,
+    project_brief_md: str,
+    storyline_md: str,
+    ai_notice_version: str,
+    trial_focus_note: str,
+) -> tuple[Trial, list[Task], TrialScenarioVersion]:
+    trial = Trial(
+        company_id=company_id,
+        title=title,
+        role=role,
+        preferred_language_framework=preferred_language_framework,
+        seniority=seniority,
+        focus=focus,
+        company_context={
+            "companyName": company_name,
+            "preferredLanguageFramework": preferred_language_framework,
+            "demoMode": "yc-demo",
+        },
+        company_rubric_json=_demo_company_rubrics(),
+        ai_prompt_overrides_json=None,
+        ai_notice_version=ai_notice_version,
+        ai_notice_text="Winoe demo notice for the YC rehearsal dataset.",
+        ai_eval_enabled_by_day={
+            "1": True,
+            "2": True,
+            "3": True,
+            "4": True,
+            "5": True,
+        },
+        day_window_overrides_enabled=True,
+        day_window_overrides_json={"5": {"startLocal": "09:00", "endLocal": "21:00"}},
+        created_by=created_by,
+        status=TRIAL_STATUS_GENERATING,
+        generating_at=_now(),
+    )
+    db.add(trial)
+    _apply_legacy_trial_fields(trial)
+    await db.flush()
+
+    tasks = await seed_default_tasks(db, trial.id, trial.template_key)
+    scenario_version = await create_initial_scenario_version(
+        db, trial=trial, tasks=tasks
+    )
+    scenario_version.storyline_md = storyline_md
+    scenario_version.task_prompts_json = _demo_task_prompts(tasks)
+    scenario_version.rubric_json = {
+        "dimensions": [
+            {"key": "architecture", "weight": 0.18},
+            {"key": "scope_control", "weight": 0.10},
+            {"key": "implementation_discipline", "weight": 0.16},
+            {"key": "testing_discipline", "weight": 0.14},
+            {"key": "code_quality", "weight": 0.12},
+            {"key": "dependency_hygiene", "weight": 0.10},
+            {"key": "communication_handoff_demo", "weight": 0.10},
+            {"key": "reflection_self_awareness", "weight": 0.10},
+        ]
+    }
+    scenario_version.project_brief_md = project_brief_md
+    scenario_version.focus_notes = trial_focus_note
+    scenario_version.preferred_language_framework = preferred_language_framework
+    scenario_version.seniority = seniority
+    scenario_version.locked_at = _now()
+    trial.ready_for_review_at = _now()
+    trial.activated_at = _now()
+    trial.active_scenario_version_id = scenario_version.id
+    trial.status = status
+    await db.flush()
+    return trial, tasks, scenario_version
+
+
 async def _clear_demo_scope(db: AsyncSession, config: DemoSeedConfig) -> None:
     """Remove any existing demo-scoped rows before reseeding."""
-    candidate_emails = [candidate.email for candidate in _demo_candidate_profiles()]
-    company = await db.scalar(
-        select(Company).where(Company.name == config.company_name)
-    )
-    company_id = company.id if company is not None else None
-    user_filters = [User.email == config.talent_partner_email]
-    if candidate_emails:
-        user_filters.append(User.email.in_(candidate_emails))
-    if company_id is not None:
-        user_filters.append(User.company_id == company_id)
+    candidate_emails = [config.talent_partner_email, *DEMO_INVITE_EMAILS]
+    demo_trial_rows = (
+        await db.execute(
+            select(Trial.id, Trial.company_id).where(
+                Trial.company_context["demoMode"].as_string() == DEMO_MODE_MARKER
+            )
+        )
+    ).all()
+    trial_ids = [row.id for row in demo_trial_rows]
+    company_ids = sorted({row.company_id for row in demo_trial_rows})
+
+    user_filters = [User.email.in_(candidate_emails)]
+    if company_ids:
+        user_filters.append(User.company_id.in_(company_ids))
     user_ids = (
         (await db.execute(select(User.id).where(or_(*user_filters)))).scalars().all()
-    )
-
-    trial_filters = [Trial.title == config.trial_title]
-    if company_id is not None:
-        trial_filters.append(Trial.company_id == company_id)
-    trial_ids = (
-        (await db.execute(select(Trial.id).where(or_(*trial_filters)))).scalars().all()
     )
 
     candidate_session_filters = [CandidateSession.invite_email.in_(candidate_emails)]
@@ -1096,12 +1493,12 @@ async def _clear_demo_scope(db: AsyncSession, config: DemoSeedConfig) -> None:
             .all()
         )
     job_ids: list[str] = []
-    if candidate_session_ids or company_id is not None:
+    if candidate_session_ids or company_ids:
         job_filters = []
         if candidate_session_ids:
             job_filters.append(Job.candidate_session_id.in_(candidate_session_ids))
-        if company_id is not None:
-            job_filters.append(Job.company_id == company_id)
+        if company_ids:
+            job_filters.append(Job.company_id.in_(company_ids))
         job_ids = (
             (await db.execute(select(Job.id).where(or_(*job_filters)))).scalars().all()
         )
@@ -1184,8 +1581,8 @@ async def _clear_demo_scope(db: AsyncSession, config: DemoSeedConfig) -> None:
 
     if user_ids:
         await db.execute(delete(User).where(User.id.in_(user_ids)))
-    if company is not None:
-        await db.execute(delete(Company).where(Company.id == company.id))
+    if company_ids:
+        await db.execute(delete(Company).where(Company.id.in_(company_ids)))
 
     await db.commit()
 
@@ -1239,378 +1636,432 @@ async def seed_yc_demo_dataset(
     db.add(talent_partner)
     await db.flush()
 
-    trial = Trial(
-        company_id=company.id,
-        title=config.trial_title,
-        role=config.trial_role,
-        preferred_language_framework=config.trial_preferred_language_framework,
-        seniority=config.trial_seniority,
-        focus=config.trial_focus,
-        company_context={
-            "companyName": config.company_name,
-            "preferredLanguageFramework": config.trial_preferred_language_framework,
-            "demoMode": "yc-demo",
-        },
-        company_rubric_json=_demo_company_rubrics(),
-        ai_prompt_overrides_json=None,
-        ai_notice_version="yc-demo-v1",
-        ai_notice_text="Winoe demo notice for the YC rehearsal dataset.",
-        ai_eval_enabled_by_day={
-            "1": True,
-            "2": True,
-            "3": True,
-            "4": True,
-            "5": True,
-        },
-        day_window_overrides_enabled=True,
-        day_window_overrides_json={"5": {"startLocal": "09:00", "endLocal": "21:00"}},
-        created_by=talent_partner.id,
-        status=TRIAL_STATUS_GENERATING,
-        generating_at=_now(),
-    )
-    db.add(trial)
-    _apply_legacy_trial_fields(trial)
-    await db.flush()
-
-    tasks = await seed_default_tasks(db, trial.id, trial.template_key)
-    scenario_version = await create_initial_scenario_version(
-        db, trial=trial, tasks=tasks
-    )
-    scenario_version.storyline_md = _demo_scenario_storyline()
-    scenario_version.task_prompts_json = _demo_task_prompts(tasks)
-    scenario_version.rubric_json = {
-        "dimensions": [
-            {"key": "architecture", "weight": 0.25},
-            {"key": "implementation", "weight": 0.35},
-            {"key": "testing", "weight": 0.20},
-            {"key": "documentation", "weight": 0.10},
-            {"key": "judgment", "weight": 0.10},
-        ]
-    }
-    scenario_version.project_brief_md = _demo_trial_brief_markdown(config)
-    scenario_version.focus_notes = config.trial_focus
-    scenario_version.preferred_language_framework = (
-        config.trial_preferred_language_framework
-    )
-    scenario_version.seniority = config.trial_seniority
-    scenario_version.locked_at = _now()
-    trial.status = TRIAL_STATUS_READY_FOR_REVIEW
-    trial.ready_for_review_at = _now()
-    trial.activated_at = _now()
-    await db.flush()
-
+    invite_groups = _demo_invite_candidate_profiles()
     candidate_sessions: list[CandidateSession] = []
     repo_full_names: list[str] = []
-    for candidate in _demo_candidate_profiles():
-        candidate_session = CandidateSession(
-            trial_id=trial.id,
-            scenario_version_id=scenario_version.id,
+
+    brief_md = _demo_trial_brief_markdown(config)
+    storyline_md = _demo_scenario_storyline()
+
+    active_trial_a, _active_tasks_a, active_scenario_a = await _seed_trial_scaffold(
+        db,
+        company_id=company.id,
+        created_by=talent_partner.id,
+        title="Senior Backend Engineer Trial",
+        role="Senior Backend Engineer",
+        seniority="senior",
+        preferred_language_framework="Python + FastAPI",
+        focus="Build a reliable backend surface for a five-day evidence-backed Trial.",
+        status=TRIAL_STATUS_ACTIVE_INVITING,
+        company_name=config.company_name,
+        project_brief_md=brief_md,
+        storyline_md=storyline_md,
+        ai_notice_version="yc-demo-v1",
+        trial_focus_note="Python + FastAPI backend with clean evidence capture.",
+    )
+    for invite in invite_groups["active_inviting"]:
+        session = CandidateSession(
+            trial_id=active_trial_a.id,
+            scenario_version_id=active_scenario_a.id,
             candidate_user_id=None,
-            candidate_name=candidate.name,
-            invite_email=candidate.email,
-            candidate_email=candidate.email,
-            candidate_auth0_email=candidate.email,
-            token=_candidate_token(config, candidate),
-            status="completed",
-            started_at=_now() - timedelta(days=4),
-            completed_at=_now(),
-            claimed_at=_now() - timedelta(days=4),
+            candidate_name=invite.name,
+            invite_email=invite.email,
+            candidate_email=invite.email,
+            candidate_auth0_email=invite.email,
+            token=_stable_hex(config.company_name, invite.email, "invite", length=32),
+            status="not_started",
+            claimed_at=None,
+            scheduled_start_at=None,
+            started_at=None,
+            completed_at=None,
             expires_at=_now() + timedelta(days=7),
             invite_email_status="sent",
-            invite_email_sent_at=_now() - timedelta(days=4),
-            invite_email_last_attempt_at=_now() - timedelta(days=4),
-            scheduled_start_at=_now() - timedelta(days=4),
+            invite_email_sent_at=_now() - timedelta(hours=6),
+            invite_email_last_attempt_at=_now() - timedelta(hours=6),
             candidate_timezone=config.timezone,
-            github_username=candidate.repo_suffix.replace("-", ""),
+            github_username=invite.github_username,
             consent_version="yc-demo-v1",
-            consent_timestamp=_now() - timedelta(days=4),
+            consent_timestamp=None,
             ai_notice_version="yc-demo-v1",
-            day_windows_json=[
-                {"dayIndex": day_index, "status": "submitted"}
-                for day_index in range(1, 6)
-            ],
-            schedule_locked_at=_now() - timedelta(days=4),
+            day_windows_json=[],
         )
-        db.add(candidate_session)
+        db.add(session)
         await db.flush()
-        candidate_sessions.append(candidate_session)
+        candidate_sessions.append(session)
 
-        repo_name = _candidate_repo_name(config, candidate)
-        repo_result = await bootstrap_empty_candidate_repo(
-            github_client=github_client,
-            candidate_session=candidate_session,
-            trial=trial,
-            scenario_version=scenario_version,
-            task=tasks[1],
-            repo_prefix=config.repo_prefix,
-            destination_owner=config.git_owner,
-            repo_name=repo_name,
-        )
-        repo_full_names.append(repo_result.repo_full_name)
+    completed_candidate = _demo_candidate_profiles()[0]
+    completed_trial, completed_tasks, completed_scenario = await _seed_trial_scaffold(
+        db,
+        company_id=company.id,
+        created_by=talent_partner.id,
+        title=config.trial_title,
+        role=config.trial_role,
+        seniority=config.trial_seniority,
+        preferred_language_framework=config.trial_preferred_language_framework,
+        focus=config.trial_focus,
+        status=TRIAL_STATUS_READY_FOR_REVIEW,
+        company_name=config.company_name,
+        project_brief_md=brief_md,
+        storyline_md=storyline_md,
+        ai_notice_version="yc-demo-v1",
+        trial_focus_note=config.trial_focus,
+    )
+    candidate_session = CandidateSession(
+        trial_id=completed_trial.id,
+        scenario_version_id=completed_scenario.id,
+        candidate_user_id=None,
+        candidate_name=completed_candidate.name,
+        invite_email=completed_candidate.email,
+        candidate_email=completed_candidate.email,
+        candidate_auth0_email=completed_candidate.email,
+        token=_candidate_token(config, completed_candidate),
+        status="completed",
+        started_at=_now() - timedelta(days=4),
+        completed_at=_now(),
+        claimed_at=_now() - timedelta(days=4),
+        expires_at=_now() + timedelta(days=7),
+        invite_email_status="sent",
+        invite_email_sent_at=_now() - timedelta(days=4),
+        invite_email_last_attempt_at=_now() - timedelta(days=4),
+        scheduled_start_at=_now() - timedelta(days=4),
+        candidate_timezone=config.timezone,
+        github_username=completed_candidate.repo_suffix.replace("-", ""),
+        consent_version="yc-demo-v1",
+        consent_timestamp=_now() - timedelta(days=4),
+        ai_notice_version="yc-demo-v1",
+        day_windows_json=[
+            {"dayIndex": day_index, "status": "submitted"} for day_index in range(1, 6)
+        ],
+        schedule_locked_at=_now() - timedelta(days=4),
+    )
+    db.add(candidate_session)
+    await db.flush()
+    candidate_sessions.append(candidate_session)
 
-        workspace_group = WorkspaceGroup(
-            candidate_session_id=candidate_session.id,
-            workspace_key=config.codespace_workspace_key,
-            template_repo_full_name=None,
-            repo_full_name=repo_result.repo_full_name,
-            default_branch=repo_result.default_branch,
-            bootstrap_commit_sha=repo_result.bootstrap_commit_sha,
-            created_at=_now(),
-        )
-        db.add(workspace_group)
-        await db.flush()
-        workspace = Workspace(
-            workspace_group_id=workspace_group.id,
-            candidate_session_id=candidate_session.id,
-            task_id=tasks[1].id,
-            template_repo_full_name=None,
-            repo_full_name=repo_result.repo_full_name,
-            repo_id=repo_result.repo_id,
-            default_branch=repo_result.default_branch,
-            bootstrap_commit_sha=repo_result.bootstrap_commit_sha,
-            codespace_name=repo_result.codespace_name,
-            codespace_url=repo_result.codespace_url,
-            codespace_state=repo_result.codespace_state,
-            workspace_provisioning_status=repo_result.workspace_provisioning_status,
-            latest_commit_sha=_candidate_commit_sha(config, candidate, day=3),
-            last_workflow_run_id=f"yc-demo-{candidate.label}-workflow",
-            last_workflow_conclusion="success"
-            if candidate.label == "candidate-a"
-            else "neutral",
-            last_test_summary_json=(
-                f'{{"passed": {candidate.test_summary[2][0]}, "failed": {candidate.test_summary[2][1]}}}'
-            ),
-            created_at=_now(),
-        )
-        db.add(workspace)
-        await db.flush()
+    repo_name = _candidate_repo_name(config, completed_candidate)
+    repo_result = await bootstrap_empty_candidate_repo(
+        github_client=github_client,
+        candidate_session=candidate_session,
+        trial=completed_trial,
+        scenario_version=completed_scenario,
+        task=completed_tasks[1],
+        repo_prefix=config.repo_prefix,
+        destination_owner=config.git_owner,
+        repo_name=repo_name,
+    )
+    repo_full_names.append(repo_result.repo_full_name)
 
-        day2_commit_sha = _candidate_commit_sha(config, candidate, day=2)
-        day3_commit_sha = _candidate_commit_sha(config, candidate, day=3)
-        recording_key = _candidate_recording_key(config, candidate)
-        submissions = _candidate_submissions(
-            config,
-            candidate,
-            repo_full_name=repo_result.repo_full_name,
-            bootstrap_commit_sha=repo_result.bootstrap_commit_sha or "",
-            day2_commit_sha=day2_commit_sha,
-            day3_commit_sha=day3_commit_sha,
-            recording_key=recording_key,
-        )
-        for day_index, task in enumerate(tasks, start=1):
-            submission_spec = submissions[day_index]
-            submission_recording_id: int | None = None
-            if day_index == 4:
-                recording = RecordingAsset(
-                    candidate_session_id=candidate_session.id,
-                    task_id=task.id,
-                    storage_key=recording_key,
-                    content_type="video/mp4",
-                    bytes=2_048_000,
-                    asset_kind="recording",
-                    duration_seconds=120,
-                    status="ready",
-                    consent_version="yc-demo-v1",
-                    consent_timestamp=_now() - timedelta(days=1),
-                    ai_notice_version="yc-demo-v1",
-                    retention_expires_at=_now() + timedelta(days=30),
-                )
-                db.add(recording)
-                await db.flush()
-                transcript = Transcript(
-                    recording_id=recording.id,
-                    text=(
-                        f"{candidate.name} explained the design, tradeoffs, and next steps "
-                        f"for the {config.company_name} demo."
-                    ),
-                    segments_json=[
-                        {"start": 0, "end": 60, "text": candidate.summary_line},
-                        {
-                            "start": 60,
-                            "end": 120,
-                            "text": "The evidence trail is grounded in the submitted artifacts.",
-                        },
-                    ],
-                    model_name="demo-transcribe",
-                    status="ready",
-                )
-                db.add(transcript)
-                await db.flush()
-                submission_recording_id = recording.id
-                submission_spec["content_json"]["transcriptRecordingId"] = recording.id
-            submission = Submission(
+    workspace_group = WorkspaceGroup(
+        candidate_session_id=candidate_session.id,
+        workspace_key=config.codespace_workspace_key,
+        template_repo_full_name=None,
+        repo_full_name=repo_result.repo_full_name,
+        default_branch=repo_result.default_branch,
+        bootstrap_commit_sha=repo_result.bootstrap_commit_sha,
+        created_at=_now(),
+    )
+    db.add(workspace_group)
+    await db.flush()
+    workspace = Workspace(
+        workspace_group_id=workspace_group.id,
+        candidate_session_id=candidate_session.id,
+        task_id=completed_tasks[1].id,
+        template_repo_full_name=None,
+        repo_full_name=repo_result.repo_full_name,
+        repo_id=repo_result.repo_id,
+        default_branch=repo_result.default_branch,
+        bootstrap_commit_sha=repo_result.bootstrap_commit_sha,
+        codespace_name=repo_result.codespace_name,
+        codespace_url=repo_result.codespace_url,
+        codespace_state=repo_result.codespace_state,
+        workspace_provisioning_status=repo_result.workspace_provisioning_status,
+        latest_commit_sha=_candidate_commit_sha(config, completed_candidate, day=3),
+        last_workflow_run_id=f"yc-demo-{completed_candidate.label}-workflow",
+        last_workflow_conclusion="success",
+        last_test_summary_json=(
+            f'{{"passed": {completed_candidate.test_summary[3][0]}, "failed": {completed_candidate.test_summary[3][1]}}}'
+        ),
+        created_at=_now(),
+    )
+    db.add(workspace)
+    await db.flush()
+
+    day2_commit_sha = _candidate_commit_sha(config, completed_candidate, day=2)
+    day3_commit_sha = _candidate_commit_sha(config, completed_candidate, day=3)
+    recording_key = _candidate_recording_key(config, completed_candidate)
+    submissions = _candidate_submissions(
+        config,
+        completed_candidate,
+        repo_full_name=repo_result.repo_full_name,
+        bootstrap_commit_sha=repo_result.bootstrap_commit_sha or "",
+        day2_commit_sha=day2_commit_sha,
+        day3_commit_sha=day3_commit_sha,
+        recording_key=recording_key,
+    )
+    for day_index, task in enumerate(completed_tasks, start=1):
+        submission_spec = submissions[day_index]
+        submission_recording_id: int | None = None
+        if day_index == 4:
+            recording = RecordingAsset(
                 candidate_session_id=candidate_session.id,
                 task_id=task.id,
-                recording_id=submission_recording_id,
-                submitted_at=_now() - timedelta(days=5 - day_index),
-                content_text=submission_spec["content_text"],
-                content_json=submission_spec["content_json"],
-                code_repo_path=submission_spec["code_repo_path"],
-                commit_sha=submission_spec["commit_sha"],
-                final_sha=submission_spec["commit_sha"] if day_index == 3 else None,
-                workflow_run_id=(
-                    f"yc-demo-{candidate.label}-day{day_index}"
-                    if day_index in {2, 3}
-                    else None
-                ),
-                workflow_run_attempt=1 if day_index in {2, 3} else None,
-                workflow_run_status="completed" if day_index in {2, 3} else None,
-                workflow_run_conclusion="success" if day_index in {2, 3} else None,
-                workflow_run_completed_at=_now() if day_index in {2, 3} else None,
-                diff_summary_json=submission_spec["diff_summary_json"],
-                tests_passed=submission_spec["tests_passed"],
-                tests_failed=submission_spec["tests_failed"],
-                test_output=submission_spec["test_output"],
-                last_run_at=_now() if day_index in {2, 3} else None,
+                storage_key=recording_key,
+                content_type="video/mp4",
+                bytes=2_048_000,
+                asset_kind="recording",
+                duration_seconds=120,
+                status="ready",
+                consent_version="yc-demo-v1",
+                consent_timestamp=_now() - timedelta(days=1),
+                ai_notice_version="yc-demo-v1",
+                retention_expires_at=_now() + timedelta(days=30),
             )
-            db.add(submission)
+            db.add(recording)
             await db.flush()
-            if day_index in {2, 3}:
-                await db.execute(
-                    delete(CandidateDayAudit).where(
-                        CandidateDayAudit.candidate_session_id == candidate_session.id,
-                        CandidateDayAudit.day_index == day_index,
-                    )
-                )
-                db.add(
-                    CandidateDayAudit(
-                        candidate_session_id=candidate_session.id,
-                        day_index=day_index,
-                        cutoff_at=_now() - timedelta(days=5 - day_index),
-                        cutoff_commit_sha=(
-                            day2_commit_sha if day_index == 2 else day3_commit_sha
-                        ),
-                        eval_basis_ref=(
-                            f"{repo_result.repo_full_name}@"
-                            f"{day2_commit_sha if day_index == 2 else day3_commit_sha}"
-                        ),
-                    )
-                )
-                await db.flush()
-
-        day_rows, reviewer_rows = _build_report_rows(
-            candidate=candidate,
-            repo_full_name=repo_result.repo_full_name,
-            bootstrap_commit_sha=repo_result.bootstrap_commit_sha or "",
-            day2_commit_sha=day2_commit_sha,
-            day3_commit_sha=day3_commit_sha,
-        )
-        raw_report_json = {
-            "overallWinoeScore": candidate.overall_score,
-            "recommendation": candidate.recommendation,
-            "confidence": candidate.confidence,
-            "dayScores": day_rows,
-            "reviewerReports": reviewer_rows,
-        }
-        run = await create_run(
-            db,
-            candidate_session_id=candidate_session.id,
-            scenario_version_id=scenario_version.id,
-            model_name="demo-winoe-report",
-            model_version="demo-1",
-            prompt_version="demo-1",
-            rubric_version="demo-1",
-            day2_checkpoint_sha=day2_commit_sha,
-            day3_final_sha=day3_commit_sha,
-            cutoff_commit_sha=day3_commit_sha,
-            transcript_reference=f"transcript:{recording_key}",
-            job_id=None,
-            basis_fingerprint=_stable_hex(
-                candidate.email, repo_result.repo_full_name, "basis", length=64
-            ),
-            overall_winoe_score=candidate.overall_score,
-            recommendation=candidate.internal_recommendation,
-            confidence=candidate.confidence,
-            generated_at=_now(),
-            raw_report_json=raw_report_json,
-            status=EVALUATION_RUN_STATUS_COMPLETED,
-            started_at=_now() - timedelta(hours=1),
-            completed_at=_now(),
-            metadata_json={
-                "aiPolicyProvider": "demo-seed",
-                "aiPolicySnapshotDigest": (
-                    scenario_version.ai_policy_snapshot_json or {}
-                ).get("snapshotDigest"),
-                "rubricSnapshots": [
+            transcript = Transcript(
+                recording_id=recording.id,
+                text=(
+                    f"{completed_candidate.name} explained the design, tradeoffs, and next steps "
+                    f"for the {config.company_name} demo."
+                ),
+                segments_json=[
+                    {"start": 0, "end": 60, "text": completed_candidate.summary_line},
                     {
-                        "scope": "winoe",
-                        "rubricKind": "demo",
-                        "rubricKey": candidate.label,
-                        "rubricVersion": "demo-1",
-                    }
-                ],
-            },
-            commit=False,
-        )
-        await add_day_scores(
-            db,
-            run=run,
-            day_scores=day_rows,
-            commit=False,
-        )
-        for reviewer_row in reviewer_rows:
-            db.add(
-                EvaluationReviewerReport(
-                    run_id=run.id,
-                    reviewer_agent_key=reviewer_row["reviewer_agent_key"],
-                    day_index=reviewer_row["day_index"],
-                    submission_kind=reviewer_row["submission_kind"],
-                    score=reviewer_row["score"],
-                    dimensional_scores_json=reviewer_row["dimensional_scores_json"],
-                    evidence_citations_json=reviewer_row["evidence_citations_json"],
-                    assessment_text=reviewer_row["assessment_text"],
-                    strengths_json=reviewer_row["strengths_json"],
-                    risks_json=reviewer_row["risks_json"],
-                    raw_output_json={
-                        "summary": candidate.summary_line,
-                        "candidate": candidate.name,
+                        "start": 60,
+                        "end": 120,
+                        "text": "The evidence trail is grounded in the submitted artifacts.",
                     },
+                ],
+                model_name="demo-transcribe",
+                status="ready",
+            )
+            db.add(transcript)
+            await db.flush()
+            submission_recording_id = recording.id
+            submission_spec["content_json"]["transcriptRecordingId"] = recording.id
+        submission = Submission(
+            candidate_session_id=candidate_session.id,
+            task_id=task.id,
+            recording_id=submission_recording_id,
+            submitted_at=_now() - timedelta(days=5 - day_index),
+            content_text=submission_spec["content_text"],
+            content_json=submission_spec["content_json"],
+            code_repo_path=submission_spec["code_repo_path"],
+            commit_sha=submission_spec["commit_sha"],
+            final_sha=submission_spec["commit_sha"] if day_index == 3 else None,
+            workflow_run_id=(
+                f"yc-demo-{completed_candidate.label}-day{day_index}"
+                if day_index in {2, 3}
+                else None
+            ),
+            workflow_run_attempt=1 if day_index in {2, 3} else None,
+            workflow_run_status="completed" if day_index in {2, 3} else None,
+            workflow_run_conclusion="success" if day_index in {2, 3} else None,
+            workflow_run_completed_at=_now() if day_index in {2, 3} else None,
+            diff_summary_json=submission_spec["diff_summary_json"],
+            tests_passed=submission_spec["tests_passed"],
+            tests_failed=submission_spec["tests_failed"],
+            test_output=submission_spec["test_output"],
+            last_run_at=_now() if day_index in {2, 3} else None,
+        )
+        db.add(submission)
+        await db.flush()
+        if day_index in {2, 3}:
+            await db.execute(
+                delete(CandidateDayAudit).where(
+                    CandidateDayAudit.candidate_session_id == candidate_session.id,
+                    CandidateDayAudit.day_index == day_index,
                 )
             )
-        marker = await upsert_marker(
+            db.add(
+                CandidateDayAudit(
+                    candidate_session_id=candidate_session.id,
+                    day_index=day_index,
+                    cutoff_at=_now() - timedelta(days=5 - day_index),
+                    cutoff_commit_sha=(
+                        day2_commit_sha if day_index == 2 else day3_commit_sha
+                    ),
+                    eval_basis_ref=(
+                        f"{repo_result.repo_full_name}@"
+                        f"{day2_commit_sha if day_index == 2 else day3_commit_sha}"
+                    ),
+                )
+            )
+            await db.flush()
+
+    day_rows, reviewer_rows = _build_report_rows(
+        candidate=completed_candidate,
+        repo_full_name=repo_result.repo_full_name,
+        bootstrap_commit_sha=repo_result.bootstrap_commit_sha or "",
+        day2_commit_sha=day2_commit_sha,
+        day3_commit_sha=day3_commit_sha,
+    )
+    report_dimensions = _build_demo_report_dimensions(completed_candidate)
+    report_citations = _build_demo_report_citations(
+        bootstrap_commit_sha=repo_result.bootstrap_commit_sha or "",
+        day2_commit_sha=day2_commit_sha,
+        day3_commit_sha=day3_commit_sha,
+    )
+    raw_report_json = {
+        "overallWinoeScore": completed_candidate.overall_score,
+        "recommendation": completed_candidate.recommendation,
+        "confidence": completed_candidate.confidence,
+        "verdictOneLiner": (
+            "Sarah's Trial is cohesive, evidence-backed, and easy to explain without overclaiming."
+        ),
+        "narrativeAssessment": (
+            "Sarah kept the work tight and readable. The Day 1 design doc set a clear boundary, "
+            "the Day 2 and Day 3 commits moved steadily, and the Day 4 transcript tied the story back "
+            "to concrete artifacts. The strongest signals are architecture discipline, implementation "
+            "discipline, and communication clarity. The discussable gaps are operational hardening and "
+            "one more explicit edge-case pass."
+        ),
+        "cohortContext": (
+            "This completed Trial has the densest evidence trail in the seeded demo set, with a clean chain from brief to handoff."
+        ),
+        "dimensions": report_dimensions,
+        "citations": report_citations,
+        "dayScores": day_rows,
+        "reviewerReports": reviewer_rows,
+    }
+    run = await create_run(
+        db,
+        candidate_session_id=candidate_session.id,
+        scenario_version_id=completed_scenario.id,
+        model_name="demo-winoe-report",
+        model_version="demo-1",
+        prompt_version="demo-1",
+        rubric_version="demo-1",
+        day2_checkpoint_sha=day2_commit_sha,
+        day3_final_sha=day3_commit_sha,
+        cutoff_commit_sha=day3_commit_sha,
+        transcript_reference=f"transcript:{recording_key}",
+        job_id=None,
+        basis_fingerprint=_stable_hex(
+            completed_candidate.email, repo_result.repo_full_name, "basis", length=64
+        ),
+        overall_winoe_score=completed_candidate.overall_score,
+        recommendation=completed_candidate.internal_recommendation,
+        confidence=completed_candidate.confidence,
+        generated_at=_now(),
+        raw_report_json=raw_report_json,
+        status=EVALUATION_RUN_STATUS_COMPLETED,
+        started_at=_now() - timedelta(hours=1),
+        completed_at=_now(),
+        metadata_json={
+            "aiPolicyProvider": "demo-seed",
+            "aiPolicySnapshotDigest": (
+                completed_scenario.ai_policy_snapshot_json or {}
+            ).get("snapshotDigest"),
+            "rubricSnapshots": [
+                {
+                    "scope": "winoe",
+                    "rubricKind": "demo",
+                    "rubricKey": completed_candidate.label,
+                    "rubricVersion": "demo-1",
+                }
+            ],
+        },
+        commit=False,
+    )
+    await add_day_scores(
+        db,
+        run=run,
+        day_scores=day_rows,
+        commit=False,
+    )
+    for reviewer_row in reviewer_rows:
+        db.add(
+            EvaluationReviewerReport(
+                run_id=run.id,
+                reviewer_agent_key=reviewer_row["reviewer_agent_key"],
+                day_index=reviewer_row["day_index"],
+                submission_kind=reviewer_row["submission_kind"],
+                score=reviewer_row["score"],
+                dimensional_scores_json=reviewer_row["dimensional_scores_json"],
+                evidence_citations_json=reviewer_row["evidence_citations_json"],
+                assessment_text=reviewer_row["assessment_text"],
+                strengths_json=reviewer_row["strengths_json"],
+                risks_json=reviewer_row["risks_json"],
+                raw_output_json={
+                    "summary": completed_candidate.summary_line,
+                    "candidate": completed_candidate.name,
+                },
+            )
+        )
+    marker = await upsert_marker(
+        db,
+        candidate_session_id=candidate_session.id,
+        generated_at=_now(),
+        commit=False,
+    )
+    if marker.id is not None:
+        await replace_report_citations(
             db,
-            candidate_session_id=candidate_session.id,
-            generated_at=_now(),
+            report_id=marker.id,
+            citations=report_citations,
             commit=False,
         )
-        if marker.id is not None:
-            report_citations = []
-            for day_row in day_rows:
-                for pointer in day_row["evidence_pointers_json"]:
-                    if not isinstance(pointer, dict):
-                        continue
-                    artifact_ref = pointer.get("ref")
-                    excerpt = pointer.get("excerpt")
-                    dimension = pointer.get("dimensionKey") or pointer.get(
-                        "dimensionLabel"
-                    )
-                    kind = pointer.get("kind")
-                    if not all(
-                        isinstance(value, str) and value.strip()
-                        for value in (artifact_ref, excerpt, dimension, kind)
-                    ):
-                        continue
-                    report_citations.append(
-                        {
-                            "dimension": str(dimension).strip(),
-                            "artifact_type": str(kind).strip(),
-                            "artifact_ref": str(artifact_ref).strip(),
-                            "excerpt": str(excerpt).strip(),
-                        }
-                    )
-            await replace_report_citations(
-                db,
-                report_id=marker.id,
-                citations=report_citations,
-                commit=False,
-            )
-        candidate_session.completed_at = _now()
-        candidate_session.status = "completed"
+    candidate_session.completed_at = _now()
+    candidate_session.status = "completed"
+    completed_trial.completed_at = _now()
+    completed_trial.status = TRIAL_STATUS_COMPLETED
+
+    awaiting_trial, _, awaiting_scenario = await _seed_trial_scaffold(
+        db,
+        company_id=company.id,
+        created_by=talent_partner.id,
+        title="Staff Engineer Trial",
+        role="Staff Engineer",
+        seniority="staff",
+        preferred_language_framework="Go",
+        focus="Keep the architecture minimal while leaving a crisp evidence trail.",
+        status=TRIAL_STATUS_ACTIVE_INVITING,
+        company_name=config.company_name,
+        project_brief_md=brief_md,
+        storyline_md="A staff-level Trial that is ready to invite a candidate and wait for start.",
+        ai_notice_version="yc-demo-v1",
+        trial_focus_note="Go-oriented staff level work with an invite still pending.",
+    )
+    awaiting_candidate = invite_groups["awaiting_candidate"][0]
+    awaiting_session = CandidateSession(
+        trial_id=awaiting_trial.id,
+        scenario_version_id=awaiting_scenario.id,
+        candidate_user_id=None,
+        candidate_name=awaiting_candidate.name,
+        invite_email=awaiting_candidate.email,
+        candidate_email=awaiting_candidate.email,
+        candidate_auth0_email=awaiting_candidate.email,
+        token=_stable_hex(
+            config.company_name, awaiting_candidate.email, "invite", length=32
+        ),
+        status="not_started",
+        claimed_at=None,
+        scheduled_start_at=None,
+        started_at=None,
+        completed_at=None,
+        expires_at=_now() + timedelta(days=7),
+        invite_email_status="sent",
+        invite_email_sent_at=_now() - timedelta(hours=6),
+        invite_email_last_attempt_at=_now() - timedelta(hours=6),
+        candidate_timezone=config.timezone,
+        github_username=awaiting_candidate.github_username,
+        consent_version="yc-demo-v1",
+        consent_timestamp=None,
+        ai_notice_version="yc-demo-v1",
+        day_windows_json=[],
+    )
+    db.add(awaiting_session)
+    await db.flush()
+    candidate_sessions.append(awaiting_session)
+
+    for trial in (active_trial_a, completed_trial, awaiting_trial):
+        trial.activated_at = trial.activated_at or _now()
 
     await db.commit()
     return DemoSeedSummary(
         company_id=company.id,
-        trial_id=trial.id,
+        trial_id=completed_trial.id,
         candidate_session_ids=[candidate.id for candidate in candidate_sessions],
         repo_full_names=repo_full_names,
     )

--- a/app/evaluations/schemas/evaluations_schemas_evaluations_winoe_report_schema.py
+++ b/app/evaluations/schemas/evaluations_schemas_evaluations_winoe_report_schema.py
@@ -51,6 +51,23 @@ class WinoeReportReviewerReportOut(APIModel):
     concerns: list[str] = Field(default_factory=list)
 
 
+class WinoeReportDimensionOut(APIModel):
+    """Represent a scored Winoe Report dimension."""
+
+    name: str
+    score: float
+    justification: str
+
+
+class WinoeReportCitationOut(APIModel):
+    """Represent a persisted Evidence Trail citation."""
+
+    dimension: str
+    artifact_type: str
+    artifact_ref: str
+    excerpt: str
+
+
 class WinoeReportDayScoreOut(APIModel):
     """Represent winoe report day score out data and behavior."""
 
@@ -85,6 +102,11 @@ class WinoeReportReportOut(APIModel):
         "limited_signal",
     ]
     confidence: float
+    verdictOneLiner: str | None = None
+    narrativeAssessment: str | None = None
+    cohortContext: str | None = None
+    dimensions: list[WinoeReportDimensionOut] = Field(default_factory=list)
+    citations: list[WinoeReportCitationOut] = Field(default_factory=list)
     dayScores: list[WinoeReportDayScoreOut] = Field(default_factory=list)
     reviewerReports: list[WinoeReportReviewerReportOut] = Field(default_factory=list)
     version: WinoeReportVersionOut
@@ -102,8 +124,10 @@ class WinoeReportStatusResponse(APIModel):
 
 __all__ = [
     "WinoeReportDayScoreOut",
+    "WinoeReportCitationOut",
     "WinoeReportEvidenceOut",
     "WinoeReportGenerateResponse",
+    "WinoeReportDimensionOut",
     "WinoeReportReportOut",
     "WinoeReportReviewerReportOut",
     "WinoeReportStatusResponse",

--- a/app/evaluations/services/evaluations_services_evaluations_winoe_report_composer_service.py
+++ b/app/evaluations/services/evaluations_services_evaluations_winoe_report_composer_service.py
@@ -145,6 +145,16 @@ def compose_report(run: EvaluationRun) -> dict[str, Any]:
     )
     if disabled_indexes:
         report["disabledDayIndexes"] = sorted(disabled_indexes)
+    if isinstance(persisted_report.get("verdictOneLiner"), str):
+        report["verdictOneLiner"] = str(persisted_report["verdictOneLiner"])
+    if isinstance(persisted_report.get("narrativeAssessment"), str):
+        report["narrativeAssessment"] = str(persisted_report["narrativeAssessment"])
+    if isinstance(persisted_report.get("cohortContext"), str):
+        report["cohortContext"] = str(persisted_report["cohortContext"])
+    if isinstance(persisted_report.get("dimensions"), list):
+        report["dimensions"] = list(persisted_report["dimensions"])
+    if isinstance(persisted_report.get("citations"), list):
+        report["citations"] = list(persisted_report["citations"])
     return report
 
 

--- a/app/integrations/github/integrations_github_factory_client.py
+++ b/app/integrations/github/integrations_github_factory_client.py
@@ -27,15 +27,13 @@ def _real_github_client_singleton() -> GithubClient:
 
 def get_github_provisioning_client() -> GithubClient | FakeGithubClient:
     """Return the configured GitHub provider for workspace provisioning."""
+    raw_demo_mode_requested = _is_truthy(getattr(settings, "DEMO_MODE", None))
+    if raw_demo_mode_requested and settings.is_production_environment():
+        raise RuntimeError(
+            "DEMO_MODE/WINOE_DEMO_MODE is forbidden in production environments."
+        )
     if settings.demo_mode_enabled:
         return get_fake_github_client()
-    if _is_truthy(getattr(settings, "DEMO_MODE", None)) and (
-        settings.is_production_environment()
-    ):
-        logger.warning(
-            "DEMO_MODE requested but disabled in production; using real GitHub provider.",
-            extra={"env": str(getattr(settings, "ENV", "") or "").lower()},
-        )
     return _real_github_client_singleton()
 
 

--- a/fixtures/demo/README.md
+++ b/fixtures/demo/README.md
@@ -1,0 +1,9 @@
+# Winoe Demo Fixtures
+
+This directory holds deterministic demo artifacts for the YC rehearsal dataset.
+
+Contents:
+- `repos/sarah-chen/` contains the completed Trial B markdown artifacts.
+- `artifacts/` contains compact JSON snapshots used to document the seeded repo history and report shape.
+
+All fixture content uses current Winoe terminology only.

--- a/fixtures/demo/artifacts/sarah-chen-commit-history.json
+++ b/fixtures/demo/artifacts/sarah-chen-commit-history.json
@@ -1,0 +1,17 @@
+{
+  "repository": "winoe-ws-sarah-chen",
+  "commits": [
+    {
+      "sha": "c9b4a58f4d8e11b1c1c9b7d2e9fd0b7f0d7e8e11",
+      "message": "Initialize empty Trial workspace"
+    },
+    {
+      "sha": "d7f1a6b15c06e2b2c1ab52f6b1f4c2e1c1f4a98aa",
+      "message": "Add devcontainer and project brief"
+    },
+    {
+      "sha": "e4c8f6d1a7b2c3d4e5f60718293a4b5c6d7e8f90",
+      "message": "Finish the implementation and evidence trail"
+    }
+  ]
+}

--- a/fixtures/demo/reports/sarah-chen-winoe-report.json
+++ b/fixtures/demo/reports/sarah-chen-winoe-report.json
@@ -1,0 +1,20 @@
+{
+  "overallWinoeScore": 0.78,
+  "verdictOneLiner": "The Trial is cohesive, evidence-backed, and easy to defend.",
+  "narrativeAssessment": "Sarah kept the work tight and readable. The Day 1 design doc set a clear boundary, the Day 2 and Day 3 commits moved steadily, and the Day 4 transcript tied the story back to concrete artifacts.",
+  "cohortContext": "This was the strongest completed Trial in the seeded demo cohort.",
+  "dimensions": [
+    {"name": "Architectural coherence", "score": 0.88, "justification": "The Day 1 brief keeps the scope bounded."},
+    {"name": "Scope control", "score": 0.86, "justification": "The repo stays focused on the Trial."},
+    {"name": "Implementation discipline", "score": 0.89, "justification": "Day 2 and Day 3 show steady progress."},
+    {"name": "Testing discipline", "score": 0.87, "justification": "Tests are present and tied to the build."},
+    {"name": "Code quality", "score": 0.88, "justification": "The code snapshots stay readable."},
+    {"name": "Dependency hygiene", "score": 0.85, "justification": "The stack stays clean."},
+    {"name": "Communication / Handoff + Demo", "score": 0.86, "justification": "The handoff is grounded in artifacts."},
+    {"name": "Reflection & self-awareness", "score": 0.84, "justification": "The reflection is candid and specific."}
+  ],
+  "citations": [
+    {"dimension": "architectural_coherence", "artifact_type": "rubric", "artifact_ref": "day1-design-doc.md:L12-L31", "excerpt": "Architecture plan, tradeoffs, and testing strategy."},
+    {"dimension": "scope_control", "artifact_type": "commit", "artifact_ref": "c9b4a58f4d8e11b1c1c9b7d2e9fd0b7f0d7e8e11:README.md:L1-L24", "excerpt": "Bootstrap commit created the empty repository, devcontainer, and README."}
+  ]
+}

--- a/fixtures/demo/repos/sarah-chen/day1-design-doc.md
+++ b/fixtures/demo/repos/sarah-chen/day1-design-doc.md
@@ -1,0 +1,7 @@
+# Day 1 Design Document
+
+## Architecture
+Use a small FastAPI service with clear service boundaries and idempotent writes.
+
+## Tradeoffs
+Keep the structure simple enough to defend in a five-day Trial.

--- a/fixtures/demo/repos/sarah-chen/day2-implementation-kickoff.md
+++ b/fixtures/demo/repos/sarah-chen/day2-implementation-kickoff.md
@@ -1,0 +1,3 @@
+# Day 2 Implementation Kickoff
+
+Sarah Chen started from an empty repository, added the initial API shape, and kept the evidence trail easy to follow.

--- a/fixtures/demo/repos/sarah-chen/day3-implementation-wrap-up.md
+++ b/fixtures/demo/repos/sarah-chen/day3-implementation-wrap-up.md
@@ -1,0 +1,3 @@
+# Day 3 Implementation Wrap-Up
+
+The repository now has a clear implementation path, tests, and documentation that line up with the Trial brief.

--- a/fixtures/demo/repos/sarah-chen/day4-handoff-demo.md
+++ b/fixtures/demo/repos/sarah-chen/day4-handoff-demo.md
@@ -1,0 +1,3 @@
+# Day 4 Handoff + Demo
+
+Sarah explained the architecture, the main tradeoffs, and the next steps with concrete references to the submitted work.

--- a/fixtures/demo/repos/sarah-chen/day5-reflection.md
+++ b/fixtures/demo/repos/sarah-chen/day5-reflection.md
@@ -1,0 +1,3 @@
+# Day 5 Reflection
+
+The reflection is direct about what went well, what was hard, and what should be tightened next.

--- a/pr.md
+++ b/pr.md
@@ -1,132 +1,102 @@
-# Task 7: Add Benchmarks APIs, Submission Review artifacts, and seekable media support
+# Task 10 — Demo Infrastructure
 
 ## Summary
+- Added fake GitHub provider support for demo mode so seeded demo environments do not make real GitHub network calls.
+- Wired `WINOE_DEMO_MODE` / `DEMO_MODE` selection behavior so demo mode is explicit and production-safe.
+- Added a hard production guard that rejects demo mode when `WINOE_ENV=production`.
+- Built the one-command demo seed flow and made the seeded YC demo dataset deterministic and idempotent.
+- Seeded the Sarah Chen completed Trial with a Winoe Report, Evidence Trail, and Day 1-5 artifacts.
+- Added legacy demo-reference cleanup guardrails and a documented YC demo checklist.
+- Cleaned up the migration graph so the fake placeholder migration is removed and the canonical Alembic head remains intact.
 
-This backend PR supports Task 7 by adding:
+## Backend Change List
+- Fake GitHub provider behavior:
+  - deterministic fake repo, Codespace, workflow, and artifact behavior
+  - no real GitHub network calls in demo mode
+  - fake/demo evidence links used for seeded demo content
+- Demo mode config:
+  - `WINOE_DEMO_MODE=true`
+  - `WINOE_ENV=production` rejection
+- Seed script:
+  - `scripts/seed_demo.sh`
+  - custom env vars:
+    - `DEMO_TALENT_PARTNER_EMAIL`
+    - `DEMO_TALENT_PARTNER_NAME`
+    - `DEMO_COMPANY_NAME`
+  - idempotent seeded dataset
+- Demo dataset:
+  - 1 Talent Partner
+  - 3 Trials
+  - 4 candidate sessions
+  - Sarah Chen completed Trial
+  - 5 submissions
+  - 1 Winoe Report
+  - 1 EvaluationRun
+- Trial A / Trial C candidate list:
+  - invited / not-yet-started seeded candidates use schema-valid `not_started`
+- Legacy cleanup:
+  - `scripts/check_no_legacy_demo_refs.sh`
+  - CI guard
+- Demo runbook:
+  - `YC_DEMO_CHECKLIST.md`
+- Migration graph:
+  - fake placeholder migration removed
+  - canonical Alembic head preserved
+  - stale local DB recovery documented
 
-- Benchmarks list API
-- Benchmarks compare API
-- query-level Talent Partner ownership isolation
-- same-Trial-only comparison
-- Submission Review artifact payloads
-- Day 2 / Day 3 code artifact normalization
-- demo seed support for real code snapshot artifacts
-- fake-storage byte-range support for seekable Day 4 media
+## Verification
+```bash
+bash -n scripts/seed_demo.sh
+bash -n scripts/check_no_legacy_demo_refs.sh
+bash scripts/check_no_legacy_demo_refs.sh
+poetry run pytest -q tests/demo/services/test_demo_yc_seed_service.py tests/trials/routes/test_trials_candidates_list_populated_routes.py -o addopts=''
+./precommit.sh
+```
 
-The backend enforces the data rules for the Talent Partner review surfaces rather than relying on frontend routing alone.
+Final seed command:
 
-## What changed
+```bash
+WINOE_ENV=local \
+WINOE_DEMO_MODE=true \
+DEMO_TALENT_PARTNER_EMAIL="winoetalentpartner@gmail.com" \
+DEMO_TALENT_PARTNER_NAME="TalentPartner" \
+DEMO_COMPANY_NAME="Acme" \
+./scripts/seed_demo.sh
+```
 
-### Benchmarks API
+Final outcome:
+- exit code `0`
+- fake GitHub provider used
+- seeded dataset verified
+- asyncpg / SQLAlchemy shutdown warning is non-blocking if it appears after success
 
-Added:
+## Manual QA Evidence
+- `/health` passed.
+- `/ready` passed and GitHub was skipped / fake-safe in demo mode.
+- dashboard showed 3 Trials.
+- Trial A candidate list worked.
+- Trial C candidate list worked.
+- Sarah Chen Winoe Report data seeded correctly.
+- legacy UI sweep passed.
 
-- `GET /api/v1/benchmarks?trial_id={id}`
-- `GET /api/v1/benchmarks/compare?candidate_ids=id1,id2,id3`
+## Known Warnings / Follow-ups
+- Local stale Alembic stamp recovery may require the documented reset path.
+- Seed teardown warning should be cleaned up later if desired.
+- PDF export is frontend-owned and currently behaves as print mode.
 
-The list API returns same-Trial cohort data with:
+## Final QA Result
 
-- cohort summary fields for `n`, median, mean, range, and sufficient flag
-- pagination
-- candidate rows with:
-  - candidate identity
-  - Trial identity
-  - Winoe Score
-  - dimensions
-  - report ID
-  - status
-  - submitted timestamp
-- honest inclusion of candidates whose reports are not ready yet
-- `null` for missing scores instead of fake `0`
+`Task 10 FINAL QA PASS — ready to finish / raise PRs.`
 
-The compare API returns 2-3 candidate side-by-side data with strict same-Trial validation.
-
-### Data isolation
-
-Data isolation is enforced at the query/service layer, not only in frontend route selection.
-
-Explicit validation and rejection behavior includes:
-
-- fewer than 2 candidates
-- more than 3 candidates
-- duplicate IDs
-- malformed IDs
-- mixed-Trial candidates
-- unauthorized candidates
-- nonexistent candidates using repo-standard error behavior
-
-Talent Partner access is resolved through the Trial relationship, so the API only exposes data the caller is allowed to see.
-
-### Submission Review payloads
-
-The submission-review endpoint returns:
-
-- candidate metadata
-- Trial metadata
-- Day 1 markdown
-- Day 2 code payload
-- Day 3 code payload
-- Day 4 demo / transcript / media payload
-- Day 5 markdown
-
-Day 2 and Day 3 normalize repository or code snapshot artifacts into:
-
-- `fileTree`
-- selected file metadata
-- selected file content
-- language
-- commit timeline
-
-Fallback handling remains for older or simpler payload shapes where appropriate.
-
-### Demo seed data
-
-- YC demo seed now includes realistic code snapshot artifacts for Day 2 and Day 3.
-- The seed supports manual QA of real file tree, code, and commit rendering.
-- This is backend-provided demo data, not frontend fake state.
-
-### Media Range support
-
-The fake-storage media download route now supports browser byte-range requests:
-
-- `Range: bytes=...`
-- `206 Partial Content`
-- `Accept-Ranges: bytes`
-- `Content-Range`
-
-This fixed local Day 4 transcript seek, where the browser could not seek the media element until the response became seekable.
-
-The full `200 OK` path still works for normal downloads, and the parser is intentionally narrow for browser-needed byte-range patterns.
-
-## Manual QA support / proof
-
-- Browser QA proved Day 4 click-to-seek:
-  - route `/talent-partner/trials/2/candidates/5/submission`
-  - clicked `00:35 Implementation walkthrough.`
-  - `video.currentTime: 0 → 35`
-  - active highlight updated
-- Backend API QA passed for:
-  - Benchmarks list
-  - Compare 2 candidates
-  - Compare 3 candidates
-  - validation errors
-  - data isolation
-- QA artifacts and media remained local-only and were not committed.
-
-## Tests
-
-- `pytest -o addopts='' tests/candidates/routes/test_candidates_session_review_returns_completed_artifacts_routes.py tests/trials/routes/test_trials_benchmarks_and_submission_review_routes.py tests/trials/services/test_trials_benchmarks_service.py`
-- `./precommit.sh`
-
-Final backend precommit passed:
-
-- `2093 passed`
-- `coverage 96.05%`
-- `precommit passed`
-
-## Risk / follow-up
-
-- Fake-storage Range support is intentionally narrow.
-- The local QA media file was not committed.
-- Production media/storage providers should already support byte ranges, or they should be verified separately before scaling up video playback.
-- No Task 7 functional blocker remains.
+Final verification confirmed:
+- normal seed command exits 0 after documented reset repair path
+- seeded data is idempotent and stable
+- fake GitHub provider is used in demo mode
+- production demo mode is rejected
+- dashboard shows 3 Trials
+- Trial A and Trial C candidate lists work
+- Sarah Chen Winoe Report renders with Winoe Score 78 and exactly 8 dimensions
+- Evidence Trail and Day 1-5 artifacts are accessible
+- legacy guard passes
+- backend precommit passes
+- frontend precommit passes

--- a/scripts/check_no_legacy_demo_refs.sh
+++ b/scripts/check_no_legacy_demo_refs.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+demo_visible_targets=(
+  "app/demo"
+  "fixtures"
+  "prompts"
+  "scripts"
+  "tests/data"
+  "tests/demo"
+  "YC_DEMO_CHECKLIST.md"
+)
+
+demo_visible_patterns=(
+  "Tenon"
+  "SimuHire"
+  "tenon-ai/"
+  "@tenon"
+  "tenon-hire-dev"
+  "tenon-ws-"
+  "Tenon platform"
+  "Tenon report"
+  "recruiter"
+  "simulation"
+  "Fit Profile"
+  "Fit Score"
+  "template catalog"
+  "precommit"
+  "Codespace Specializor"
+  "eliminate"
+  "reject"
+  "filter out"
+  "screen out"
+  "discard"
+  "A-player"
+  "culture fit"
+  "hiring recommendation"
+)
+
+prompt_governance_targets=(
+  "app/ai/prompt_assets/v4/winoe_soul.md"
+  "app/ai/prompt_assets/v4/winoe_synthesis.md"
+)
+
+prompt_governance_patterns=(
+  "Tenon platform"
+  "Tenon report"
+  "tenon-template"
+  "tenon-hire-dev"
+  "tenon-ws-"
+)
+
+scan_paths() {
+  local label="$1"
+  shift
+  local paths=("$@")
+  if [[ ${#paths[@]} -eq 0 ]]; then
+    return 0
+  fi
+  echo "Scanning ${label}:"
+  for path in "${paths[@]}"; do
+    echo "  - ${path}"
+  done
+}
+
+scan_patterns() {
+  local label="$1"
+  shift
+  local patterns=("$@")
+  if [[ ${#patterns[@]} -eq 0 ]]; then
+    return 0
+  fi
+  echo "Enforcing ${label}:"
+  for pattern in "${patterns[@]}"; do
+    echo "  - ${pattern}"
+  done
+}
+
+scan_paths "demo-visible paths" "${demo_visible_targets[@]}"
+scan_patterns "demo-visible residue patterns" "${demo_visible_patterns[@]}"
+
+matches=0
+for target in "${demo_visible_targets[@]}"; do
+  if [[ ! -e "$target" ]]; then
+    continue
+  fi
+  for pattern in "${demo_visible_patterns[@]}"; do
+    if rg -n -i --hidden --no-messages \
+      --glob '!**/__pycache__/**' \
+      --glob '!scripts/check_no_legacy_demo_refs.sh' \
+      --glob '!scripts/compare_contract_smoke_test.py' \
+      --glob '!tests/scripts/test_check_no_legacy_demo_refs_sh.py' \
+      --glob '!app/ai/prompt_assets/v4/winoe_soul.md' \
+      --glob '!app/ai/prompt_assets/v4/winoe_synthesis.md' \
+      --fixed-strings -e "$pattern" "$target"; then
+      matches=1
+    fi
+  done
+done
+
+scan_paths "prompt guardrail files" "${prompt_governance_targets[@]}"
+scan_patterns "prompt-asset residue patterns" "${prompt_governance_patterns[@]}"
+
+for target in "${prompt_governance_targets[@]}"; do
+  if [[ ! -e "$target" ]]; then
+    continue
+  fi
+  for pattern in "${prompt_governance_patterns[@]}"; do
+    if rg -n -i --hidden --no-messages \
+      --glob '!**/__pycache__/**' \
+      --fixed-strings -e "$pattern" "$target"; then
+      matches=1
+    fi
+  done
+done
+
+if [[ "$matches" -ne 0 ]]; then
+  echo "Legacy demo references found in demo-visible paths." >&2
+  exit 1
+fi
+
+echo "No legacy demo references found in demo-visible paths or prompt guardrails."

--- a/scripts/check_no_legacy_demo_refs.sh
+++ b/scripts/check_no_legacy_demo_refs.sh
@@ -76,6 +76,109 @@ scan_patterns() {
   done
 }
 
+normalize_path() {
+  local path="$1"
+  path="${path#./}"
+  printf "%s" "$path"
+}
+
+is_excluded_scan_file() {
+  local scope="$1"
+  local path
+  path="$(normalize_path "$2")"
+
+  case "$path" in
+    */__pycache__/* | __pycache__/*)
+      return 0
+      ;;
+  esac
+
+  if [[ "$scope" != "demo" ]]; then
+    return 1
+  fi
+
+  case "$path" in
+    scripts/check_no_legacy_demo_refs.sh | \
+      scripts/compare_contract_smoke_test.py | \
+      tests/scripts/test_check_no_legacy_demo_refs_sh.py | \
+      app/ai/prompt_assets/v4/winoe_soul.md | \
+      app/ai/prompt_assets/v4/winoe_synthesis.md)
+      return 0
+      ;;
+  esac
+
+  return 1
+}
+
+grep_file_for_pattern() {
+  local file="$1"
+  local pattern="$2"
+  local output
+
+  if output="$(grep -n -i -F -- "$pattern" "$file" 2>/dev/null)"; then
+    while IFS= read -r line; do
+      printf "%s:%s\n" "$file" "$line"
+    done <<<"$output"
+    return 0
+  fi
+
+  return 1
+}
+
+grep_fallback_scan() {
+  local target="$1"
+  local pattern="$2"
+  local scope="$3"
+  local file
+  local found=1
+
+  if [[ -f "$target" ]]; then
+    if ! is_excluded_scan_file "$scope" "$target" &&
+      grep_file_for_pattern "$target" "$pattern"; then
+      found=0
+    fi
+    return "$found"
+  fi
+
+  while IFS= read -r -d "" file; do
+    if is_excluded_scan_file "$scope" "$file"; then
+      continue
+    fi
+    if grep_file_for_pattern "$file" "$pattern"; then
+      found=0
+    fi
+  done < <(find "$target" -type d -name "__pycache__" -prune -o -type f -print0)
+
+  return "$found"
+}
+
+scan_fixed_string() {
+  local target="$1"
+  local pattern="$2"
+  local scope="$3"
+
+  if command -v rg >/dev/null 2>&1; then
+    if [[ "$scope" == "demo" ]]; then
+      rg -n -i --hidden --no-messages \
+        --glob '!**/__pycache__/**' \
+        --glob '!scripts/check_no_legacy_demo_refs.sh' \
+        --glob '!scripts/compare_contract_smoke_test.py' \
+        --glob '!tests/scripts/test_check_no_legacy_demo_refs_sh.py' \
+        --glob '!app/ai/prompt_assets/v4/winoe_soul.md' \
+        --glob '!app/ai/prompt_assets/v4/winoe_synthesis.md' \
+        --fixed-strings -e "$pattern" "$target"
+      return
+    fi
+
+    rg -n -i --hidden --no-messages \
+      --glob '!**/__pycache__/**' \
+      --fixed-strings -e "$pattern" "$target"
+    return
+  fi
+
+  grep_fallback_scan "$target" "$pattern" "$scope"
+}
+
 scan_paths "demo-visible paths" "${demo_visible_targets[@]}"
 scan_patterns "demo-visible residue patterns" "${demo_visible_patterns[@]}"
 
@@ -85,14 +188,7 @@ for target in "${demo_visible_targets[@]}"; do
     continue
   fi
   for pattern in "${demo_visible_patterns[@]}"; do
-    if rg -n -i --hidden --no-messages \
-      --glob '!**/__pycache__/**' \
-      --glob '!scripts/check_no_legacy_demo_refs.sh' \
-      --glob '!scripts/compare_contract_smoke_test.py' \
-      --glob '!tests/scripts/test_check_no_legacy_demo_refs_sh.py' \
-      --glob '!app/ai/prompt_assets/v4/winoe_soul.md' \
-      --glob '!app/ai/prompt_assets/v4/winoe_synthesis.md' \
-      --fixed-strings -e "$pattern" "$target"; then
+    if scan_fixed_string "$target" "$pattern" "demo"; then
       matches=1
     fi
   done
@@ -106,9 +202,7 @@ for target in "${prompt_governance_targets[@]}"; do
     continue
   fi
   for pattern in "${prompt_governance_patterns[@]}"; do
-    if rg -n -i --hidden --no-messages \
-      --glob '!**/__pycache__/**' \
-      --fixed-strings -e "$pattern" "$target"; then
+    if scan_fixed_string "$target" "$pattern" "prompt"; then
       matches=1
     fi
   done

--- a/scripts/seed_demo.py
+++ b/scripts/seed_demo.py
@@ -7,14 +7,31 @@ import subprocess
 import sys
 from pathlib import Path
 
+from sqlalchemy import func, select
+
 from app.config import settings
 from app.demo.services.yc_demo_seed_service import (
     DemoSeedConfig,
     _reset_database,
     seed_yc_demo_dataset,
 )
+from app.evaluations.repositories.evaluations_repositories_evaluations_core_model import (
+    EVALUATION_RUN_STATUS_COMPLETED,
+)
 from app.integrations.github import FakeGithubClient, GithubClient
 from app.shared.database import async_session_maker, engine
+from app.shared.database.shared_database_models_model import (
+    CandidateSession,
+    Company,
+    EvaluationRun,
+    Submission,
+    Trial,
+    User,
+    WinoeReport,
+)
+from app.submissions.repositories.submissions_repositories_submissions_winoe_report_citation_model import (
+    WinoeReportCitation,
+)
 
 
 def _is_truthy(value: object) -> bool:
@@ -31,15 +48,15 @@ def _parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--talent-partner-email",
-        default=os.getenv("DEMO_TALENT_PARTNER_EMAIL", "talent.partner.demo@winoe.ai"),
+        default=os.getenv("DEMO_TALENT_PARTNER_EMAIL", "demo@winoe.ai"),
     )
     parser.add_argument(
         "--talent-partner-name",
-        default=os.getenv("DEMO_TALENT_PARTNER_NAME", "Winoe Demo Talent Partner"),
+        default=os.getenv("DEMO_TALENT_PARTNER_NAME", "Demo Partner"),
     )
     parser.add_argument(
         "--company-name",
-        default=os.getenv("DEMO_COMPANY_NAME", "Winoe Demo Company"),
+        default=os.getenv("DEMO_COMPANY_NAME", "Acme"),
     )
     parser.add_argument(
         "--github-provider",
@@ -130,6 +147,118 @@ def _resolve_github_provider_label(mode: str) -> str:
     return "fake" if settings.demo_mode_enabled else "real"
 
 
+async def _verify_seeded_dataset(summary, config: DemoSeedConfig) -> None:
+    async with async_session_maker() as db:
+        company_count = await db.scalar(
+            select(func.count())
+            .select_from(Company)
+            .where(Company.id == summary.company_id)
+        )
+        candidate_sessions = (
+            (
+                await db.execute(
+                    select(CandidateSession).where(
+                        CandidateSession.id.in_(summary.candidate_session_ids)
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        trial_ids = sorted({row.trial_id for row in candidate_sessions})
+        trials = (
+            (await db.execute(select(Trial).where(Trial.id.in_(trial_ids))))
+            .scalars()
+            .all()
+        )
+        demo_trials = [
+            trial
+            for trial in trials
+            if isinstance(trial.company_context, dict)
+            and trial.company_context.get("demoMode") == "yc-demo"
+        ]
+        talent_partner_count = await db.scalar(
+            select(func.count())
+            .select_from(User)
+            .where(User.email == config.talent_partner_email)
+        )
+        completed_session = next(
+            (
+                session
+                for session in candidate_sessions
+                if session.candidate_name == "Sarah Chen"
+                and session.candidate_email == "sarah.chen.demo@winoe.ai"
+                and session.status == "completed"
+            ),
+            None,
+        )
+        if completed_session is None:
+            raise RuntimeError(
+                "YC demo verification failed: Sarah Chen completed session missing"
+            )
+        report_count = await db.scalar(
+            select(func.count())
+            .select_from(WinoeReport)
+            .where(WinoeReport.candidate_session_id == completed_session.id)
+        )
+        run_count = await db.scalar(
+            select(func.count())
+            .select_from(EvaluationRun)
+            .where(
+                EvaluationRun.candidate_session_id == completed_session.id,
+                EvaluationRun.status == EVALUATION_RUN_STATUS_COMPLETED,
+            )
+        )
+        submission_count = await db.scalar(
+            select(func.count())
+            .select_from(Submission)
+            .where(Submission.candidate_session_id == completed_session.id)
+        )
+        citation_count = await db.scalar(
+            select(func.count())
+            .select_from(WinoeReportCitation)
+            .join(WinoeReport, WinoeReport.id == WinoeReportCitation.report_id)
+            .where(WinoeReport.candidate_session_id == completed_session.id)
+        )
+
+    if company_count != 1:
+        raise RuntimeError("YC demo verification failed: company count mismatch")
+    if talent_partner_count != 1:
+        raise RuntimeError(
+            "YC demo verification failed: demo talent partner count mismatch"
+        )
+    if len(demo_trials) != 3:
+        raise RuntimeError("YC demo verification failed: demo trial count mismatch")
+    if len(candidate_sessions) != 4:
+        raise RuntimeError(
+            "YC demo verification failed: seeded candidate session count mismatch"
+        )
+    if report_count != 1 or run_count != 1:
+        raise RuntimeError(
+            "YC demo verification failed: seeded report/run count mismatch"
+        )
+    if submission_count != 5:
+        raise RuntimeError(
+            "YC demo verification failed: Sarah Chen submission count mismatch"
+        )
+    if citation_count is None or citation_count < 8:
+        raise RuntimeError("YC demo verification failed: citation count mismatch")
+
+    report_run = await db.scalar(
+        select(EvaluationRun).where(
+            EvaluationRun.candidate_session_id == completed_session.id,
+            EvaluationRun.status == EVALUATION_RUN_STATUS_COMPLETED,
+        )
+    )
+    if report_run is None or not isinstance(report_run.raw_report_json, dict):
+        raise RuntimeError("YC demo verification failed: missing report payload")
+    report_json = report_run.raw_report_json
+    if len(report_json.get("dimensions") or []) != 8:
+        raise RuntimeError("YC demo verification failed: report dimension count")
+    if not report_json.get("citations"):
+        raise RuntimeError("YC demo verification failed: report citations missing")
+
+
 async def _main_async(args: argparse.Namespace) -> None:
     project_root = Path(__file__).resolve().parents[1]
     _ensure_safe_environment(
@@ -169,8 +298,10 @@ async def _main_async(args: argparse.Namespace) -> None:
             github_client=github_client,
         )
 
+    await _verify_seeded_dataset(summary, config)
+
     print(
-        "YC demo seed ready: "
+        "YC demo seed verified: "
         f"company_id={summary.company_id}, "
         f"trial_id={summary.trial_id}, "
         f"candidate_session_ids={summary.candidate_session_ids}, "

--- a/scripts/seed_demo.sh
+++ b/scripts/seed_demo.sh
@@ -2,4 +2,9 @@
 
 set -euo pipefail
 
+echo "Seeding Winoe demo data..."
+
+export WINOE_DEMO_MODE="${WINOE_DEMO_MODE:-true}"
+export WINOE_ENV="${WINOE_ENV:-local}"
+
 exec poetry run python -m scripts.seed_demo "$@"

--- a/tests/ai/test_ai_prompt_pack_soul_service.py
+++ b/tests/ai/test_ai_prompt_pack_soul_service.py
@@ -40,6 +40,28 @@ def test_soul_markdown_exists_and_defines_required_sections() -> None:
         assert heading in text
 
 
+def test_soul_markdown_lists_explicit_forbidden_terms() -> None:
+    text = SOUL_PATH.read_text(encoding="utf-8")
+
+    for term in (
+        "Tenon",
+        "SimuHire",
+        "recruiter",
+        "simulation",
+        "Fit Profile",
+        "Fit Score",
+        "template catalog",
+        "precommit",
+        "Codespace Specializor",
+        "A-player",
+        "culture fit",
+        "hiring recommendation language that implies Winoe decides",
+    ):
+        assert term in text
+    assert "Governance Note" in text
+    assert "internal examples of language Winoe must avoid" in text
+
+
 def test_winoe_report_prompt_pack_entry_includes_soul_persona_governance() -> None:
     entry = build_prompt_pack_entry("winoeReport")
 
@@ -49,6 +71,8 @@ def test_winoe_report_prompt_pack_entry_includes_soul_persona_governance() -> No
     assert "Reveal" in entry.instructions_md
     assert "Evidence Trail" in entry.instructions_md
     assert "Winoe Score" in entry.instructions_md
+    assert "Tenon" in entry.instructions_md
+    assert "forbidden examples" in entry.instructions_md
 
 
 def test_winoe_report_snapshot_prompt_loads_soul_and_run_context() -> None:
@@ -64,6 +88,8 @@ def test_winoe_report_snapshot_prompt_loads_soul_and_run_context() -> None:
     assert "Warm but honest" in system_prompt
     assert "Anti-black-box" in system_prompt
     assert "Never make hiring decisions" in system_prompt
+    assert "hiring recommendation language that implies Winoe decides" in system_prompt
+    assert "internal examples of language Winoe must avoid" in system_prompt
     assert "## Run Context" in system_prompt
     assert "Candidate session ID: 101" in system_prompt
 

--- a/tests/config/test_config_demo_mode_env_values_utils.py
+++ b/tests/config/test_config_demo_mode_env_values_utils.py
@@ -32,19 +32,41 @@ def test_demo_mode_env_values_parse_as_expected(monkeypatch, env_value, expected
 def test_demo_mode_is_disabled_in_production_even_when_requested(
     monkeypatch, env_key, env_value
 ):
-    monkeypatch.setenv("WINOE_DEMO_MODE", "true")
-    monkeypatch.setenv(env_key, env_value)
-
     settings = Settings(
         _env_file=None,
+        ENV="test",
         AUTH0_DOMAIN="example.auth0.com",
         AUTH0_API_AUDIENCE="https://api.example.com",
         CORS_ALLOW_ORIGINS=["https://frontend.winoe.ai"],
     )
+    object.__setattr__(settings, "DEMO_MODE", True)
+    monkeypatch.setenv(env_key, env_value)
 
     assert settings.is_production_environment() is True
     assert settings.DEMO_MODE is True
     assert settings.demo_mode_enabled is False
+
+
+@pytest.mark.parametrize(
+    ("env_key", "env_value"),
+    [
+        ("WINOE_ENV", "production"),
+        ("ENV", "production"),
+    ],
+)
+def test_demo_mode_rejected_during_settings_validation_in_production(
+    monkeypatch, env_key, env_value
+):
+    monkeypatch.setenv("WINOE_DEMO_MODE", "true")
+    monkeypatch.setenv(env_key, env_value)
+
+    with pytest.raises(ValueError, match="DEMO_MODE/WINOE_DEMO_MODE"):
+        Settings(
+            _env_file=None,
+            AUTH0_DOMAIN="example.auth0.com",
+            AUTH0_API_AUDIENCE="https://api.example.com",
+            CORS_ALLOW_ORIGINS=["https://frontend.winoe.ai"],
+        )
 
 
 @pytest.mark.parametrize("raw_value", ["false", "0", "", None])

--- a/tests/demo/services/test_demo_yc_seed_service.py
+++ b/tests/demo/services/test_demo_yc_seed_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import re
+from datetime import UTC, datetime
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -14,6 +15,9 @@ from app.evaluations.repositories.evaluations_repositories_evaluations_core_mode
     EvaluationDayScore,
     EvaluationReviewerReport,
     EvaluationRun,
+)
+from app.evaluations.repositories.evaluations_repositories_evaluations_create_run_with_scores_repository import (
+    create_run_with_day_scores,
 )
 from app.evaluations.services.evaluations_services_evaluations_winoe_report_api_service import (
     fetch_winoe_report,
@@ -42,7 +46,15 @@ from app.submissions.repositories.github_native.workspaces.submissions_repositor
 from app.submissions.repositories.submissions_repositories_submissions_winoe_report_citation_model import (
     WinoeReportCitation,
 )
+from app.submissions.repositories.submissions_repositories_submissions_winoe_report_repository import (
+    upsert_marker,
+)
 from scripts import seed_demo as seed_demo_script
+from tests.shared.factories import (
+    create_candidate_session,
+    create_talent_partner,
+    create_trial,
+)
 
 
 class _SharedSessionContext:
@@ -72,9 +84,9 @@ def _session_maker(async_session):
 def _seed_args(
     *,
     reset_db: bool = False,
-    talent_partner_email: str = "talent.partner.demo@winoe.ai",
-    talent_partner_name: str = "Winoe Demo Talent Partner",
-    company_name: str = "Winoe Demo Company",
+    talent_partner_email: str = "demo@winoe.ai",
+    talent_partner_name: str = "Demo Partner",
+    company_name: str = "Acme",
     github_provider: str = "fake",
     allow_production_write: bool = False,
 ) -> SimpleNamespace:
@@ -216,34 +228,39 @@ async def test_seed_demo_cli_creates_complete_dataset_and_is_idempotent(
 
     assert company_count == 1
     assert user_count == 1
-    assert trial_count == 1
-    assert candidate_session_count == 2
-    assert submission_count == 10
-    assert report_count == 2
-    assert run_count == 2
-    assert day_score_count == 10
-    assert reviewer_count == 10
-    assert workspace_count == 2
-    assert workspace_group_count == 2
-    assert recording_count == 2
-    assert transcript_count == 2
-    assert audit_count == 4
+    assert trial_count == 3
+    assert candidate_session_count == 4
+    assert submission_count == 5
+    assert report_count == 1
+    assert run_count == 1
+    assert day_score_count == 5
+    assert reviewer_count == 5
+    assert workspace_count == 1
+    assert workspace_group_count == 1
+    assert recording_count == 1
+    assert transcript_count == 1
+    assert audit_count == 2
     assert citation_count and citation_count > 0
-    assert scenario_version_count == 1
-    assert task_count == 5
+    assert scenario_version_count == 3
+    assert task_count == 15
 
     talent_partner = await async_session.scalar(
-        select(User).where(User.email == "talent.partner.demo@winoe.ai")
+        select(User).where(User.email == "demo@winoe.ai")
     )
     assert talent_partner is not None
 
     trial = await async_session.scalar(
-        select(Trial).where(Trial.title == "YC Demo Backend Engineer Trial")
+        select(Trial).where(Trial.title == "Senior Frontend Engineer Trial")
     )
     assert trial is not None
     assert trial.scenario_template == ""
-    assert trial.status == "ready_for_review"
-    assert "from-scratch backend API" in trial.focus
+    assert trial.status == "completed"
+    assert "from-scratch product surface" in trial.focus
+    assert trial.company_context == {
+        "companyName": "Acme",
+        "preferredLanguageFramework": "TypeScript + React",
+        "demoMode": "yc-demo",
+    }
     assert isinstance(trial.company_rubric_json, dict)
     assert set(trial.company_rubric_json).issuperset(
         {
@@ -265,10 +282,14 @@ async def test_seed_demo_cli_creates_complete_dataset_and_is_idempotent(
         )
     )
 
-    brief_text = await async_session.scalar(select(ScenarioVersion.project_brief_md))
+    brief_text = await async_session.scalar(
+        select(ScenarioVersion.project_brief_md).where(
+            ScenarioVersion.trial_id == trial.id
+        )
+    )
     assert brief_text is not None
     assert "Project Brief" in brief_text
-    assert "from-scratch backend service" in brief_text
+    assert "from-scratch work Trial" in brief_text
     _assert_no_retired_terms(str(brief_text))
 
     candidate_sessions = (
@@ -281,20 +302,43 @@ async def test_seed_demo_cli_creates_complete_dataset_and_is_idempotent(
         .all()
     )
     assert [row.candidate_name for row in candidate_sessions] == [
-        "Avery Chen",
-        "Jordan Patel",
+        "Marcus Okonjo",
+        "Priya Patel",
+        "Sarah Chen",
+        "Nina Alvarez",
     ]
-    assert [row.status for row in candidate_sessions] == ["completed", "completed"]
-    assert [row.completed_at is not None for row in candidate_sessions] == [True, True]
-    assert [len(row.day_windows_json or []) for row in candidate_sessions] == [5, 5]
-    for row in candidate_sessions:
-        assert [day["status"] for day in row.day_windows_json or []] == [
-            "submitted",
-            "submitted",
-            "submitted",
-            "submitted",
-            "submitted",
-        ]
+    assert [row.status for row in candidate_sessions] == [
+        "not_started",
+        "not_started",
+        "completed",
+        "not_started",
+    ]
+    assert [row.completed_at is not None for row in candidate_sessions] == [
+        False,
+        False,
+        True,
+        False,
+    ]
+    assert [len(row.day_windows_json or []) for row in candidate_sessions] == [
+        0,
+        0,
+        5,
+        0,
+    ]
+    awaiting_trial = await async_session.scalar(
+        select(Trial).where(Trial.id == candidate_sessions[3].trial_id)
+    )
+    assert awaiting_trial is not None
+    assert awaiting_trial.status == "active_inviting"
+    assert candidate_sessions[3].status == "not_started"
+    assert candidate_sessions[3].completed_at is None
+    assert [day["status"] for day in candidate_sessions[2].day_windows_json or []] == [
+        "submitted",
+        "submitted",
+        "submitted",
+        "submitted",
+        "submitted",
+    ]
 
     submission_rows = (
         await async_session.execute(
@@ -303,7 +347,7 @@ async def test_seed_demo_cli_creates_complete_dataset_and_is_idempotent(
             .order_by(Submission.candidate_session_id, Task.day_index)
         )
     ).all()
-    assert len(submission_rows) == 10
+    assert len(submission_rows) == 5
     expected_artifacts = {
         1: "design_document",
         2: "implementation_kickoff",
@@ -343,72 +387,83 @@ async def test_seed_demo_cli_creates_complete_dataset_and_is_idempotent(
         .scalars()
         .all()
     )
-    assert len(recording_rows) == 2
-    assert len(transcript_rows) == 2
+    assert len(recording_rows) == 1
+    assert len(transcript_rows) == 1
 
     reports = (
         (await async_session.execute(select(WinoeReport).order_by(WinoeReport.id)))
         .scalars()
         .all()
     )
-    assert len(reports) == 2
+    assert len(reports) == 1
 
     first_report = await fetch_winoe_report(
         async_session,
-        candidate_session_id=candidate_sessions[0].id,
-        user=talent_partner,
-    )
-    second_report = await fetch_winoe_report(
-        async_session,
-        candidate_session_id=candidate_sessions[1].id,
+        candidate_session_id=candidate_sessions[2].id,
         user=talent_partner,
     )
 
     assert first_report["status"] == "ready"
-    assert second_report["status"] == "ready"
-    assert (
-        first_report["report"]["overallWinoeScore"]
-        > second_report["report"]["overallWinoeScore"]
+    report = first_report["report"]
+    assert isinstance(report["overallWinoeScore"], float)
+    assert len(report["dayScores"]) == 5
+    assert len(report["reviewerReports"]) == 5
+    assert len(report["dimensions"]) == 8
+    assert len(report["citations"]) == 16
+    assert report["verdictOneLiner"]
+    assert report["narrativeAssessment"]
+    assert report["cohortContext"]
+    assert [dimension["name"] for dimension in report["dimensions"]] == [
+        "Architecture & Design",
+        "Problem Understanding",
+        "Implementation Quality",
+        "Code Quality",
+        "Testing Discipline",
+        "Development Process",
+        "Communication",
+        "Reflection & Ownership",
+    ]
+    assert {citation["dimension"] for citation in report["citations"]} == {
+        "Architecture & Design",
+        "Problem Understanding",
+        "Implementation Quality",
+        "Code Quality",
+        "Testing Discipline",
+        "Development Process",
+        "Communication",
+        "Reflection & Ownership",
+    }
+    assert any(
+        isinstance(citation, dict) and citation.get("dimensionKey")
+        for day_score in report["dayScores"]
+        for citation in day_score["evidence"]
     )
-
-    for _candidate_session, payload in zip(
-        candidate_sessions, (first_report, second_report), strict=True
-    ):
-        report = payload["report"]
-        assert isinstance(report["overallWinoeScore"], float)
-        assert len(report["dayScores"]) == 5
-        assert len(report["reviewerReports"]) == 5
-        assert any(
-            isinstance(citation, dict) and citation.get("dimensionKey")
-            for day_score in report["dayScores"]
-            for citation in day_score["evidence"]
-        )
-        assert {
-            citation.get("dimensionKey")
-            for day_score in report["dayScores"]
-            for citation in day_score["evidence"]
-            if isinstance(citation, dict) and citation.get("dimensionKey")
-        }.issuperset(
-            {
-                "architectural_coherence",
-                "development_process",
-                "testing_discipline",
-                "communication_handoff_demo",
-                "reflection_self_awareness",
-            }
-        )
-        for reviewer_report in report["reviewerReports"]:
-            assert reviewer_report["dimensionalScores"]
-            assert len(reviewer_report["dimensionalScores"]) >= 3
-            assert reviewer_report["strengths"]
-            assert reviewer_report["concerns"]
-        await _assert_evidence_links(
-            reviewer_reports=report["reviewerReports"],
-        )
-
-    assert (
-        first_report["report"]["reviewerReports"][0]["strengths"]
-        != second_report["report"]["reviewerReports"][0]["strengths"]
+    assert {
+        citation.get("dimensionKey")
+        for day_score in report["dayScores"]
+        for citation in day_score["evidence"]
+        if isinstance(citation, dict) and citation.get("dimensionKey")
+    }.issuperset(
+        {
+            "architectural_coherence",
+            "scope_control",
+            "implementation_discipline",
+            "testing_discipline",
+            "code_quality",
+            "dependency_hygiene",
+            "communication_handoff_demo",
+            "evidence_trail_traceability",
+            "reflection_self_awareness",
+            "growth_orientation",
+        }
+    )
+    for reviewer_report in report["reviewerReports"]:
+        assert reviewer_report["dimensionalScores"]
+        assert len(reviewer_report["dimensionalScores"]) >= 8
+        assert reviewer_report["strengths"]
+        assert reviewer_report["concerns"]
+    await _assert_evidence_links(
+        reviewer_reports=report["reviewerReports"],
     )
 
     submission_texts = (
@@ -425,6 +480,66 @@ async def test_seed_demo_cli_creates_complete_dataset_and_is_idempotent(
 
 
 @pytest.mark.asyncio
+async def test_seed_demo_cli_accepts_custom_talent_partner_email_and_lists_trials(
+    async_client, async_session, monkeypatch
+):
+    custom_email = "winoetalentpartner@gmail.com"
+    monkeypatch.setattr(seed_demo_script, "_run_migrations", lambda _root: None)
+    monkeypatch.setattr(
+        seed_demo_script,
+        "async_session_maker",
+        _session_maker(async_session),
+    )
+    monkeypatch.setattr(
+        seed_demo_script, "_build_github_client", lambda _mode: FakeGithubClient()
+    )
+
+    await seed_demo_script._main_async(
+        _seed_args(
+            talent_partner_email=custom_email,
+            talent_partner_name="TalentPartner",
+            company_name="Acme",
+        )
+    )
+
+    talent_partner = await async_session.scalar(
+        select(User).where(User.email == custom_email)
+    )
+    assert talent_partner is not None
+    assert talent_partner.name == "TalentPartner"
+
+    allowed_statuses = {"not_started", "in_progress", "completed", "expired"}
+    active_trial = await async_session.scalar(
+        select(Trial).where(Trial.title == "Senior Backend Engineer Trial")
+    )
+    awaiting_trial = await async_session.scalar(
+        select(Trial).where(Trial.title == "Staff Engineer Trial")
+    )
+    assert active_trial is not None
+    assert awaiting_trial is not None
+
+    active_res = await async_client.get(
+        f"/api/trials/{active_trial.id}/candidates",
+        headers={"x-dev-user-email": custom_email},
+    )
+    awaiting_res = await async_client.get(
+        f"/api/trials/{awaiting_trial.id}/candidates",
+        headers={"x-dev-user-email": custom_email},
+    )
+    assert active_res.status_code == 200
+    assert awaiting_res.status_code == 200
+
+    active_rows = active_res.json()
+    awaiting_rows = awaiting_res.json()
+    assert active_rows
+    assert awaiting_rows
+    assert {row["status"] for row in active_rows} == {"not_started"}
+    assert {row["status"] for row in awaiting_rows} == {"not_started"}
+    assert all(row["status"] in allowed_statuses for row in active_rows)
+    assert all(row["status"] in allowed_statuses for row in awaiting_rows)
+
+
+@pytest.mark.asyncio
 async def test_demo_rerun_preserves_non_demo_rows(async_session, monkeypatch):
     monkeypatch.setattr(seed_demo_script, "_run_migrations", lambda _root: None)
     monkeypatch.setattr(
@@ -438,17 +553,67 @@ async def test_demo_rerun_preserves_non_demo_rows(async_session, monkeypatch):
 
     await seed_demo_script._main_async(_seed_args())
 
-    other_company = Company(name="Acme Research")
-    async_session.add(other_company)
-    await async_session.flush()
-    other_user = User(
-        name="Acme Operator",
+    other_partner = await create_talent_partner(
+        async_session,
         email="operator@acme.example",
-        role="talent_partner",
-        company_id=other_company.id,
-        password_hash="",
+        company_name="Acme Research",
+        name="Acme Operator",
     )
-    async_session.add(other_user)
+    other_trial, _other_tasks = await create_trial(
+        async_session,
+        created_by=other_partner,
+        title="Non Demo Trial",
+        role="Backend Engineer",
+        focus="Outside the demo scope",
+        company_context={"demoMode": "not-demo"},
+    )
+    now = datetime.now(UTC)
+    other_candidate_session = await create_candidate_session(
+        async_session,
+        trial=other_trial,
+        candidate_name="Other Candidate",
+        invite_email="other@example.com",
+        candidate_email="other@example.com",
+        status="completed",
+        completed_at=now,
+        started_at=now,
+    )
+    await create_run_with_day_scores(
+        async_session,
+        candidate_session_id=other_candidate_session.id,
+        scenario_version_id=other_candidate_session.scenario_version_id,
+        model_name="gpt-5.2",
+        model_version="gpt-5.2",
+        prompt_version="demo",
+        rubric_version="demo",
+        day2_checkpoint_sha="a" * 40,
+        day3_final_sha="b" * 40,
+        cutoff_commit_sha="b" * 40,
+        transcript_reference="transcript:other",
+        day_scores=[
+            {
+                "day_index": 1,
+                "score": 0.5,
+                "rubric_results_json": {"signal": 0.5},
+                "evidence_pointers_json": [],
+            }
+        ],
+        overall_winoe_score=0.5,
+        recommendation="positive_signal",
+        confidence=0.5,
+        generated_at=now,
+        raw_report_json={"overallWinoeScore": 0.5, "dimensions": [], "citations": []},
+        status="completed",
+        started_at=now,
+        completed_at=now,
+        commit=False,
+    )
+    await upsert_marker(
+        async_session,
+        candidate_session_id=other_candidate_session.id,
+        generated_at=now,
+        commit=False,
+    )
     await async_session.commit()
 
     await seed_demo_script._main_async(_seed_args())
@@ -462,14 +627,10 @@ async def test_demo_rerun_preserves_non_demo_rows(async_session, monkeypatch):
         .where(User.email == "operator@acme.example")
     )
     demo_company_count = await async_session.scalar(
-        select(func.count())
-        .select_from(Company)
-        .where(Company.name == "Winoe Demo Company")
+        select(func.count()).select_from(Company).where(Company.name == "Acme")
     )
     demo_user_count = await async_session.scalar(
-        select(func.count())
-        .select_from(User)
-        .where(User.email == "talent.partner.demo@winoe.ai")
+        select(func.count()).select_from(User).where(User.email == "demo@winoe.ai")
     )
 
     assert other_company_count == 1
@@ -600,10 +761,11 @@ def test_checklist_contains_seed_command_and_current_winoe_language():
     checklist_text = (
         Path(__file__).resolve().parents[3] / "YC_DEMO_CHECKLIST.md"
     ).read_text(encoding="utf-8")
-    assert (
-        "poetry run python -m scripts.seed_demo --github-provider fake --reset-db"
-        in checklist_text
-    )
+    assert "export WINOE_ENV=local" in checklist_text
+    assert "export WINOE_DEMO_MODE=true" in checklist_text
+    assert "./scripts/seed_demo.sh" in checklist_text
+    assert "http://localhost:3000/login" in checklist_text
+    assert "http://localhost:3000/talent-partner/trials" in checklist_text
     assert "Talent Partner" in checklist_text
     assert "Evidence Trail" in checklist_text
     assert "Winoe Report" in checklist_text
@@ -627,16 +789,11 @@ async def test_clear_demo_scope_nulls_trial_fk_before_scenario_version_delete(
         def all(self):
             return list(self._values)
 
-    class _FakeCompany:
-        id = 1
-
     class _RecordingSession:
         def __init__(self):
             self.calls = []
 
         async def scalar(self, stmt):
-            if "companies" in str(stmt):
-                return _FakeCompany()
             return None
 
         async def execute(self, stmt):
@@ -645,7 +802,7 @@ async def test_clear_demo_scope_nulls_trial_fk_before_scenario_version_delete(
             if "SELECT users.id" in stmt_text:
                 return _ScalarResult([2])
             if "SELECT trials.id" in stmt_text:
-                return _ScalarResult([11])
+                return _ScalarResult([SimpleNamespace(id=11, company_id=1)])
             if "SELECT candidate_sessions.id" in stmt_text:
                 return _ScalarResult([21])
             if "SELECT scenario_versions.id" in stmt_text:
@@ -669,9 +826,9 @@ async def test_clear_demo_scope_nulls_trial_fk_before_scenario_version_delete(
 
     session = _RecordingSession()
     config = SimpleNamespace(
-        trial_title="YC Demo Backend Engineer Trial",
-        company_name="Winoe Demo Company",
-        talent_partner_email="talent.partner.demo@winoe.ai",
+        trial_title="Senior Frontend Engineer Trial",
+        company_name="Acme",
+        talent_partner_email="demo@winoe.ai",
     )
     await _clear_demo_scope(session, config)
 

--- a/tests/integrations/github/test_integrations_github_fake_provider_client.py
+++ b/tests/integrations/github/test_integrations_github_fake_provider_client.py
@@ -108,8 +108,8 @@ async def test_provider_selection_honors_demo_mode_and_production_override(monke
         production_real_singleton,
     )
 
-    client = get_github_provisioning_client()
-    assert client is real_marker
+    with pytest.raises(RuntimeError, match="forbidden in production"):
+        get_github_provisioning_client()
     assert fake_called["count"] == 0
 
 

--- a/tests/scripts/test_check_no_legacy_demo_refs_sh.py
+++ b/tests/scripts/test_check_no_legacy_demo_refs_sh.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import shutil
 import subprocess
 from pathlib import Path
 
@@ -51,6 +53,16 @@ def _seed_minimal_paths(root: Path) -> None:
     )
 
 
+def _path_without_rg(root: Path) -> str:
+    bin_dir = root / "bin"
+    bin_dir.mkdir()
+    for executable in ("find", "grep"):
+        source = shutil.which(executable)
+        assert source is not None
+        os.symlink(source, bin_dir / executable)
+    return str(bin_dir)
+
+
 def test_script_allows_internal_prompt_guardrails(tmp_path):
     _seed_minimal_paths(tmp_path)
 
@@ -83,6 +95,27 @@ def test_script_flags_legacy_strings_in_prompts_directory(tmp_path):
     )
 
     assert result.returncode != 0
+    assert "Legacy demo references found" in result.stderr
+
+
+def test_script_flags_legacy_strings_when_rg_is_unavailable(tmp_path):
+    _seed_minimal_paths(tmp_path)
+    _write(
+        tmp_path / "prompts/legacy.md",
+        "Internal notes that still mention Tenon platform.\n",
+    )
+
+    result = subprocess.run(
+        ["/bin/bash", str(SCRIPT)],
+        cwd=tmp_path,
+        env={**os.environ, "PATH": _path_without_rg(tmp_path)},
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "rg: command not found" not in result.stderr
     assert "Legacy demo references found" in result.stderr
 
 

--- a/tests/scripts/test_check_no_legacy_demo_refs_sh.py
+++ b/tests/scripts/test_check_no_legacy_demo_refs_sh.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+SCRIPT = (
+    Path(__file__).resolve().parents[2] / "scripts" / "check_no_legacy_demo_refs.sh"
+)
+
+
+def _write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def _seed_minimal_paths(root: Path) -> None:
+    _write(root / "app/demo/ok.txt", "Winoe demo content only.\n")
+    _write(root / "fixtures/ok.txt", "Demo fixture content.\n")
+    _write(
+        root / "scripts/check_no_legacy_demo_refs.sh",
+        "#!/usr/bin/env bash\n# legacy example: tenon-template\n",
+    )
+    _write(
+        root / "tests/scripts/test_check_no_legacy_demo_refs_sh.py",
+        "# legacy example: Tenon platform\n",
+    )
+    _write(root / "tests/data/ok.txt", "Demo test data.\n")
+    _write(root / "tests/demo/ok.txt", "Demo test content.\n")
+    _write(root / "YC_DEMO_CHECKLIST.md", "YC demo checklist.\n")
+    _write(
+        root / "app/ai/prompt_assets/v4/winoe_soul.md",
+        "\n".join(
+            [
+                "## Words I Avoid",
+                "- Tenon",
+                "- recruiter",
+                "- template catalog",
+                "## Governance Note",
+                "- These terms are internal examples only.",
+            ]
+        ),
+    )
+    _write(
+        root / "app/ai/prompt_assets/v4/winoe_synthesis.md",
+        "\n".join(
+            [
+                "Rules:",
+                "- The terms may appear as internal do-not-use examples only.",
+            ]
+        ),
+    )
+
+
+def test_script_allows_internal_prompt_guardrails(tmp_path):
+    _seed_minimal_paths(tmp_path)
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "Scanning demo-visible paths" in result.stdout
+    assert "prompt guardrail files" in result.stdout
+
+
+def test_script_flags_legacy_strings_in_prompts_directory(tmp_path):
+    _seed_minimal_paths(tmp_path)
+    _write(
+        tmp_path / "prompts/legacy.md",
+        "Internal notes that still mention Tenon platform.\n",
+    )
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "Legacy demo references found" in result.stderr
+
+
+def test_script_flags_legacy_strings_in_arbitrary_future_scripts(tmp_path):
+    _seed_minimal_paths(tmp_path)
+    _write(
+        tmp_path / "scripts/some_future_demo_helper.py",
+        "demo_url = 'https://example.invalid/@tenon/tenon-hire-dev'\n",
+    )
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode != 0
+    assert "Legacy demo references found" in result.stderr
+
+
+def test_script_excludes_itself_and_guard_test_file_from_broad_scan(tmp_path):
+    _seed_minimal_paths(tmp_path)
+
+    result = subprocess.run(
+        ["bash", str(SCRIPT)],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "No legacy demo references found" in result.stdout

--- a/tests/trials/routes/test_trials_candidates_list_populated_routes.py
+++ b/tests/trials/routes/test_trials_candidates_list_populated_routes.py
@@ -77,3 +77,59 @@ async def test_trial_with_multiple_sessions_returns_all_and_has_report(
     assert by_id[cs2.id]["candidateName"] == "Bob"
     assert by_id[cs2.id]["status"] == "completed"
     assert by_id[cs2.id]["hasWinoeReport"] is True
+
+
+@pytest.mark.asyncio
+async def test_trial_candidates_list_uses_schema_valid_statuses(
+    async_client, async_session
+):
+    user, company = await seed_talent_partner(
+        async_session,
+        email="r3@acme.com",
+        company_name="Acme3",
+        name="TalentPartner Three",
+    )
+    sim = await create_trial(
+        async_session, user_id=user.id, company_id=company.id, title="Schema Valid Sim"
+    )
+    scenario = await attach_active_scenario(async_session, sim)
+
+    invited = CandidateSession(
+        trial_id=sim.id,
+        scenario_version_id=scenario.id,
+        candidate_name="Invited Candidate",
+        invite_email="invited@example.com",
+        token="tok-invited",
+        status="not_started",
+        invite_email_status="sent",
+        invite_email_sent_at=datetime.now(UTC),
+        expires_at=None,
+    )
+    in_progress = CandidateSession(
+        trial_id=sim.id,
+        scenario_version_id=scenario.id,
+        candidate_name="Working Candidate",
+        invite_email="working@example.com",
+        token="tok-working",
+        status="in_progress",
+        started_at=datetime.now(UTC),
+        expires_at=None,
+    )
+    async_session.add_all([invited, in_progress])
+    await async_session.commit()
+
+    resp = await async_client.get(
+        f"/api/trials/{sim.id}/candidates",
+        headers={"x-dev-user-email": user.email},
+    )
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert {row["status"] for row in data} <= {
+        "not_started",
+        "in_progress",
+        "completed",
+        "expired",
+    }
+    invited_row = next(row for row in data if row["candidateSessionId"] == invited.id)
+    assert invited_row["status"] == "not_started"
+    assert invited_row["inviteEmailStatus"] == "sent"

--- a/tests/trials/services/test_trials_lifecycle_approve_service_unit.py
+++ b/tests/trials/services/test_trials_lifecycle_approve_service_unit.py
@@ -71,6 +71,24 @@ async def test_approve_trial_rejects_generating():
 
 
 @pytest.mark.asyncio
+async def test_approve_trial_rejects_terminated():
+    db = AsyncMock()
+    trial = MagicMock()
+    trial.status = "terminated"
+
+    with patch.object(
+        approve_mod,
+        "require_owner_for_lifecycle",
+        new_callable=AsyncMock,
+        return_value=trial,
+    ), pytest.raises(ApiError) as exc:
+        await approve_mod.approve_trial_for_inviting(db, trial_id=1, actor_user_id=7)
+
+    assert exc.value.error_code == "TRIAL_TERMINATED"
+    db.commit.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_approve_trial_rejects_wrong_status():
     db = AsyncMock()
     trial = MagicMock()
@@ -170,6 +188,14 @@ async def test_approve_trial_rejects_empty_rubric_dict():
     ), pytest.raises(ApiError) as exc:
         await approve_mod.approve_trial_for_inviting(db, trial_id=1, actor_user_id=7)
     assert exc.value.error_code == "TRIAL_RUBRIC_MISSING"
+
+
+def test_approve_trial_helper_rejects_non_string_brief_and_invalid_rubric():
+    scenario = _scenario(brief="Brief.", rubric="invalid")
+    scenario.project_brief_md = 123
+
+    assert approve_mod._brief_present(scenario=scenario) is False
+    assert approve_mod._rubric_present(scenario) is False
 
 
 @pytest.mark.asyncio

--- a/tests/trials/services/test_trials_scenario_generation_generation_service.py
+++ b/tests/trials/services/test_trials_scenario_generation_generation_service.py
@@ -23,6 +23,9 @@ from app.trials.services import scenario_generation
 from app.trials.services import (
     trials_services_trials_scenario_generation_runtime_service as scenario_generation_runtime,
 )
+from app.trials.services.trials_services_trials_scenario_generation_story_service import (
+    build_project_brief_markdown,
+)
 from tests.shared.factories import build_trial_agent_snapshots
 
 
@@ -196,6 +199,20 @@ def test_project_brief_stays_open_ended_for_context_changes() -> None:
     assert "codespace" not in payload.project_brief_md.lower()
     assert "python" in payload.project_brief_md.lower()
     assert "template" not in payload.project_brief_md.lower()
+
+
+def test_project_brief_reads_preferred_stack_from_company_context() -> None:
+    brief = build_project_brief_markdown(
+        role="Backend Engineer",
+        focus="billing operations",
+        company_context={
+            "name": "Acme",
+            "preferredLanguageFramework": "Go + HTMX",
+        },
+    )
+
+    assert "Acme is trying to improve billing operations." in brief
+    assert "Preferred language/framework context: Go + HTMX." in brief
 
 
 def test_deterministic_template_generation_uses_demo_and_reflection_language() -> None:


### PR DESCRIPTION
## Summary
- Added fake GitHub provider support for demo mode so seeded demo environments do not make real GitHub network calls.
- Wired `WINOE_DEMO_MODE` / `DEMO_MODE` selection behavior so demo mode is explicit and production-safe.
- Added a hard production guard that rejects demo mode when `WINOE_ENV=production`.
- Built the one-command demo seed flow and made the seeded YC demo dataset deterministic and idempotent.
- Seeded the Sarah Chen completed Trial with a Winoe Report, Evidence Trail, and Day 1-5 artifacts.
- Added legacy demo-reference cleanup guardrails and a documented YC demo checklist.
- Cleaned up the migration graph so the fake placeholder migration is removed and the canonical Alembic head remains intact.

## Backend Change List
- Fake GitHub provider behavior:
  - deterministic fake repo, Codespace, workflow, and artifact behavior
  - no real GitHub network calls in demo mode
  - fake/demo evidence links used for seeded demo content
- Demo mode config:
  - `WINOE_DEMO_MODE=true`
  - `WINOE_ENV=production` rejection
- Seed script:
  - `scripts/seed_demo.sh`
  - custom env vars:
    - `DEMO_TALENT_PARTNER_EMAIL`
    - `DEMO_TALENT_PARTNER_NAME`
    - `DEMO_COMPANY_NAME`
  - idempotent seeded dataset
- Demo dataset:
  - 1 Talent Partner
  - 3 Trials
  - 4 candidate sessions
  - Sarah Chen completed Trial
  - 5 submissions
  - 1 Winoe Report
  - 1 EvaluationRun
- Trial A / Trial C candidate list:
  - invited / not-yet-started seeded candidates use schema-valid `not_started`
- Legacy cleanup:
  - `scripts/check_no_legacy_demo_refs.sh`
  - CI guard
- Demo runbook:
  - `YC_DEMO_CHECKLIST.md`
- Migration graph:
  - fake placeholder migration removed
  - canonical Alembic head preserved
  - stale local DB recovery documented

## Verification
```bash
bash -n scripts/seed_demo.sh
bash -n scripts/check_no_legacy_demo_refs.sh
bash scripts/check_no_legacy_demo_refs.sh
poetry run pytest -q tests/demo/services/test_demo_yc_seed_service.py tests/trials/routes/test_trials_candidates_list_populated_routes.py -o addopts=''
./precommit.sh
```

Final seed command:

```bash
WINOE_ENV=local \
WINOE_DEMO_MODE=true \
DEMO_TALENT_PARTNER_EMAIL="winoetalentpartner@gmail.com" \
DEMO_TALENT_PARTNER_NAME="TalentPartner" \
DEMO_COMPANY_NAME="Acme" \
./scripts/seed_demo.sh
```

Final outcome:
- exit code `0`
- fake GitHub provider used
- seeded dataset verified
- asyncpg / SQLAlchemy shutdown warning is non-blocking if it appears after success

## Manual QA Evidence
- `/health` passed.
- `/ready` passed and GitHub was skipped / fake-safe in demo mode.
- dashboard showed 3 Trials.
- Trial A candidate list worked.
- Trial C candidate list worked.
- Sarah Chen Winoe Report data seeded correctly.
- legacy UI sweep passed.

## Known Warnings / Follow-ups
- Local stale Alembic stamp recovery may require the documented reset path.
- Seed teardown warning should be cleaned up later if desired.
- PDF export is frontend-owned and currently behaves as print mode.

## Final QA Result

`Task 10 FINAL QA PASS — ready to finish / raise PRs.`

Final verification confirmed:
- normal seed command exits 0 after documented reset repair path
- seeded data is idempotent and stable
- fake GitHub provider is used in demo mode
- production demo mode is rejected
- dashboard shows 3 Trials
- Trial A and Trial C candidate lists work
- Sarah Chen Winoe Report renders with Winoe Score 78 and exactly 8 dimensions
- Evidence Trail and Day 1-5 artifacts are accessible
- legacy guard passes
- backend precommit passes
- frontend precommit passes
