### PR TITLE
Task 3: Harden AI pipeline integrity, citation resolution, validator enforcement, and demo QA seeds

### DIFF
--- a/app/ai/__init__.py
+++ b/app/ai/__init__.py
@@ -1,5 +1,14 @@
 """Shared AI runtime helpers for prompt packs, overrides, and structured outputs."""
 
+from .ai_model_preflight_service import (
+    AIModelMatrixRow,
+    AIModelPreflightResult,
+    AIModelPreflightTarget,
+    build_ai_model_matrix_rows,
+    build_ai_model_preflight_targets,
+    verify_ai_model_endpoint,
+    verify_ai_model_preflight,
+)
 from .ai_output_models import (
     AggregatedWinoeReportOutput,
     DayReviewerOutput,
@@ -59,6 +68,9 @@ __all__ = [
     "AIFeatureConfig",
     "AI_AGENT_KEYS",
     "AI_PROMPT_OVERRIDE_KEYS",
+    "AIModelMatrixRow",
+    "AIModelPreflightResult",
+    "AIModelPreflightTarget",
     "AI_RUNTIME_MODE_DEMO",
     "AI_RUNTIME_MODE_REAL",
     "AI_RUNTIME_MODE_TEST",
@@ -74,6 +86,8 @@ __all__ = [
     "WinoeSynthesisDimension",
     "allow_demo_or_test_mode",
     "build_ai_policy_snapshot",
+    "build_ai_model_matrix_rows",
+    "build_ai_model_preflight_targets",
     "build_prompt_pack_entry",
     "build_required_snapshot_prompt",
     "build_snapshot_prompt",
@@ -100,4 +114,6 @@ __all__ = [
     "resolve_runtime_mode",
     "resolve_scenario_generation_config",
     "resolve_transcription_config",
+    "verify_ai_model_endpoint",
+    "verify_ai_model_preflight",
 ]

--- a/app/ai/ai_model_preflight_service.py
+++ b/app/ai/ai_model_preflight_service.py
@@ -1,0 +1,548 @@
+"""Model matrix and preflight checks for Winoe AI demo safety."""
+
+from __future__ import annotations
+
+import io
+import json
+import tempfile
+import wave
+from dataclasses import asdict, dataclass
+from typing import Literal
+
+from pydantic import BaseModel
+
+from app.ai.ai_prompt_pack_service import build_prompt_pack_entry
+from app.ai.ai_provider_clients_service import (
+    AIProviderExecutionError,
+    api_key_configured,
+    call_anthropic_json,
+    call_openai_json_schema,
+    openai_api_error_summary,
+)
+from app.config import settings
+
+AIModelCapability = Literal["structured_json", "transcription"]
+
+
+@dataclass(frozen=True, slots=True)
+class AIModelMatrixRow:
+    """Describe one feature-level primary or fallback model binding."""
+
+    feature: str
+    role: str
+    capability: AIModelCapability
+    provider: str
+    model: str
+    prompt_version: str
+    configured_from: str
+
+
+@dataclass(frozen=True, slots=True)
+class AIModelPreflightTarget:
+    """Describe one distinct provider/model pair to verify."""
+
+    capability: AIModelCapability
+    provider: str
+    model: str
+    used_by: tuple[AIModelMatrixRow, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class AIModelPreflightResult:
+    """Describe one live model reachability check."""
+
+    capability: AIModelCapability
+    provider: str
+    model: str
+    reachable: bool
+    used_by: tuple[str, ...]
+    error: str | None = None
+
+
+class _ModelPreflightProbeOutput(BaseModel):
+    ok: bool
+
+
+def _settings_path(*parts: str) -> str:
+    if len(parts) == 2:
+        return f"app/config/config_settings_fields_config.py:L{parts[0]}-L{parts[1]}"
+    return "app/config/config_settings_fields_config.py:" + ",".join(parts)
+
+
+def _require_non_blank(*, feature: str, role: str, value: str, field_name: str) -> str:
+    normalized = value.strip()
+    if normalized:
+        return normalized
+    raise AIProviderExecutionError(
+        f"missing_model_config:{feature}:{role}:{field_name}"
+    )
+
+
+def _require_supported_fallback_provider(
+    *,
+    feature: str,
+    field_name: str,
+    value: str,
+    expected_provider: str,
+) -> str:
+    normalized = value.strip().lower()
+    expected = expected_provider.strip().lower()
+    if normalized == expected:
+        return normalized
+    raise AIProviderExecutionError(
+        f"unsupported_fallback_provider:{feature}:{field_name}:{value}:{expected_provider}"
+    )
+
+
+def build_ai_model_matrix_rows() -> list[AIModelMatrixRow]:
+    """Return the pinned primary/fallback model matrix used in the demo."""
+    prestart_prompt_version = build_prompt_pack_entry("prestart").prompt_version
+    day1_prompt_version = build_prompt_pack_entry("designDocReviewer").prompt_version
+    day23_prompt_version = build_prompt_pack_entry(
+        "codeImplementationReviewer"
+    ).prompt_version
+    day4_prompt_version = build_prompt_pack_entry(
+        "demoPresentationReviewer"
+    ).prompt_version
+    day5_prompt_version = build_prompt_pack_entry(
+        "reflectionEssayReviewer"
+    ).prompt_version
+    winoe_prompt_version = build_prompt_pack_entry("winoeReport").prompt_version
+
+    return [
+        AIModelMatrixRow(
+            feature="Prestart / Project Brief Creator",
+            role="primary",
+            capability="structured_json",
+            provider=_require_non_blank(
+                feature="Prestart / Project Brief Creator",
+                role="primary",
+                field_name="SCENARIO_GENERATION_PROVIDER",
+                value=str(settings.SCENARIO_GENERATION_PROVIDER or ""),
+            ).lower(),
+            model=_require_non_blank(
+                feature="Prestart / Project Brief Creator",
+                role="primary",
+                field_name="SCENARIO_GENERATION_MODEL",
+                value=str(settings.SCENARIO_GENERATION_MODEL or ""),
+            ),
+            prompt_version=prestart_prompt_version,
+            configured_from=_settings_path("93", "96"),
+        ),
+        AIModelMatrixRow(
+            feature="Prestart / Project Brief Creator",
+            role="fallback",
+            capability="structured_json",
+            provider=_require_supported_fallback_provider(
+                feature="Prestart / Project Brief Creator",
+                field_name="SCENARIO_GENERATION_FALLBACK_PROVIDER",
+                value=str(settings.SCENARIO_GENERATION_FALLBACK_PROVIDER or ""),
+                expected_provider="openai",
+            ).lower(),
+            model=_require_non_blank(
+                feature="Prestart / Project Brief Creator",
+                role="fallback",
+                field_name="SCENARIO_GENERATION_FALLBACK_MODEL",
+                value=str(settings.SCENARIO_GENERATION_FALLBACK_MODEL or ""),
+            ),
+            prompt_version=prestart_prompt_version,
+            configured_from="app/integrations/scenario_generation/anthropic_provider_client.py",
+        ),
+        AIModelMatrixRow(
+            feature="Design Doc Reviewer",
+            role="primary",
+            capability="structured_json",
+            provider=_require_non_blank(
+                feature="Design Doc Reviewer",
+                role="primary",
+                field_name="WINOE_REPORT_DAY1_PROVIDER",
+                value=str(settings.WINOE_REPORT_DAY1_PROVIDER or ""),
+            ).lower(),
+            model=_require_non_blank(
+                feature="Design Doc Reviewer",
+                role="primary",
+                field_name="WINOE_REPORT_DAY1_MODEL",
+                value=str(settings.WINOE_REPORT_DAY1_MODEL or ""),
+            ),
+            prompt_version=day1_prompt_version,
+            configured_from=_settings_path("98", "101"),
+        ),
+        AIModelMatrixRow(
+            feature="Design Doc Reviewer",
+            role="fallback",
+            capability="structured_json",
+            provider=_require_supported_fallback_provider(
+                feature="Design Doc Reviewer",
+                field_name="WINOE_REPORT_DAY1_FALLBACK_PROVIDER",
+                value=str(settings.WINOE_REPORT_DAY1_FALLBACK_PROVIDER or ""),
+                expected_provider="openai",
+            ).lower(),
+            model=_require_non_blank(
+                feature="Design Doc Reviewer",
+                role="fallback",
+                field_name="WINOE_REPORT_DAY1_FALLBACK_MODEL",
+                value=str(settings.WINOE_REPORT_DAY1_FALLBACK_MODEL or ""),
+            ),
+            prompt_version=day1_prompt_version,
+            configured_from="app/integrations/winoe_report_review/anthropic_provider_client.py",
+        ),
+        AIModelMatrixRow(
+            feature="Code Implementation Reviewer",
+            role="primary",
+            capability="structured_json",
+            provider=_require_non_blank(
+                feature="Code Implementation Reviewer",
+                role="primary",
+                field_name="WINOE_REPORT_DAY23_PROVIDER",
+                value=str(settings.WINOE_REPORT_DAY23_PROVIDER or ""),
+            ).lower(),
+            model=_require_non_blank(
+                feature="Code Implementation Reviewer",
+                role="primary",
+                field_name="WINOE_REPORT_DAY23_MODEL",
+                value=str(settings.WINOE_REPORT_DAY23_MODEL or ""),
+            ),
+            prompt_version=day23_prompt_version,
+            configured_from=_settings_path("103", "106"),
+        ),
+        AIModelMatrixRow(
+            feature="Code Implementation Reviewer",
+            role="fallback",
+            capability="structured_json",
+            provider=_require_supported_fallback_provider(
+                feature="Code Implementation Reviewer",
+                field_name="WINOE_REPORT_DAY23_FALLBACK_PROVIDER",
+                value=str(settings.WINOE_REPORT_DAY23_FALLBACK_PROVIDER or ""),
+                expected_provider="anthropic",
+            ).lower(),
+            model=_require_non_blank(
+                feature="Code Implementation Reviewer",
+                role="fallback",
+                field_name="WINOE_REPORT_DAY23_FALLBACK_MODEL",
+                value=str(settings.WINOE_REPORT_DAY23_FALLBACK_MODEL or ""),
+            ),
+            prompt_version=day23_prompt_version,
+            configured_from="app/integrations/winoe_report_review/openai_provider_client.py",
+        ),
+        AIModelMatrixRow(
+            feature="Demo Presentation Reviewer",
+            role="primary",
+            capability="structured_json",
+            provider=_require_non_blank(
+                feature="Demo Presentation Reviewer",
+                role="primary",
+                field_name="WINOE_REPORT_DAY4_PROVIDER",
+                value=str(settings.WINOE_REPORT_DAY4_PROVIDER or ""),
+            ).lower(),
+            model=_require_non_blank(
+                feature="Demo Presentation Reviewer",
+                role="primary",
+                field_name="WINOE_REPORT_DAY4_MODEL",
+                value=str(settings.WINOE_REPORT_DAY4_MODEL or ""),
+            ),
+            prompt_version=day4_prompt_version,
+            configured_from=_settings_path("108", "111"),
+        ),
+        AIModelMatrixRow(
+            feature="Demo Presentation Reviewer",
+            role="fallback",
+            capability="structured_json",
+            provider=_require_supported_fallback_provider(
+                feature="Demo Presentation Reviewer",
+                field_name="WINOE_REPORT_DAY4_FALLBACK_PROVIDER",
+                value=str(settings.WINOE_REPORT_DAY4_FALLBACK_PROVIDER or ""),
+                expected_provider="openai",
+            ).lower(),
+            model=_require_non_blank(
+                feature="Demo Presentation Reviewer",
+                role="fallback",
+                field_name="WINOE_REPORT_DAY4_FALLBACK_MODEL",
+                value=str(settings.WINOE_REPORT_DAY4_FALLBACK_MODEL or ""),
+            ),
+            prompt_version=day4_prompt_version,
+            configured_from="app/integrations/winoe_report_review/anthropic_provider_client.py",
+        ),
+        AIModelMatrixRow(
+            feature="Reflection Essay Reviewer",
+            role="primary",
+            capability="structured_json",
+            provider=_require_non_blank(
+                feature="Reflection Essay Reviewer",
+                role="primary",
+                field_name="WINOE_REPORT_DAY5_PROVIDER",
+                value=str(settings.WINOE_REPORT_DAY5_PROVIDER or ""),
+            ).lower(),
+            model=_require_non_blank(
+                feature="Reflection Essay Reviewer",
+                role="primary",
+                field_name="WINOE_REPORT_DAY5_MODEL",
+                value=str(settings.WINOE_REPORT_DAY5_MODEL or ""),
+            ),
+            prompt_version=day5_prompt_version,
+            configured_from=_settings_path("113", "116"),
+        ),
+        AIModelMatrixRow(
+            feature="Reflection Essay Reviewer",
+            role="fallback",
+            capability="structured_json",
+            provider=_require_supported_fallback_provider(
+                feature="Reflection Essay Reviewer",
+                field_name="WINOE_REPORT_DAY5_FALLBACK_PROVIDER",
+                value=str(settings.WINOE_REPORT_DAY5_FALLBACK_PROVIDER or ""),
+                expected_provider="openai",
+            ).lower(),
+            model=_require_non_blank(
+                feature="Reflection Essay Reviewer",
+                role="fallback",
+                field_name="WINOE_REPORT_DAY5_FALLBACK_MODEL",
+                value=str(settings.WINOE_REPORT_DAY5_FALLBACK_MODEL or ""),
+            ),
+            prompt_version=day5_prompt_version,
+            configured_from="app/integrations/winoe_report_review/anthropic_provider_client.py",
+        ),
+        AIModelMatrixRow(
+            feature="Winoe, the Talent Intelligence Agent",
+            role="primary",
+            capability="structured_json",
+            provider=_require_non_blank(
+                feature="Winoe, the Talent Intelligence Agent",
+                role="primary",
+                field_name="WINOE_REPORT_AGGREGATOR_PROVIDER",
+                value=str(settings.WINOE_REPORT_AGGREGATOR_PROVIDER or ""),
+            ).lower(),
+            model=_require_non_blank(
+                feature="Winoe, the Talent Intelligence Agent",
+                role="primary",
+                field_name="WINOE_REPORT_AGGREGATOR_MODEL",
+                value=str(settings.WINOE_REPORT_AGGREGATOR_MODEL or ""),
+            ),
+            prompt_version=winoe_prompt_version,
+            configured_from=_settings_path("118", "121"),
+        ),
+        AIModelMatrixRow(
+            feature="Winoe, the Talent Intelligence Agent",
+            role="fallback",
+            capability="structured_json",
+            provider=_require_supported_fallback_provider(
+                feature="Winoe, the Talent Intelligence Agent",
+                field_name="WINOE_REPORT_AGGREGATOR_FALLBACK_PROVIDER",
+                value=str(settings.WINOE_REPORT_AGGREGATOR_FALLBACK_PROVIDER or ""),
+                expected_provider="anthropic",
+            ).lower(),
+            model=_require_non_blank(
+                feature="Winoe, the Talent Intelligence Agent",
+                role="fallback",
+                field_name="WINOE_REPORT_AGGREGATOR_FALLBACK_MODEL",
+                value=str(settings.WINOE_REPORT_AGGREGATOR_FALLBACK_MODEL or ""),
+            ),
+            prompt_version=winoe_prompt_version,
+            configured_from="app/integrations/winoe_report_review/openai_provider_client.py",
+        ),
+        AIModelMatrixRow(
+            feature="Transcription",
+            role="primary",
+            capability="transcription",
+            provider=_require_non_blank(
+                feature="Transcription",
+                role="primary",
+                field_name="TRANSCRIPTION_PROVIDER",
+                value=str(settings.TRANSCRIPTION_PROVIDER or ""),
+            ).lower(),
+            model=_require_non_blank(
+                feature="Transcription",
+                role="primary",
+                field_name="TRANSCRIPTION_MODEL",
+                value=str(settings.TRANSCRIPTION_MODEL or ""),
+            ),
+            prompt_version="n/a",
+            configured_from=_settings_path("123", "126"),
+        ),
+    ]
+
+
+def build_ai_model_preflight_targets() -> list[AIModelPreflightTarget]:
+    """Collapse the matrix into distinct provider/model checks."""
+    rows = build_ai_model_matrix_rows()
+    grouped: dict[tuple[AIModelCapability, str, str], list[AIModelMatrixRow]] = {}
+    for row in rows:
+        key = (row.capability, row.provider, row.model)
+        grouped.setdefault(key, []).append(row)
+    return [
+        AIModelPreflightTarget(
+            capability=capability,
+            provider=provider,
+            model=model,
+            used_by=tuple(used_by),
+        )
+        for (capability, provider, model), used_by in sorted(grouped.items())
+        if provider and model
+    ]
+
+
+def _build_silent_wav_bytes(*, duration_seconds: float = 0.25) -> bytes:
+    """Create a tiny deterministic silent WAV fixture for transcription preflight."""
+    sample_rate = 16_000
+    frame_count = max(1, int(sample_rate * duration_seconds))
+    buffer = io.BytesIO()
+    with wave.open(buffer, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(b"\x00\x00" * frame_count)
+    return buffer.getvalue()
+
+
+def _openai_model_reachable(*, model: str) -> None:
+    if not api_key_configured(settings.OPENAI_API_KEY):
+        raise AIProviderExecutionError("missing_openai_api_key")
+    call_openai_json_schema(
+        api_key=settings.OPENAI_API_KEY,
+        model=model,
+        system_prompt="Return a JSON object that confirms structured output support.",
+        user_prompt='Respond with {"ok": true}.',
+        response_model=_ModelPreflightProbeOutput,
+        timeout_seconds=20,
+        max_retries=0,
+        max_output_tokens=16,
+    )
+
+
+def _openai_transcription_model_reachable(*, model: str) -> None:
+    if not api_key_configured(settings.OPENAI_API_KEY):
+        raise AIProviderExecutionError("missing_openai_api_key")
+    try:
+        from openai import OpenAI
+    except ImportError as exc:  # pragma: no cover - depends on environment
+        raise AIProviderExecutionError("openai_sdk_not_installed") from exc
+
+    client = OpenAI(
+        api_key=settings.OPENAI_API_KEY,
+        timeout=20,
+        max_retries=0,
+    )
+    audio_bytes = _build_silent_wav_bytes()
+    with tempfile.NamedTemporaryFile(suffix=".wav") as handle:
+        handle.write(audio_bytes)
+        handle.flush()
+        try:
+            with open(handle.name, "rb") as audio_file:
+                client.audio.transcriptions.create(
+                    file=audio_file,
+                    model=model,
+                    response_format="json",
+                )
+        except Exception as exc:  # pragma: no cover - exercised by negative tests
+            raise AIProviderExecutionError(
+                f"openai_transcription_failed:{openai_api_error_summary(exc)}"
+            ) from exc
+
+
+def _anthropic_model_reachable(*, model: str) -> None:
+    if not api_key_configured(settings.ANTHROPIC_API_KEY):
+        raise AIProviderExecutionError("missing_anthropic_api_key")
+    call_anthropic_json(
+        api_key=settings.ANTHROPIC_API_KEY,
+        model=model,
+        system_prompt="Return a JSON object that confirms message-based structured output support.",
+        user_prompt='Respond with {"ok": true}.',
+        response_model=_ModelPreflightProbeOutput,
+        timeout_seconds=20,
+        max_retries=0,
+        max_tokens=8,
+    )
+
+
+def verify_ai_model_endpoint(*, provider: str, model: str) -> None:
+    """Raise if one configured endpoint is not reachable."""
+    normalized = (provider or "").strip().lower()
+    if normalized == "openai":
+        target = next(
+            (
+                row
+                for row in build_ai_model_matrix_rows()
+                if row.provider == normalized and row.model == model
+            ),
+            None,
+        )
+        if target is None:
+            raise AIProviderExecutionError(f"unknown_model_target:{provider}:{model}")
+        if target.capability == "structured_json":
+            _openai_model_reachable(model=model)
+            return
+        if target.capability == "transcription":
+            _openai_transcription_model_reachable(model=model)
+            return
+        raise AIProviderExecutionError(
+            f"unsupported_probe_capability:{provider}:{model}:{target.capability}"
+        )
+        return
+    if normalized == "anthropic":
+        _anthropic_model_reachable(model=model)
+        return
+    raise AIProviderExecutionError(f"unsupported_provider:{provider}")
+
+
+def verify_ai_model_preflight() -> list[AIModelPreflightResult]:
+    """Verify every distinct configured endpoint and return the results."""
+    results: list[AIModelPreflightResult] = []
+    failures: list[str] = []
+    for target in build_ai_model_preflight_targets():
+        used_by = tuple(
+            f"{row.feature}:{row.role}:{row.prompt_version}" for row in target.used_by
+        )
+        try:
+            verify_ai_model_endpoint(provider=target.provider, model=target.model)
+        except Exception as exc:  # pragma: no cover - exercised by negative tests
+            message = (
+                f"{target.provider}:{target.model}:{target.capability}:"
+                f"{type(exc).__name__}"
+            )
+            failure_detail = str(exc).strip()
+            if failure_detail:
+                message = f"{message}:{failure_detail}"
+            failures.append(message)
+            results.append(
+                AIModelPreflightResult(
+                    capability=target.capability,
+                    provider=target.provider,
+                    model=target.model,
+                    reachable=False,
+                    used_by=used_by,
+                    error=message,
+                )
+            )
+        else:
+            results.append(
+                AIModelPreflightResult(
+                    capability=target.capability,
+                    provider=target.provider,
+                    model=target.model,
+                    reachable=True,
+                    used_by=used_by,
+                )
+            )
+    if failures:
+        raise RuntimeError(
+            "model_preflight_failed\n"
+            + json.dumps(
+                {
+                    "failures": failures,
+                    "results": [asdict(result) for result in results],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+        )
+    return results
+
+
+__all__ = [
+    "AIModelMatrixRow",
+    "AIModelCapability",
+    "AIModelPreflightResult",
+    "AIModelPreflightTarget",
+    "build_ai_model_matrix_rows",
+    "build_ai_model_preflight_targets",
+    "verify_ai_model_endpoint",
+    "verify_ai_model_preflight",
+]

--- a/app/ai/ai_provider_clients_service.py
+++ b/app/ai/ai_provider_clients_service.py
@@ -84,6 +84,47 @@ def _extract_json_text(raw_text: str) -> str:
     return text
 
 
+def openai_api_error_summary(exc: BaseException, *, max_len: int = 400) -> str:
+    """Return a single-line, non-secret summary for OpenAI HTTP/API errors."""
+    parts: list[str] = [type(exc).__name__]
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int):
+        parts.append(f"http={status}")
+    request_id = getattr(exc, "request_id", None)
+    if isinstance(request_id, str) and request_id.strip():
+        rid = request_id.strip()
+        parts.append(f"request_id={rid[:48]}")
+    body = getattr(exc, "body", None)
+    err_type: str | None = None
+    err_msg: str | None = None
+    if isinstance(body, dict):
+        nested = body.get("error")
+        if isinstance(nested, dict):
+            et = nested.get("type")
+            if isinstance(et, str) and et.strip():
+                err_type = et.strip()[:120]
+            em = nested.get("message")
+            if isinstance(em, str) and em.strip():
+                err_msg = " ".join(em.split())[:240]
+            code = nested.get("code")
+            if isinstance(code, str) and code.strip():
+                parts.append(f"api_error_code={code.strip()[:120]}")
+        if err_type is None:
+            et = body.get("type")
+            if isinstance(et, str) and et.strip():
+                err_type = et.strip()[:120]
+        if err_msg is None:
+            em = body.get("message")
+            if isinstance(em, str) and em.strip():
+                err_msg = " ".join(em.split())[:240]
+    if err_type:
+        parts.append(f"api_error_type={err_type}")
+    if err_msg:
+        parts.append(f"api_error_message={err_msg}")
+    out = "|".join(parts)
+    return out[:max_len]
+
+
 def _openai_schema_validation_error(exc: Exception) -> bool:
     message = str(exc)
     return (
@@ -243,10 +284,10 @@ def call_openai_json_schema(
                 raise
             except Exception as fallback_exc:
                 raise AIProviderExecutionError(
-                    f"openai_request_failed:{type(fallback_exc).__name__}"
+                    f"openai_request_failed:{openai_api_error_summary(fallback_exc)}"
                 ) from fallback_exc
         raise AIProviderExecutionError(
-            f"openai_request_failed:{type(exc).__name__}"
+            f"openai_request_failed:{openai_api_error_summary(exc)}"
         ) from exc
 
     output_text = getattr(response, "output_text", None)
@@ -360,4 +401,5 @@ __all__ = [
     "api_key_configured",
     "call_anthropic_json",
     "call_openai_json_schema",
+    "openai_api_error_summary",
 ]

--- a/app/config/config_settings_fields_config.py
+++ b/app/config/config_settings_fields_config.py
@@ -67,6 +67,8 @@ class SettingsFields(BaseSettings):
     SCENARIO_GENERATION_MODEL: str = "claude-opus-4-7"
     SCENARIO_GENERATION_TIMEOUT_SECONDS: int = 120
     SCENARIO_GENERATION_MAX_RETRIES: int = 2
+    SCENARIO_GENERATION_FALLBACK_PROVIDER: str = "openai"
+    SCENARIO_GENERATION_FALLBACK_MODEL: str = "gpt-5.5"
 
     WINOE_REPORT_DAY1_RUNTIME_MODE: str | None = Field(
         default=None,
@@ -79,6 +81,8 @@ class SettingsFields(BaseSettings):
     WINOE_REPORT_DAY1_MODEL: str = "claude-opus-4-7"
     WINOE_REPORT_DAY1_TIMEOUT_SECONDS: int = 90
     WINOE_REPORT_DAY1_MAX_RETRIES: int = 2
+    WINOE_REPORT_DAY1_FALLBACK_PROVIDER: str = "openai"
+    WINOE_REPORT_DAY1_FALLBACK_MODEL: str = "gpt-5.5"
 
     WINOE_REPORT_DAY23_RUNTIME_MODE: str | None = Field(
         default=None,
@@ -91,6 +95,8 @@ class SettingsFields(BaseSettings):
     WINOE_REPORT_DAY23_MODEL: str = "gpt-5.5"
     WINOE_REPORT_DAY23_TIMEOUT_SECONDS: int = 120
     WINOE_REPORT_DAY23_MAX_RETRIES: int = 2
+    WINOE_REPORT_DAY23_FALLBACK_PROVIDER: str = "anthropic"
+    WINOE_REPORT_DAY23_FALLBACK_MODEL: str = "claude-sonnet-4-6"
 
     WINOE_REPORT_DAY4_RUNTIME_MODE: str | None = Field(
         default=None,
@@ -103,6 +109,8 @@ class SettingsFields(BaseSettings):
     WINOE_REPORT_DAY4_MODEL: str = "claude-sonnet-4-6"
     WINOE_REPORT_DAY4_TIMEOUT_SECONDS: int = 90
     WINOE_REPORT_DAY4_MAX_RETRIES: int = 2
+    WINOE_REPORT_DAY4_FALLBACK_PROVIDER: str = "openai"
+    WINOE_REPORT_DAY4_FALLBACK_MODEL: str = "gpt-5.5"
 
     WINOE_REPORT_DAY5_RUNTIME_MODE: str | None = Field(
         default=None,
@@ -115,6 +123,8 @@ class SettingsFields(BaseSettings):
     WINOE_REPORT_DAY5_MODEL: str = "claude-sonnet-4-6"
     WINOE_REPORT_DAY5_TIMEOUT_SECONDS: int = 90
     WINOE_REPORT_DAY5_MAX_RETRIES: int = 2
+    WINOE_REPORT_DAY5_FALLBACK_PROVIDER: str = "openai"
+    WINOE_REPORT_DAY5_FALLBACK_MODEL: str = "gpt-5.5"
 
     WINOE_REPORT_AGGREGATOR_RUNTIME_MODE: str | None = Field(
         default=None,
@@ -127,8 +137,8 @@ class SettingsFields(BaseSettings):
     WINOE_REPORT_AGGREGATOR_MODEL: str = "gpt-5.5"
     WINOE_REPORT_AGGREGATOR_TIMEOUT_SECONDS: int = 90
     WINOE_REPORT_AGGREGATOR_MAX_RETRIES: int = 2
-    WINOE_REPORT_ANTHROPIC_FALLBACK_DAY_MODEL: str = "claude-sonnet-4-6"
-    WINOE_REPORT_ANTHROPIC_FALLBACK_AGGREGATOR_MODEL: str = "claude-sonnet-4-6"
+    WINOE_REPORT_AGGREGATOR_FALLBACK_PROVIDER: str = "anthropic"
+    WINOE_REPORT_AGGREGATOR_FALLBACK_MODEL: str = "claude-sonnet-4-6"
 
     TRANSCRIPTION_RUNTIME_MODE: str | None = None
     TRANSCRIPTION_PROVIDER: str = "openai"

--- a/app/demo/services/task3_local_qa_seed_service.py
+++ b/app/demo/services/task3_local_qa_seed_service.py
@@ -328,13 +328,18 @@ async def seed_task3_local_qa(db, *, talent_partner_email: str) -> None:
         raise RuntimeError("task3 local QA seed is not allowed in production.")
 
     email = talent_partner_email.strip().lower()
-    company = await db.scalar(select(Company).where(Company.name == TASK3_QA_COMPANY))
     user = await db.scalar(select(User).where(User.email == email))
-
+    company = None
+    if user is not None and user.company_id is not None:
+        company = await db.scalar(select(Company).where(Company.id == user.company_id))
     if company is None:
-        company = Company(name=TASK3_QA_COMPANY)
-        db.add(company)
-        await db.flush()
+        company = await db.scalar(
+            select(Company).where(Company.name == TASK3_QA_COMPANY)
+        )
+        if company is None:
+            company = Company(name=TASK3_QA_COMPANY)
+            db.add(company)
+            await db.flush()
 
     if user is None:
         user = User(
@@ -346,8 +351,11 @@ async def seed_task3_local_qa(db, *, talent_partner_email: str) -> None:
         )
         db.add(user)
         await db.flush()
-    elif user.company_id != company.id:
+    elif user.company_id is None:
         user.company_id = company.id
+        await db.flush()
+    else:
+        user.role = "talent_partner"
         await db.flush()
 
     await purge_task3_local_qa(db, talent_partner_email=email)
@@ -370,7 +378,7 @@ async def seed_task3_local_qa(db, *, talent_partner_email: str) -> None:
             db,
             trial=t_active,
             scenario_version_id=scen_a.id,
-            invite_email=f"task3-active-{i}@local.test",
+            invite_email=f"task3-active-{i}@example.com",
             candidate_name=f"Active Candidate {i + 1}",
             status="in_progress",
         )
@@ -408,7 +416,7 @@ async def seed_task3_local_qa(db, *, talent_partner_email: str) -> None:
             db,
             trial=t_done,
             scenario_version_id=scen_d.id,
-            invite_email=f"task3-done-{i}@local.test",
+            invite_email=f"task3-done-{i}@example.com",
             candidate_name=f"Completed Candidate {i + 1}",
             status="completed",
         )

--- a/app/demo/services/yc_demo_seed_service.py
+++ b/app/demo/services/yc_demo_seed_service.py
@@ -1560,11 +1560,10 @@ async def _clear_demo_scope(db: AsyncSession, config: DemoSeedConfig) -> None:
     trial_ids = [row.id for row in demo_trial_rows]
     company_ids = sorted({row.company_id for row in demo_trial_rows})
 
-    user_filters = [User.email.in_(candidate_emails)]
-    if company_ids:
-        user_filters.append(User.company_id.in_(company_ids))
     user_ids = (
-        (await db.execute(select(User.id).where(or_(*user_filters)))).scalars().all()
+        (await db.execute(select(User.id).where(User.email.in_(candidate_emails))))
+        .scalars()
+        .all()
     )
 
     candidate_session_filters = [CandidateSession.invite_email.in_(candidate_emails)]
@@ -1766,10 +1765,69 @@ async def _clear_demo_scope(db: AsyncSession, config: DemoSeedConfig) -> None:
     if trial_ids:
         await db.execute(delete(Trial).where(Trial.id.in_(trial_ids)))
 
+    deletable_user_ids = list(user_ids)
     if user_ids:
-        await db.execute(delete(User).where(User.id.in_(user_ids)))
+        non_demo_trial_owner_ids = (
+            (
+                await db.execute(
+                    select(Trial.created_by).where(
+                        Trial.created_by.in_(user_ids),
+                        Trial.id.notin_(trial_ids) if trial_ids else True,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        protected_user_ids = {int(user_id) for user_id in non_demo_trial_owner_ids}
+        deletable_user_ids = [
+            user_id for user_id in user_ids if int(user_id) not in protected_user_ids
+        ]
+        if deletable_user_ids:
+            await db.execute(delete(User).where(User.id.in_(deletable_user_ids)))
     if company_ids:
-        await db.execute(delete(Company).where(Company.id.in_(company_ids)))
+        remaining_trial_company_ids = (
+            (
+                await db.execute(
+                    select(Trial.company_id).where(
+                        Trial.company_id.in_(company_ids),
+                        Trial.id.notin_(trial_ids) if trial_ids else True,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        remaining_user_company_ids = (
+            (
+                await db.execute(
+                    select(User.company_id).where(
+                        User.company_id.in_(company_ids),
+                        User.id.notin_(deletable_user_ids)
+                        if deletable_user_ids
+                        else True,
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+        protected_company_ids = {
+            int(company_id)
+            for company_id in (
+                list(remaining_trial_company_ids) + list(remaining_user_company_ids)
+            )
+            if company_id is not None
+        }
+        deletable_company_ids = [
+            company_id
+            for company_id in company_ids
+            if int(company_id) not in protected_company_ids
+        ]
+        if deletable_company_ids:
+            await db.execute(
+                delete(Company).where(Company.id.in_(deletable_company_ids))
+            )
 
     await db.commit()
 
@@ -1809,19 +1867,52 @@ async def seed_yc_demo_dataset(
     """Create or replace the demo dataset in the current database."""
     await _clear_demo_scope(db, config)
 
-    company = Company(name=config.company_name)
-    db.add(company)
-    await db.flush()
-
-    talent_partner = User(
-        name=config.talent_partner_name,
-        email=config.talent_partner_email,
-        role="talent_partner",
-        company_id=company.id,
-        password_hash="",
+    company = await db.scalar(
+        select(Company).where(Company.name == config.company_name)
     )
-    db.add(talent_partner)
-    await db.flush()
+    if company is None:
+        company = Company(name=config.company_name)
+        db.add(company)
+        await db.flush()
+
+    talent_partner = await db.scalar(
+        select(User).where(User.email == config.talent_partner_email)
+    )
+    if talent_partner is None:
+        talent_partner = User(
+            name=config.talent_partner_name,
+            email=config.talent_partner_email,
+            role="talent_partner",
+            company_id=company.id,
+            password_hash="",
+        )
+        db.add(talent_partner)
+        await db.flush()
+    else:
+        talent_partner.name = config.talent_partner_name
+        talent_partner.role = "talent_partner"
+        talent_partner.company_id = company.id
+        await db.flush()
+
+    qa_candidate_email = config.qa_candidate_email.strip().lower()
+    qa_candidate_user = await db.scalar(
+        select(User).where(User.email == qa_candidate_email)
+    )
+    if qa_candidate_user is None:
+        qa_candidate_user = User(
+            name="Candidate",
+            email=qa_candidate_email,
+            role="candidate",
+            company_id=None,
+            password_hash="",
+        )
+        db.add(qa_candidate_user)
+        await db.flush()
+    else:
+        qa_candidate_user.name = "Candidate"
+        qa_candidate_user.role = "candidate"
+        qa_candidate_user.company_id = None
+        await db.flush()
 
     candidate_sessions: list[CandidateSession] = []
     repo_full_names: list[str] = []
@@ -2204,7 +2295,7 @@ async def seed_yc_demo_dataset(
     active_session = CandidateSession(
         trial_id=active_trial.id,
         scenario_version_id=active_scenario.id,
-        candidate_user_id=None,
+        candidate_user_id=qa_candidate_user.id,
         candidate_name=active_candidate.name,
         invite_email=active_candidate.email,
         candidate_email=active_candidate.email,

--- a/app/evaluations/schemas/evaluations_schemas_evaluations_winoe_report_citations_schema.py
+++ b/app/evaluations/schemas/evaluations_schemas_evaluations_winoe_report_citations_schema.py
@@ -8,9 +8,13 @@ from app.shared.types.shared_types_base_model import APIModel
 class WinoeReportCitationOut(APIModel):
     """Represent one citation in a Winoe Report."""
 
+    citation_id: int | None = None
+    dimension: str
     artifact_type: str
     artifact_ref: str
+    artifact_range: str | None = None
     excerpt: str
+    resolved_open_target: str | None = None
     view_url: str | None = None
 
 

--- a/app/evaluations/services/evaluations_services_evaluations_evaluator_runtime_service.py
+++ b/app/evaluations/services/evaluations_services_evaluations_evaluator_runtime_service.py
@@ -14,6 +14,7 @@ from app.ai import (
     require_ai_policy_snapshot,
     validate_ai_policy_snapshot_contract,
 )
+from app.config import settings
 from app.evaluations.services.evaluations_services_evaluations_evaluator_evidence_service import (
     _build_day_evidence,
 )
@@ -40,6 +41,18 @@ _MARKDOWN_RANGE_RE = re.compile(
 )
 _TIMESTAMP_RANGE_RE = re.compile(r"^\[(?P<start>\d{2}:\d{2})-(?P<end>\d{2}:\d{2})\]$")
 _SUBMISSION_REF_RE = re.compile(r"^submission:(?P<id>[1-9]\d*)$")
+
+
+def _fallback_provider_for_reviewer(reviewer_key: str) -> str:
+    if reviewer_key == "designDocReviewer":
+        return str(settings.WINOE_REPORT_DAY1_FALLBACK_PROVIDER or "")
+    if reviewer_key == "codeImplementationReviewer":
+        return str(settings.WINOE_REPORT_DAY23_FALLBACK_PROVIDER or "")
+    if reviewer_key == "demoPresentationReviewer":
+        return str(settings.WINOE_REPORT_DAY4_FALLBACK_PROVIDER or "")
+    if reviewer_key == "reflectionEssayReviewer":
+        return str(settings.WINOE_REPORT_DAY5_FALLBACK_PROVIDER or "")
+    raise LookupError(f"unsupported_reviewer_key:{reviewer_key}")
 
 
 class DeterministicWinoeReportEvaluator:
@@ -158,6 +171,8 @@ class LiveWinoeReportEvaluator:
                     scenario_version_id=bundle.scenario_version_id,
                 )
                 request = WinoeReportDayReviewRequest(
+                    agent_key=reviewer_key,
+                    fallback_provider=_fallback_provider_for_reviewer(reviewer_key),
                     system_prompt=system_prompt,
                     user_prompt=_build_day_review_prompt(
                         bundle=bundle,
@@ -232,6 +247,10 @@ class LiveWinoeReportEvaluator:
             provider = get_winoe_report_review_provider(aggregator_provider)
             aggregate_output = provider.aggregate_winoe_report(
                 request=WinoeReportAggregateRequest(
+                    agent_key="winoeReport",
+                    fallback_provider=str(
+                        settings.WINOE_REPORT_AGGREGATOR_FALLBACK_PROVIDER or ""
+                    ),
                     system_prompt=system_prompt,
                     user_prompt=json.dumps(
                         {

--- a/app/evaluations/services/evaluations_services_evaluations_winoe_report_citations_service.py
+++ b/app/evaluations/services/evaluations_services_evaluations_winoe_report_citations_service.py
@@ -66,31 +66,48 @@ def _view_url_for_citation(
         submission = submissions_by_day.get(4)
         if submission is None:
             return None
-        return f"/api/submissions/{submission.id}/view?range={artifact_ref.strip('[]')}"
+        return f"/api/submissions/{submission.id}"
 
     if artifact_ref.startswith("day1"):
         submission = submissions_by_day.get(1)
+    elif artifact_ref.startswith("day3"):
+        submission = submissions_by_day.get(3)
+    elif artifact_ref.startswith("day4"):
+        submission = submissions_by_day.get(4)
     elif artifact_ref.startswith("day5"):
         submission = submissions_by_day.get(5)
     elif artifact_type == "code_implementation":
         submission = submissions_by_day.get(3) or submissions_by_day.get(2)
+    elif artifact_type == "submission":
+        submission = (
+            submissions_by_day.get(1)
+            if artifact_ref.startswith("day1")
+            else submissions_by_day.get(3)
+            if artifact_ref.startswith("day3")
+            else submissions_by_day.get(4)
+            if artifact_ref.startswith("day4")
+            else submissions_by_day.get(5)
+            if artifact_ref.startswith("day5")
+            else None
+        )
     else:
         submission = None
 
     if submission is None:
         return None
 
+    return f"/api/submissions/{submission.id}"
+
+
+def _artifact_range_for_citation(citation: Any) -> str | None:
+    artifact_ref = getattr(citation, "artifact_ref", "") or ""
     markdown_match = _MARKDOWN_RANGE_RE.match(artifact_ref)
     if markdown_match is not None:
-        line_start = markdown_match.group("start")
-        line_end = markdown_match.group("end")
-        return f"/api/submissions/{submission.id}/view?range={line_start}-{line_end}"
-
+        return f"L{markdown_match.group('start')}-L{markdown_match.group('end')}"
     timestamp_match = _TIMESTAMP_RANGE_RE.match(artifact_ref)
     if timestamp_match is not None:
-        return f"/api/submissions/{submission.id}/view?range={artifact_ref.strip('[]')}"
-
-    return f"/api/submissions/{submission.id}/view"
+        return f"{timestamp_match.group('start')}-{timestamp_match.group('end')}"
+    return None
 
 
 async def get_report_citations(
@@ -127,14 +144,19 @@ async def get_report_citations(
     )
     payload_citations: list[dict[str, Any]] = []
     for citation in citations:
+        view_url = _view_url_for_citation(
+            citation=citation, submissions_by_day=submissions_by_day
+        )
         payload_citations.append(
             {
+                "citation_id": citation.id,
+                "dimension": citation.dimension,
                 "artifact_type": citation.artifact_type,
                 "artifact_ref": citation.artifact_ref,
+                "artifact_range": _artifact_range_for_citation(citation),
                 "excerpt": citation.excerpt,
-                "view_url": _view_url_for_citation(
-                    citation=citation, submissions_by_day=submissions_by_day
-                ),
+                "resolved_open_target": view_url,
+                "view_url": view_url,
             }
         )
     return {

--- a/app/integrations/scenario_generation/anthropic_provider_client.py
+++ b/app/integrations/scenario_generation/anthropic_provider_client.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import logging
+
 from app.ai import ScenarioGenerationOutput
 from app.ai.ai_provider_clients_service import (
     AIProviderExecutionError,
+    api_key_configured,
     call_anthropic_json,
+    call_openai_json_schema,
 )
 from app.config import settings
 from app.integrations.scenario_generation.base_client import (
@@ -13,6 +17,44 @@ from app.integrations.scenario_generation.base_client import (
     ScenarioGenerationProviderRequest,
     ScenarioGenerationProviderResponse,
 )
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_FALLBACK_PROVIDER = "openai"
+_SUPPORTED_AGENT_KEY = "prestart"
+
+
+def _fallback_openai_model() -> str:
+    return str(settings.SCENARIO_GENERATION_FALLBACK_MODEL or "").strip()
+
+
+def _normalized_provider(value: str) -> str:
+    return str(value or "").strip().lower()
+
+
+def _require_supported_fallback_provider(*, request_provider: str) -> None:
+    normalized = _normalized_provider(request_provider)
+    if normalized != _SUPPORTED_FALLBACK_PROVIDER:
+        raise ScenarioGenerationProviderError(
+            "unsupported_scenario_generation_fallback_provider:"
+            f"anthropic:{request_provider}"
+        )
+
+
+def _require_supported_agent_key(*, agent_key: str) -> None:
+    if _normalized_provider(agent_key) != _SUPPORTED_AGENT_KEY:
+        raise ScenarioGenerationProviderError(
+            f"unsupported_scenario_generation_agent:anthropic:{agent_key}"
+        )
+
+
+def _is_retryable_anthropic_error(exc: Exception) -> bool:
+    normalized = str(exc).strip().lower()
+    if not normalized:
+        return False
+    return normalized.startswith("anthropic_request_failed") or normalized.startswith(
+        "anthropic_invalid_json_output"
+    )
 
 
 class AnthropicScenarioGenerationProvider:
@@ -28,6 +70,9 @@ class AnthropicScenarioGenerationProvider:
         *,
         request: ScenarioGenerationProviderRequest,
     ) -> ScenarioGenerationProviderResponse:
+        _require_supported_agent_key(agent_key=request.agent_key)
+        _require_supported_fallback_provider(request_provider=request.fallback_provider)
+        served_model = request.model
         try:
             result = call_anthropic_json(
                 api_key=settings.ANTHROPIC_API_KEY,
@@ -40,11 +85,44 @@ class AnthropicScenarioGenerationProvider:
                 max_tokens=self._MAX_TOKENS,
             )
         except AIProviderExecutionError as exc:
-            raise ScenarioGenerationProviderError(str(exc)) from exc
+            if not _is_retryable_anthropic_error(exc) or not api_key_configured(
+                settings.OPENAI_API_KEY
+            ):
+                raise ScenarioGenerationProviderError(str(exc)) from exc
+            fallback_model = _fallback_openai_model()
+            if not fallback_model:
+                raise ScenarioGenerationProviderError(
+                    "missing_scenario_generation_fallback_model"
+                ) from exc
+            served_model = fallback_model
+            logger.warning(
+                "scenario_generation_anthropic_retryable_failure_falling_back_to_openai primaryModel=%s fallbackModel=%s reason=%s",
+                request.model,
+                fallback_model,
+                type(exc).__name__,
+            )
+            try:
+                result = call_openai_json_schema(
+                    api_key=settings.OPENAI_API_KEY,
+                    model=fallback_model,
+                    system_prompt=request.system_prompt,
+                    user_prompt=request.user_prompt,
+                    response_model=ScenarioGenerationOutput,
+                    timeout_seconds=settings.SCENARIO_GENERATION_TIMEOUT_SECONDS,
+                    max_retries=settings.SCENARIO_GENERATION_MAX_RETRIES,
+                )
+            except AIProviderExecutionError as fallback_exc:
+                raise ScenarioGenerationProviderError(
+                    str(fallback_exc)
+                ) from fallback_exc
+        logger.info(
+            "scenario_generation_provider_call provider=anthropic served_model=%s",
+            served_model,
+        )
         return ScenarioGenerationProviderResponse(
             result=result,
-            model_name=request.model,
-            model_version=request.model,
+            model_name=served_model,
+            model_version=served_model,
         )
 
 

--- a/app/integrations/scenario_generation/base_client.py
+++ b/app/integrations/scenario_generation/base_client.py
@@ -16,6 +16,8 @@ class ScenarioGenerationProviderError(RuntimeError):
 class ScenarioGenerationProviderRequest:
     """Structured prompt request for scenario-generation providers."""
 
+    agent_key: str
+    fallback_provider: str
     system_prompt: str
     user_prompt: str
     model: str

--- a/app/integrations/transcription/integrations_transcription_openai_provider_client.py
+++ b/app/integrations/transcription/integrations_transcription_openai_provider_client.py
@@ -11,7 +11,10 @@ from urllib.parse import parse_qs, unquote, urlparse
 from urllib.request import Request, urlopen
 
 from app.ai import resolve_transcription_config
-from app.ai.ai_provider_clients_service import api_key_configured
+from app.ai.ai_provider_clients_service import (
+    api_key_configured,
+    openai_api_error_summary,
+)
 from app.config import settings
 from app.integrations.transcription.integrations_transcription_base_client import (
     TranscriptionProvider,
@@ -344,7 +347,7 @@ class OpenAITranscriptionProvider(TranscriptionProvider):
                         raise openai_error
             except Exception as exc:  # pragma: no cover - network/provider variability
                 raise TranscriptionProviderError(
-                    f"openai_transcription_failed:{type(exc).__name__}"
+                    f"openai_transcription_failed:{openai_api_error_summary(exc)}"
                 ) from exc
 
         transcript_text = _extract_text(response)

--- a/app/integrations/winoe_report_review/anthropic_provider_client.py
+++ b/app/integrations/winoe_report_review/anthropic_provider_client.py
@@ -2,10 +2,14 @@
 
 from __future__ import annotations
 
+import logging
+
 from app.ai import AggregatedWinoeReportOutput, DayReviewerOutput
 from app.ai.ai_provider_clients_service import (
     AIProviderExecutionError,
+    api_key_configured,
     call_anthropic_json,
+    call_openai_json_schema,
 )
 from app.config import settings
 from app.integrations.winoe_report_review.base_client import (
@@ -13,6 +17,64 @@ from app.integrations.winoe_report_review.base_client import (
     WinoeReportDayReviewRequest,
     WinoeReportReviewProviderError,
 )
+
+logger = logging.getLogger(__name__)
+
+_SUPPORTED_FALLBACK_PROVIDER = "openai"
+_SUPPORTED_DAY_AGENT_KEYS = {
+    "designdocreviewer",
+    "demopresentationreviewer",
+    "reflectionessayreviewer",
+}
+
+
+def _normalized_provider(value: str) -> str:
+    return str(value or "").strip().lower()
+
+
+def _require_supported_fallback_provider(
+    *, request_provider: str, operation: str
+) -> None:
+    normalized = _normalized_provider(request_provider)
+    if normalized != _SUPPORTED_FALLBACK_PROVIDER:
+        raise WinoeReportReviewProviderError(
+            "unsupported_winoe_report_fallback_provider:"
+            f"{operation}:anthropic:{request_provider}"
+        )
+
+
+def _require_supported_day_agent(*, agent_key: str, operation: str) -> None:
+    normalized = _normalized_provider(agent_key)
+    if normalized not in _SUPPORTED_DAY_AGENT_KEYS:
+        raise WinoeReportReviewProviderError(
+            f"unsupported_winoe_report_day_agent:{operation}:anthropic:{agent_key}"
+        )
+
+
+def _fallback_day_openai_model(*, agent_key: str) -> str:
+    normalized = _normalized_provider(agent_key)
+    if normalized == "designdocreviewer":
+        return str(settings.WINOE_REPORT_DAY1_FALLBACK_MODEL or "").strip()
+    if normalized == "demopresentationreviewer":
+        return str(settings.WINOE_REPORT_DAY4_FALLBACK_MODEL or "").strip()
+    if normalized == "reflectionessayreviewer":
+        return str(settings.WINOE_REPORT_DAY5_FALLBACK_MODEL or "").strip()
+    raise WinoeReportReviewProviderError(
+        f"unsupported_winoe_report_day_agent:{agent_key}"
+    )
+
+
+def _fallback_aggregator_openai_model() -> str:
+    return str(settings.WINOE_REPORT_AGGREGATOR_FALLBACK_MODEL or "").strip()
+
+
+def _is_retryable_anthropic_error(exc: Exception) -> bool:
+    normalized = str(exc).strip().lower()
+    if not normalized:
+        return False
+    return normalized.startswith("anthropic_request_failed") or normalized.startswith(
+        "anthropic_invalid_json_output"
+    )
 
 
 class AnthropicWinoeReportReviewProvider:
@@ -23,6 +85,13 @@ class AnthropicWinoeReportReviewProvider:
         *,
         request: WinoeReportDayReviewRequest,
     ) -> DayReviewerOutput:
+        _require_supported_day_agent(
+            agent_key=request.agent_key, operation="review_day"
+        )
+        _require_supported_fallback_provider(
+            request_provider=request.fallback_provider, operation="review_day"
+        )
+        served_model = request.model
         try:
             result = call_anthropic_json(
                 api_key=settings.ANTHROPIC_API_KEY,
@@ -44,7 +113,50 @@ class AnthropicWinoeReportReviewProvider:
                 ),
             )
         except AIProviderExecutionError as exc:
-            raise WinoeReportReviewProviderError(str(exc)) from exc
+            if not _is_retryable_anthropic_error(exc) or not api_key_configured(
+                settings.OPENAI_API_KEY
+            ):
+                raise WinoeReportReviewProviderError(str(exc)) from exc
+            fallback_model = _fallback_day_openai_model(agent_key=request.agent_key)
+            if not fallback_model:
+                raise WinoeReportReviewProviderError(
+                    "missing_winoe_report_day_fallback_model"
+                ) from exc
+            served_model = fallback_model
+            logger.warning(
+                "winoe_report_anthropic_retryable_failure_falling_back_to_openai operation=review_day primaryModel=%s fallbackModel=%s reason=%s",
+                request.model,
+                fallback_model,
+                type(exc).__name__,
+            )
+            try:
+                result = call_openai_json_schema(
+                    api_key=settings.OPENAI_API_KEY,
+                    model=fallback_model,
+                    system_prompt=request.system_prompt,
+                    user_prompt=request.user_prompt,
+                    response_model=DayReviewerOutput,
+                    timeout_seconds=max(
+                        settings.WINOE_REPORT_DAY1_TIMEOUT_SECONDS,
+                        settings.WINOE_REPORT_DAY23_TIMEOUT_SECONDS,
+                        settings.WINOE_REPORT_DAY4_TIMEOUT_SECONDS,
+                        settings.WINOE_REPORT_DAY5_TIMEOUT_SECONDS,
+                    ),
+                    max_retries=max(
+                        settings.WINOE_REPORT_DAY1_MAX_RETRIES,
+                        settings.WINOE_REPORT_DAY23_MAX_RETRIES,
+                        settings.WINOE_REPORT_DAY4_MAX_RETRIES,
+                        settings.WINOE_REPORT_DAY5_MAX_RETRIES,
+                    ),
+                )
+            except AIProviderExecutionError as fallback_exc:
+                raise WinoeReportReviewProviderError(
+                    str(fallback_exc)
+                ) from fallback_exc
+        logger.info(
+            "winoe_report_provider_call operation=review_day provider=anthropic served_model=%s",
+            served_model,
+        )
         return result
 
     def aggregate_winoe_report(
@@ -52,6 +164,15 @@ class AnthropicWinoeReportReviewProvider:
         *,
         request: WinoeReportAggregateRequest,
     ) -> AggregatedWinoeReportOutput:
+        if _normalized_provider(request.agent_key) != "winoereport":
+            raise WinoeReportReviewProviderError(
+                f"unsupported_winoe_report_agent:aggregate_winoe_report:anthropic:{request.agent_key}"
+            )
+        _require_supported_fallback_provider(
+            request_provider=request.fallback_provider,
+            operation="aggregate_winoe_report",
+        )
+        served_model = request.model
         try:
             result = call_anthropic_json(
                 api_key=settings.ANTHROPIC_API_KEY,
@@ -63,7 +184,40 @@ class AnthropicWinoeReportReviewProvider:
                 max_retries=settings.WINOE_REPORT_AGGREGATOR_MAX_RETRIES,
             )
         except AIProviderExecutionError as exc:
-            raise WinoeReportReviewProviderError(str(exc)) from exc
+            if not _is_retryable_anthropic_error(exc) or not api_key_configured(
+                settings.OPENAI_API_KEY
+            ):
+                raise WinoeReportReviewProviderError(str(exc)) from exc
+            fallback_model = _fallback_aggregator_openai_model()
+            if not fallback_model:
+                raise WinoeReportReviewProviderError(
+                    "missing_winoe_report_aggregator_fallback_model"
+                ) from exc
+            served_model = fallback_model
+            logger.warning(
+                "winoe_report_anthropic_retryable_failure_falling_back_to_openai operation=aggregate_winoe_report primaryModel=%s fallbackModel=%s reason=%s",
+                request.model,
+                fallback_model,
+                type(exc).__name__,
+            )
+            try:
+                result = call_openai_json_schema(
+                    api_key=settings.OPENAI_API_KEY,
+                    model=fallback_model,
+                    system_prompt=request.system_prompt,
+                    user_prompt=request.user_prompt,
+                    response_model=AggregatedWinoeReportOutput,
+                    timeout_seconds=settings.WINOE_REPORT_AGGREGATOR_TIMEOUT_SECONDS,
+                    max_retries=settings.WINOE_REPORT_AGGREGATOR_MAX_RETRIES,
+                )
+            except AIProviderExecutionError as fallback_exc:
+                raise WinoeReportReviewProviderError(
+                    str(fallback_exc)
+                ) from fallback_exc
+        logger.info(
+            "winoe_report_provider_call operation=aggregate_winoe_report provider=anthropic served_model=%s",
+            served_model,
+        )
         return result
 
 

--- a/app/integrations/winoe_report_review/base_client.py
+++ b/app/integrations/winoe_report_review/base_client.py
@@ -16,6 +16,8 @@ class WinoeReportReviewProviderError(RuntimeError):
 class WinoeReportDayReviewRequest:
     """Structured request for a single reviewer agent."""
 
+    agent_key: str
+    fallback_provider: str
     system_prompt: str
     user_prompt: str
     model: str
@@ -25,6 +27,8 @@ class WinoeReportDayReviewRequest:
 class WinoeReportAggregateRequest:
     """Structured request for the winoe-report aggregator."""
 
+    agent_key: str
+    fallback_provider: str
     system_prompt: str
     user_prompt: str
     model: str

--- a/app/integrations/winoe_report_review/openai_provider_client.py
+++ b/app/integrations/winoe_report_review/openai_provider_client.py
@@ -20,6 +20,10 @@ from app.integrations.winoe_report_review.base_client import (
 
 logger = logging.getLogger(__name__)
 
+_SUPPORTED_FALLBACK_PROVIDER = "anthropic"
+_SUPPORTED_DAY_AGENT_KEY = "codeimplementationreviewer"
+_SUPPORTED_AGGREGATOR_AGENT_KEY = "winoereport"
+
 _RETRYABLE_OPENAI_ERROR_MARKERS = (
     "ratelimiterror",
     "too many requests",
@@ -59,70 +63,52 @@ def _day_max_retries() -> int:
     )
 
 
-def _fallback_day_model() -> str:
-    return (
-        str(settings.WINOE_REPORT_ANTHROPIC_FALLBACK_DAY_MODEL or "").strip()
-        or "claude-sonnet-4-6"
-    )
-
-
 def _fallback_aggregator_model() -> str:
-    return (
-        str(settings.WINOE_REPORT_ANTHROPIC_FALLBACK_AGGREGATOR_MODEL or "").strip()
-        or "claude-sonnet-4-6"
+    return str(settings.WINOE_REPORT_AGGREGATOR_FALLBACK_MODEL or "").strip()
+
+
+def _normalized_provider(value: str) -> str:
+    return str(value or "").strip().lower()
+
+
+def _require_supported_fallback_provider(
+    *, request_provider: str, operation: str
+) -> None:
+    normalized = _normalized_provider(request_provider)
+    if normalized != _SUPPORTED_FALLBACK_PROVIDER:
+        raise WinoeReportReviewProviderError(
+            "unsupported_winoe_report_fallback_provider:"
+            f"{operation}:openai:{request_provider}"
+        )
+
+
+def _fallback_day_model_for_agent(*, agent_key: str) -> str:
+    normalized = _normalized_provider(agent_key)
+    if normalized == _SUPPORTED_DAY_AGENT_KEY:
+        return str(settings.WINOE_REPORT_DAY23_FALLBACK_MODEL or "").strip()
+    raise WinoeReportReviewProviderError(
+        f"unsupported_winoe_report_day_agent:{agent_key}"
     )
 
 
-def _unique_models(*model_names: str) -> list[str]:
-    models: list[str] = []
-    for model_name in model_names:
-        normalized = (model_name or "").strip()
-        if normalized and normalized not in models:
-            models.append(normalized)
-    return models
-
-
-def _fallback_day_models() -> list[str]:
-    return _unique_models(_fallback_day_model(), "claude-sonnet-4-6")
-
-
-def _fallback_aggregator_models() -> list[str]:
-    return _unique_models(_fallback_aggregator_model(), "claude-sonnet-4-6")
-
-
-def _call_anthropic_with_model_fallbacks(
+def _call_anthropic_with_model_fallback(
     *,
-    operation: str,
-    model_names: list[str],
+    model_name: str,
     system_prompt: str,
     user_prompt: str,
     response_model,
     timeout_seconds: int,
     max_retries: int,
 ):
-    last_error: AIProviderExecutionError | None = None
-    for model_name in model_names:
-        try:
-            return call_anthropic_json(
-                api_key=settings.ANTHROPIC_API_KEY,
-                model=model_name,
-                system_prompt=system_prompt,
-                user_prompt=user_prompt,
-                response_model=response_model,
-                timeout_seconds=timeout_seconds,
-                max_retries=max_retries,
-            )
-        except AIProviderExecutionError as exc:
-            last_error = exc
-            logger.warning(
-                "winoe_report_anthropic_model_attempt_failed operation=%s model=%s reason=%s",
-                operation,
-                model_name,
-                type(exc).__name__,
-            )
-    if last_error is None:  # pragma: no cover - guarded by caller
-        raise WinoeReportReviewProviderError("anthropic_fallback_models_missing")
-    raise last_error
+    return call_anthropic_json(
+        api_key=settings.ANTHROPIC_API_KEY,
+        model=model_name,
+        system_prompt=system_prompt,
+        user_prompt=user_prompt,
+        response_model=response_model,
+        timeout_seconds=timeout_seconds,
+        max_retries=max_retries,
+    )
 
 
 class OpenAIWinoeReportReviewProvider:
@@ -133,6 +119,14 @@ class OpenAIWinoeReportReviewProvider:
         *,
         request: WinoeReportDayReviewRequest,
     ) -> DayReviewerOutput:
+        if _normalized_provider(request.agent_key) != _SUPPORTED_DAY_AGENT_KEY:
+            raise WinoeReportReviewProviderError(
+                f"unsupported_winoe_report_day_agent:review_day:openai:{request.agent_key}"
+            )
+        _require_supported_fallback_provider(
+            request_provider=request.fallback_provider, operation="review_day"
+        )
+        served_model = request.model
         try:
             result = call_openai_json_schema(
                 api_key=settings.OPENAI_API_KEY,
@@ -148,17 +142,21 @@ class OpenAIWinoeReportReviewProvider:
                 settings.ANTHROPIC_API_KEY
             ):
                 raise WinoeReportReviewProviderError(str(exc)) from exc
-            fallback_models = _fallback_day_models()
+            fallback_model = _fallback_day_model_for_agent(agent_key=request.agent_key)
+            if not fallback_model:
+                raise WinoeReportReviewProviderError(
+                    "missing_winoe_report_day23_fallback_model"
+                ) from exc
+            served_model = fallback_model
             logger.warning(
-                "winoe_report_openai_retryable_failure_falling_back_to_anthropic operation=review_day primaryModel=%s fallbackModels=%s reason=%s",
+                "winoe_report_openai_retryable_failure_falling_back_to_anthropic operation=review_day primaryModel=%s fallbackModel=%s reason=%s",
                 request.model,
-                ",".join(fallback_models),
+                fallback_model,
                 type(exc).__name__,
             )
             try:
-                result = _call_anthropic_with_model_fallbacks(
-                    operation="review_day",
-                    model_names=fallback_models,
+                result = _call_anthropic_with_model_fallback(
+                    model_name=fallback_model,
                     system_prompt=request.system_prompt,
                     user_prompt=request.user_prompt,
                     response_model=DayReviewerOutput,
@@ -169,6 +167,10 @@ class OpenAIWinoeReportReviewProvider:
                 raise WinoeReportReviewProviderError(
                     str(fallback_exc)
                 ) from fallback_exc
+        logger.info(
+            "winoe_report_provider_call operation=review_day provider=openai served_model=%s",
+            served_model,
+        )
         return result
 
     def aggregate_winoe_report(
@@ -176,6 +178,15 @@ class OpenAIWinoeReportReviewProvider:
         *,
         request: WinoeReportAggregateRequest,
     ) -> AggregatedWinoeReportOutput:
+        if _normalized_provider(request.agent_key) != _SUPPORTED_AGGREGATOR_AGENT_KEY:
+            raise WinoeReportReviewProviderError(
+                f"unsupported_winoe_report_agent:aggregate_winoe_report:openai:{request.agent_key}"
+            )
+        _require_supported_fallback_provider(
+            request_provider=request.fallback_provider,
+            operation="aggregate_winoe_report",
+        )
+        served_model = request.model
         try:
             result = call_openai_json_schema(
                 api_key=settings.OPENAI_API_KEY,
@@ -191,17 +202,21 @@ class OpenAIWinoeReportReviewProvider:
                 settings.ANTHROPIC_API_KEY
             ):
                 raise WinoeReportReviewProviderError(str(exc)) from exc
-            fallback_models = _fallback_aggregator_models()
+            fallback_model = _fallback_aggregator_model()
+            if not fallback_model:
+                raise WinoeReportReviewProviderError(
+                    "missing_winoe_report_aggregator_fallback_model"
+                ) from exc
+            served_model = fallback_model
             logger.warning(
-                "winoe_report_openai_retryable_failure_falling_back_to_anthropic operation=aggregate_winoe_report primaryModel=%s fallbackModels=%s reason=%s",
+                "winoe_report_openai_retryable_failure_falling_back_to_anthropic operation=aggregate_winoe_report primaryModel=%s fallbackModel=%s reason=%s",
                 request.model,
-                ",".join(fallback_models),
+                fallback_model,
                 type(exc).__name__,
             )
             try:
-                result = _call_anthropic_with_model_fallbacks(
-                    operation="aggregate_winoe_report",
-                    model_names=fallback_models,
+                result = _call_anthropic_with_model_fallback(
+                    model_name=fallback_model,
                     system_prompt=request.system_prompt,
                     user_prompt=request.user_prompt,
                     response_model=AggregatedWinoeReportOutput,
@@ -212,6 +227,10 @@ class OpenAIWinoeReportReviewProvider:
                 raise WinoeReportReviewProviderError(
                     str(fallback_exc)
                 ) from fallback_exc
+        logger.info(
+            "winoe_report_provider_call operation=aggregate_winoe_report provider=openai served_model=%s",
+            served_model,
+        )
         return result
 
 

--- a/app/trials/services/trials_services_trials_scenario_generation_service.py
+++ b/app/trials/services/trials_services_trials_scenario_generation_service.py
@@ -12,6 +12,7 @@ from app.ai import (
     require_agent_runtime,
     require_ai_policy_snapshot,
 )
+from app.config import settings
 from app.integrations.scenario_generation import (
     ScenarioGenerationProviderError,
     ScenarioGenerationProviderRequest,
@@ -193,6 +194,8 @@ def _generate_with_llm(
     provider = get_scenario_generation_provider(str(runtime["provider"]))
     snapshot_agent = require_agent_policy_snapshot(ai_policy_snapshot_json, "prestart")
     request = ScenarioGenerationProviderRequest(
+        agent_key="prestart",
+        fallback_provider=str(settings.SCENARIO_GENERATION_FALLBACK_PROVIDER or ""),
         system_prompt=system_prompt,
         user_prompt=user_prompt,
         model=str(runtime["model"]),

--- a/pr.md
+++ b/pr.md
@@ -1,193 +1,186 @@
-# Task 2 — Demo Seed + FakeGitHubProvider Hardening
+# Task 3: Harden AI pipeline integrity, citation resolution, validator enforcement, and demo QA seeds
 
 ## Summary
 
-Task 2 hardens the Winoe AI demo foundation by making the seed deterministic, idempotent, and centered on the canonical Talent Partner and candidate credentials. It also hardens the fake GitHub layer so demo workflow dispatch, Codespace state, and artifact progression are reproducible without real GitHub access.
+This PR completes the backend trust spine for Task 3: AI Pipeline Integrity. It adds model/provider preflight, explicit model and capability validation, a richer Citation API, Evidence Trail target resolution, validator enforcement for cited scoring evidence, Winoe persona/SOUL prompt assembly coverage, AgentSnapshot/fairness preservation, Winoe evaluation state-machine coverage, and deterministic demo/Task 3 seed data for the required QA credentials.
 
-## Why This Matters
+The backend changes keep Winoe evidence-first. Winoe provides evidence for the Talent Partner to decide; it does not make hiring decisions.
 
-This gives the YC demo a stable, repeatable baseline:
+## Why this matters
 
-- the Talent Partner path starts from `winoetalentpartner@gmail.com`
-- the active candidate path starts from `winoecandidate@gmail.com`
-- the seeded data is consistent across reruns
-- fake workflow state progression can be verified without external dependencies
-- production remains protected from demo-only execution
+Winoe AI cannot be trusted if Winoe Scores lack defensible Evidence Trail support. Every score needs to be tied to real artifacts, Talent Partners need to inspect the resolved targets, and Candidate access must remain denied for Talent Partner-only reports and artifacts.
 
-## Scope
+The deterministic seed path also matters for YC/demo QA. QA should not depend on fragile local database state, drifting ownership, invalid local emails, or cleanup failures.
 
-- Recenter the demo seed around the canonical Talent Partner credential.
-- Recenter the active candidate demo path around the canonical candidate credential.
-- Produce a deterministic and idempotent demo dataset.
-- Hardcode the demo-critical evaluator and Winoe Report output so seed execution does not depend on live LLM calls.
-- Harden `FakeGitHubProvider` / `FakeGithubClient` for deterministic repo creation, from-scratch workspace bootstrap, Codespace state, run-tests workflow dispatch, queued -> running -> completed progression, success and failure paths, artifact zip availability after completion, and commit/compare/file evidence.
-- Preserve terminal `dispatch_and_wait` behavior.
-- Confirm `DEMO_MODE` refuses production.
-- Confirm no real GitHub or Codespace calls occur in `DEMO_MODE`.
+## Backend changes
 
-## Backend Changes
+### A. Model preflight / provider capability integrity
 
-### Demo Seed
+- Adds `app/ai/ai_model_preflight_service.py` and `scripts/verify_models.py`.
+- Verifies configured models are reachable through the production provider paths.
+- Makes capability validation explicit for `structured_json` and `transcription`.
+- Covers OpenAI structured JSON probes, Anthropic structured JSON probes, and OpenAI transcription probes.
+- Rejects blank primary/fallback model config and unsupported fallback provider config.
+- Sanitizes provider failure summaries so API keys/secrets are not printed.
+- Pins/documents the model matrix used by reviewer, Winoe, scenario generation, and transcription roles.
 
-- The seed now produces a single, canonical demo story instead of a loose or partially populated dataset.
-- The seed is deterministic and idempotent: reruns clear stale demo rows and reseed the same final identities and artifacts.
-- The active candidate path is anchored on `winoecandidate@gmail.com` and reaches Nina Alvarez's Day 2 state.
-- The Talent Partner path is anchored on `winoetalentpartner@gmail.com` and reaches the populated dashboard plus the completed hero Trial.
+### B. Citation API / Evidence Trail resolution
 
-### Demo Dataset Inventory
+- Extends the Winoe Report citation payload with `citation_id`, `dimension`, `artifact_range`, and `resolved_open_target`.
+- Resolves `resolved_open_target` and `view_url` to real `/api/submissions/{id}` targets.
+- Stops emitting fake `/view?...` target shapes.
+- Preserves line/timestamp metadata in `artifact_range`.
+- Expands target coverage across design doc, code implementation, transcript, and reflection artifacts.
 
-The final seeded inventory contains exactly:
+### C. Validator enforcement
 
-- 1 Talent Partner
-- 3 Trials
-- 3 candidate sessions
-- 6 submissions
-- 2 workspaces
-- 2 workspace groups
-- 1 recording asset
-- 1 transcript
-- 1 evaluation run
-- 5 day scores
-- 5 reviewer reports
-- 1 Winoe Report
-- 15 Evidence Trail citations
+- Rejects dimensional scoring evidence without citations.
+- Rejects dimensional scoring evidence with only unresolved/non-resolving citations.
+- Keeps the valid cited evidence path accepted.
 
-### Credential Story
+### D. Persona/SOUL governance
 
-- Talent Partner: `winoetalentpartner@gmail.com`
-- Candidate: `winoecandidate@gmail.com`
-- Candidate path resolves to Nina Alvarez on Day 2
+- Verifies Winoe prompt assembly includes persona/SOUL content.
+- Keeps Winoe evidence-first.
+- Preserves the boundary that Winoe does not make hiring decisions.
+- Keeps evidence with Winoe and the decision with the Talent Partner.
 
-### Completed Hero Trial
+### E. AgentSnapshot / fairness
 
-The completed hero Trial is the Sarah Chen path:
+- Confirms candidates in the same Trial use pinned agent/rubric/model snapshots.
+- Preserves the fairness architecture by avoiding live prompt-pack drift during reruns.
 
-- completed Trial state
-- finished Winoe Report
-- deterministic evaluation output
-- evidence-backed narrative and score artifacts
+### F. Evaluation state-machine
 
-### Evidence Trail
+State-machine coverage now verifies the ordered Task 3 path:
 
-The seed includes realistic five-day artifacts:
+- `REVIEWERS_DISPATCHED`
+- `REVIEWERS_COMPLETE`
+- `WINOE_SYNTHESIZING`
+- `EVIDENCE_TRAIL_VALIDATING`
+- `REPORT_FINALIZED`
+- `NOTIFICATION_SENT`
 
-- Day 1 Design Doc
-- Day 2 Implementation Kickoff
-- Day 3 Implementation Wrap-Up
-- Day 4 Handoff/Demo recording plus transcript
-- Day 5 Reflection
+### G. Demo / Task 3 seed reliability
 
-The Evidence Trail citations resolve against seeded rows and payloads, not just citation-shaped strings. The proof includes:
+- Keeps `seed_demo.sh` idempotent.
+- Keeps `seed_task3_qa.py` idempotent.
+- Aligns the required Talent Partner with the seeded Winoe Report company.
+- Ensures the required Candidate exists as a backend candidate user.
+- Avoids `.local.test` validation failures by using valid example-domain addresses.
+- Avoids FK cleanup failure.
+- Keeps candidate listing returning 200.
+- Prevents seed ownership drift across repeated runs.
 
-- `day1-design-doc.md:L1-L20`
-- `day1-design-doc.md:L21-L36`
-- Day 2 and Day 3 repo commit/file/test evidence
-- Day 4 transcript and recording evidence
-- `day5-reflection.md:L1-L18`
-- `day5-reflection.md:L19-L34`
+## Security / authorization
 
-### FakeGitHubProvider / FakeGithubClient
+- No authorization checks were weakened.
+- The required Talent Partner can access only company-owned Winoe Report, citation, and submission resources.
+- Candidate remains denied from Talent Partner-only Winoe Report, Citation API, and submission targets.
+- Unauthenticated access remains denied.
+- Provider secrets are not printed in preflight output.
 
-The fake GitHub layer now behaves deterministically for the demo-critical path:
+## QA evidence
 
-- repository creation is stable
-- from-scratch workspace bootstrap is stable
-- Codespace state is stable
-- `run-tests` workflow dispatch is stable
-- workflow progression is `queued -> running -> completed`
-- success and failure paths are covered
-- artifact zips become available after completion
-- commit, compare, and file evidence are available to the seed and report pipeline
+```text
+Model preflight: PASS
+Seed sequence:
+- ./scripts/seed_demo.sh: PASS
+- ./scripts/seed_demo.sh: PASS
+- poetry run python3 scripts/seed_task3_qa.py --talent-partner-email winoetalentpartner@gmail.com: PASS
+- poetry run python3 scripts/seed_task3_qa.py --talent-partner-email winoetalentpartner@gmail.com: PASS
 
-Terminal `dispatch_and_wait` behavior is preserved. It now waits through terminal completion and returns parsed terminal results instead of stopping at the first running observation.
-
-### DEMO_MODE Production Safety
-
-- `DEMO_MODE` is refused in production.
-- The production guard fails closed with `ValidationError: DEMO_MODE/WINOE_DEMO_MODE cannot be enabled in production.`
-- The demo seed path uses the fake provider only in `DEMO_MODE`.
-- No real GitHub or Codespace calls occur in `DEMO_MODE`.
-
-## What Did Not Change
-
-- No frontend UI implementation was added in this task.
-- No live LLM dependency was introduced into the seed path.
-- No production behavior was loosened.
-- No unrelated product areas were changed.
-
-## Verification
-
-### Seed Commands
-
-```bash
-WINOE_ENV=local \
-WINOE_DEMO_MODE=true \
-WINOE_AI_RUNTIME_MODE=demo \
-GITHUB_PROVIDER=fake \
-DEMO_RESET_DB=1 \
-./scripts/seed_demo.sh --reset-db
+Backend server: PASS at http://127.0.0.1:8000
+Backend health: GET /health -> 200 {"status":"ok"}
+Talent Partner E2E: PASS
+Candidate boundary: PASS
+Citation API: PASS
+Citation count: 15
+Unique citation targets: 4
+Citation targets: 4/4 unique targets returned 200 for Talent Partner, 403 for Candidate, 401 for unauthenticated
+Validator tests: PASS
+Persona/SOUL tests: PASS
+AgentSnapshot/fairness tests: PASS
+State-machine coverage: PASS
+Backend precommit: PASS, 2233 passed, coverage 96.16%
 ```
 
-### Seed Timing
+## Citation verification table
 
-- Seed run 1: `elapsed_seconds=2.56`
-- Seed run 2: `elapsed_seconds=2.41`
+| Artifact | Ref | Range | Target | Talent Partner | Unauth | Candidate |
+|---|---|---:|---|---:|---:|---:|
+| Design doc | `day1-design-doc.md:L1-L20` | `L1-L20` | `/api/submissions/85` | 200 | 401 | 403 |
+| Code implementation | `857cd1e...:src/services/reporting.py:L12-L76` | `L12-L76` | `/api/submissions/87` | 200 | 401 | 403 |
+| Transcript | `[00:00-02:00]` | `00:00-02:00` | `/api/submissions/88` | 200 | 401 | 403 |
+| Reflection | `day5-reflection.md:L1-L18` | `L1-L18` | `/api/submissions/89` | 200 | 401 | 403 |
 
-### Idempotency
+All citation targets use `/api/submissions/{id}`. No citation target includes `/view`. `artifact_range` preserves line/timestamp ranges.
 
-- Seed run 1: PASS
-- Seed run 2 / idempotency: PASS
-- Both runs completed successfully with exit code `0`
-- The second run reproduced the same identities, Trial structure, and inventory counts
-- Demo-scoped cleanup removed stale demo rows before reseeding
-
-### Automated Checks
-
-- Backend local checks: PASS
-- `2205 passed`
-- `96.16%` coverage
-- Backend terminology guard: PASS
-- Fake-provider focused test: PASS
-
-### Real Local QA
-
-- Real local QA: PASS after Iteration 4
-- Task 2 QA evidence folder: `qa_artifacts/task2_demo_seed_fakegithub_qa/qa_report.md`
-- The browser-visible queued/running state is non-blocking for this task and is deferred to Task 8 candidate UI polish
-
-### Production Guard
+## Test plan
 
 ```bash
-env WINOE_ENV=production WINOE_DEMO_MODE=true WINOE_AI_RUNTIME_MODE=demo GITHUB_PROVIDER=fake ./scripts/seed_demo.sh --reset-db
+poetry run python3 scripts/verify_models.py
+
+./scripts/seed_demo.sh
+./scripts/seed_demo.sh
+poetry run python3 scripts/seed_task3_qa.py --talent-partner-email winoetalentpartner@gmail.com
+poetry run python3 scripts/seed_task3_qa.py --talent-partner-email winoetalentpartner@gmail.com
+
+poetry run pytest --no-cov \
+  tests/ai/test_ai_model_preflight_service.py \
+  tests/ai/test_ai_provider_clients_service.py \
+  tests/evaluations/services/test_evaluations_evidence_trail_validator_service.py \
+  tests/evaluations/routes/test_evaluations_winoe_report_citations_routes.py \
+  tests/evaluations/services/test_evaluations_trial_evaluator_service.py \
+  tests/evaluations/services/test_evaluations_evaluator_runner_service.py \
+  tests/trials/services/test_trials_service_trial_agent_snapshots_service.py \
+  tests/demo/services/test_demo_yc_seed_service.py \
+  tests/demo/services/test_demo_task3_local_qa_seed_service.py \
+  -q
+
+bash precommit.sh
 ```
 
-- Result: PASS expected failure
-- Failure reason: `ValidationError: DEMO_MODE/WINOE_DEMO_MODE cannot be enabled in production.`
+Observed results:
 
-### Terminology Guard
+- Targeted backend pytest: `102 passed`
+- Backend precommit: `2233 passed`, coverage `96.16%`
 
-- Backend terminology guard: PASS
+## Manual QA
 
-## QA Result
+Backend server command:
 
-PASS
+```bash
+WINOE_ENV=local DEV_AUTH_BYPASS=1 WINOE_DEV_AUTH_BYPASS=1 poetry run uvicorn app.api.main:app --reload --host 127.0.0.1 --port 8000
+```
 
-Task 2 implementation is accepted and QA is accepted.
+Manual QA covered:
 
-## Known Limitations / Follow-ups
+- Talent Partner completed dashboard -> Trial detail -> Winoe Report path passed.
+- Winoe Report rendered Winoe Score, all 8 dimensions/sub-scores, and evidence controls.
+- Citation API returned 200 for Talent Partner.
+- Talent Partner citation target requests returned 200.
+- Candidate citation target requests returned 403.
+- Unauthenticated citation target requests returned 401.
+- Candidate portal rendered.
+- Candidate was blocked from Talent Partner-only Winoe Report, Citation API, and submission artifacts.
 
-- Browser-visible queued/running affordance is deferred to Task 8 candidate UI polish.
-- The fake provider covers the demo-critical path, not the full GitHub API surface.
-- The seed uses pre-baked deterministic evaluator and Winoe Report output by design.
+## Risks / non-blocking notes
 
-## Reviewer Checklist
+- No product risk was found in the Task 3 trust path.
+- Local/dev hydration mismatch warnings were observed in browser QA.
+- Existing frontend test-console warnings for React key/fake timer cleanup are outside backend PR scope.
 
-- [ ] Seed creates one Talent Partner and three Trials
-- [ ] Talent Partner credential reaches populated dashboard
-- [ ] Candidate credential reaches Nina Alvarez Day 2
-- [ ] Sarah Chen Winoe Report is ready
-- [ ] Evidence Trail citations resolve
-- [ ] Fake run-tests reaches terminal completion without real GitHub
-- [ ] DEMO_MODE refuses production
-- [ ] Local checks pass
-- [ ] Terminology guard passes
+## Rollback
+
+Revert this PR to restore prior AI/evaluation/seed behavior. This branch diff does not add database migration files, so no database migration rollback is expected. If a migration is added before merge, document and run the exact downgrade for that migration.
+
+## Reviewer checklist
+
+- [ ] Model preflight is still green.
+- [ ] Citation targets are real `/api/submissions/{id}` paths.
+- [ ] No `/view` fake target is emitted.
+- [ ] Candidate access is denied.
+- [ ] Unauthenticated access is denied.
+- [ ] Seeds are repeatable.
+- [ ] Winoe persona does not decide hire/no-hire.

--- a/pr.md
+++ b/pr.md
@@ -102,7 +102,7 @@ Validator tests: PASS
 Persona/SOUL tests: PASS
 AgentSnapshot/fairness tests: PASS
 State-machine coverage: PASS
-Backend precommit: PASS, 2233 passed, coverage 96.16%
+Backend local checks: PASS, 2233 passed, coverage 96.16%
 ```
 
 ## Citation verification table
@@ -138,13 +138,13 @@ poetry run pytest --no-cov \
   tests/demo/services/test_demo_task3_local_qa_seed_service.py \
   -q
 
-bash precommit.sh
+./precommit.sh
 ```
 
 Observed results:
 
 - Targeted backend pytest: `102 passed`
-- Backend precommit: `2233 passed`, coverage `96.16%`
+- Backend local checks: `2233 passed`, coverage `96.16%`
 
 ## Manual QA
 

--- a/scripts/seed_task3_qa.py
+++ b/scripts/seed_task3_qa.py
@@ -17,7 +17,9 @@ def _parse_args() -> argparse.Namespace:
     p = argparse.ArgumentParser(description=__doc__)
     p.add_argument(
         "--talent-partner-email",
-        default=os.getenv("QA_E2E_TALENT_PARTNER_EMAIL", "talent_partner1@local.test"),
+        default=os.getenv(
+            "QA_E2E_TALENT_PARTNER_EMAIL", "winoetalentpartner@gmail.com"
+        ),
         help="Must match /api/dev/qa-login default Talent Partner email.",
     )
     return p.parse_args()

--- a/scripts/verify_models.py
+++ b/scripts/verify_models.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Verify the live reachability of the pinned Winoe AI model matrix."""
+
+from __future__ import annotations
+
+import json
+import sys
+from dataclasses import asdict
+
+from app.ai.ai_model_preflight_service import verify_ai_model_preflight
+
+
+def main() -> int:
+    try:
+        results = verify_ai_model_preflight()
+    except Exception as exc:  # pragma: no cover - script surface
+        print(str(exc), file=sys.stderr)
+        return 1
+
+    print(
+        json.dumps(
+            [asdict(result) for result in results],
+            indent=2,
+            sort_keys=True,
+        )
+    )
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover - script surface
+    raise SystemExit(main())

--- a/tests/ai/test_ai_model_preflight_service.py
+++ b/tests/ai/test_ai_model_preflight_service.py
@@ -146,6 +146,15 @@ def test_verify_ai_model_preflight_raises_on_unreachable_endpoint(monkeypatch) -
 def test_verify_ai_model_preflight_uses_structured_output_probes(monkeypatch) -> None:
     calls: list[tuple[str, str, str]] = []
 
+    monkeypatch.setattr(
+        "app.ai.ai_model_preflight_service.settings.OPENAI_API_KEY",
+        "openai-test-key",
+    )
+    monkeypatch.setattr(
+        "app.ai.ai_model_preflight_service.settings.ANTHROPIC_API_KEY",
+        "anthropic-test-key",
+    )
+
     def _fake_openai(
         *, api_key, model, system_prompt, user_prompt, response_model, **_kwargs
     ):

--- a/tests/ai/test_ai_model_preflight_service.py
+++ b/tests/ai/test_ai_model_preflight_service.py
@@ -1,0 +1,409 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from app.ai.ai_model_preflight_service import (
+    build_ai_model_matrix_rows,
+    build_ai_model_preflight_targets,
+    verify_ai_model_preflight,
+)
+from app.ai.ai_provider_clients_service import AIProviderExecutionError
+
+
+def test_model_matrix_includes_primary_and_fallback_bindings() -> None:
+    rows = build_ai_model_matrix_rows()
+
+    assert len(rows) == 13
+    expected_bindings = {
+        (
+            "Prestart / Project Brief Creator",
+            "primary",
+            "structured_json",
+            "anthropic",
+            "claude-opus-4-7",
+        ),
+        (
+            "Prestart / Project Brief Creator",
+            "fallback",
+            "structured_json",
+            "openai",
+            "gpt-5.5",
+        ),
+        (
+            "Design Doc Reviewer",
+            "primary",
+            "structured_json",
+            "anthropic",
+            "claude-opus-4-7",
+        ),
+        (
+            "Design Doc Reviewer",
+            "fallback",
+            "structured_json",
+            "openai",
+            "gpt-5.5",
+        ),
+        (
+            "Code Implementation Reviewer",
+            "primary",
+            "structured_json",
+            "openai",
+            "gpt-5.5",
+        ),
+        (
+            "Code Implementation Reviewer",
+            "fallback",
+            "structured_json",
+            "anthropic",
+            "claude-sonnet-4-6",
+        ),
+        (
+            "Demo Presentation Reviewer",
+            "primary",
+            "structured_json",
+            "anthropic",
+            "claude-sonnet-4-6",
+        ),
+        (
+            "Demo Presentation Reviewer",
+            "fallback",
+            "structured_json",
+            "openai",
+            "gpt-5.5",
+        ),
+        (
+            "Reflection Essay Reviewer",
+            "primary",
+            "structured_json",
+            "anthropic",
+            "claude-sonnet-4-6",
+        ),
+        (
+            "Reflection Essay Reviewer",
+            "fallback",
+            "structured_json",
+            "openai",
+            "gpt-5.5",
+        ),
+        (
+            "Winoe, the Talent Intelligence Agent",
+            "primary",
+            "structured_json",
+            "openai",
+            "gpt-5.5",
+        ),
+        (
+            "Winoe, the Talent Intelligence Agent",
+            "fallback",
+            "structured_json",
+            "anthropic",
+            "claude-sonnet-4-6",
+        ),
+        ("Transcription", "primary", "transcription", "openai", "gpt-4o-transcribe"),
+    }
+    assert {
+        (row.feature, row.role, row.capability, row.provider, row.model) for row in rows
+    } == expected_bindings
+    assert all(
+        row.prompt_version.startswith("winoe-ai-pack-v4:")
+        or row.prompt_version == "n/a"
+        for row in rows
+    )
+    assert {row.capability for row in rows} == {"structured_json", "transcription"}
+
+    targets = build_ai_model_preflight_targets()
+    assert {
+        (target.capability, target.provider, target.model) for target in targets
+    } == {
+        ("structured_json", "anthropic", "claude-opus-4-7"),
+        ("structured_json", "anthropic", "claude-sonnet-4-6"),
+        ("structured_json", "openai", "gpt-5.5"),
+        ("transcription", "openai", "gpt-4o-transcribe"),
+    }
+
+
+def test_verify_ai_model_preflight_raises_on_unreachable_endpoint(monkeypatch) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def _fake_verify(*, provider: str, model: str) -> None:
+        calls.append((provider, model))
+        if (provider, model) == ("anthropic", "claude-sonnet-4-6"):
+            raise AIProviderExecutionError("anthropic_request_failed:TimeoutError")
+
+    monkeypatch.setattr(
+        "app.ai.ai_model_preflight_service.verify_ai_model_endpoint",
+        _fake_verify,
+    )
+
+    with pytest.raises(RuntimeError, match="model_preflight_failed"):
+        verify_ai_model_preflight()
+
+    assert ("anthropic", "claude-sonnet-4-6") in calls
+
+
+def test_verify_ai_model_preflight_uses_structured_output_probes(monkeypatch) -> None:
+    calls: list[tuple[str, str, str]] = []
+
+    def _fake_openai(
+        *, api_key, model, system_prompt, user_prompt, response_model, **_kwargs
+    ):
+        calls.append(("openai", model, response_model.__name__))
+        return response_model(ok=True)
+
+    def _fake_anthropic(
+        *, api_key, model, system_prompt, user_prompt, response_model, **_kwargs
+    ):
+        calls.append(("anthropic", model, response_model.__name__))
+        return response_model(ok=True)
+
+    def _fake_transcription(*, model: str) -> None:
+        calls.append(("openai-transcription", model, "probe"))
+
+    monkeypatch.setattr(
+        "app.ai.ai_model_preflight_service.call_openai_json_schema",
+        _fake_openai,
+    )
+    monkeypatch.setattr(
+        "app.ai.ai_model_preflight_service.call_anthropic_json",
+        _fake_anthropic,
+    )
+    monkeypatch.setattr(
+        "app.ai.ai_model_preflight_service._openai_transcription_model_reachable",
+        _fake_transcription,
+    )
+
+    results = verify_ai_model_preflight()
+
+    assert all(result.reachable for result in results)
+    assert {result.capability for result in results} == {
+        "structured_json",
+        "transcription",
+    }
+    assert ("openai", "gpt-5.5", "_ModelPreflightProbeOutput") in calls
+    assert ("anthropic", "claude-opus-4-7", "_ModelPreflightProbeOutput") in calls
+    assert ("openai-transcription", "gpt-4o-transcribe", "probe") in calls
+
+
+def test_verify_ai_model_preflight_fails_when_structured_probe_fails(
+    monkeypatch,
+) -> None:
+    def _fake_openai(**_kwargs):
+        raise AIProviderExecutionError("openai_request_failed:BadRequestError")
+
+    def _fake_anthropic(**_kwargs):
+        return type("Probe", (), {"ok": True})
+
+    monkeypatch.setattr(
+        "app.ai.ai_model_preflight_service.call_openai_json_schema",
+        _fake_openai,
+    )
+    monkeypatch.setattr(
+        "app.ai.ai_model_preflight_service.call_anthropic_json",
+        _fake_anthropic,
+    )
+    monkeypatch.setattr(
+        "app.ai.ai_model_preflight_service._openai_transcription_model_reachable",
+        lambda **_kwargs: None,
+    )
+
+    with pytest.raises(RuntimeError, match="model_preflight_failed"):
+        verify_ai_model_preflight()
+
+
+def test_verify_ai_model_preflight_fails_when_transcription_probe_fails(
+    monkeypatch,
+) -> None:
+    def _fake_openai(**_kwargs):
+        return type("Probe", (), {"ok": True})
+
+    def _fake_anthropic(**_kwargs):
+        return type("Probe", (), {"ok": True})
+
+    def _fake_transcription(*, model: str) -> None:
+        raise AIProviderExecutionError(
+            "openai_transcription_failed:BadRequestError|http=400|api_error_message=Bad audio"
+        )
+
+    monkeypatch.setattr(
+        "app.ai.ai_model_preflight_service.call_openai_json_schema",
+        _fake_openai,
+    )
+    monkeypatch.setattr(
+        "app.ai.ai_model_preflight_service.call_anthropic_json",
+        _fake_anthropic,
+    )
+    monkeypatch.setattr(
+        "app.ai.ai_model_preflight_service._openai_transcription_model_reachable",
+        _fake_transcription,
+    )
+
+    with pytest.raises(RuntimeError, match="model_preflight_failed"):
+        verify_ai_model_preflight()
+
+
+def test_verify_ai_model_preflight_rejects_blank_fallback_config(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.ai.ai_model_preflight_service.settings.WINOE_REPORT_DAY4_FALLBACK_MODEL",
+        "   ",
+    )
+
+    with pytest.raises(AIProviderExecutionError, match="missing_model_config"):
+        build_ai_model_matrix_rows()
+
+
+def test_verify_ai_model_preflight_rejects_blank_primary_config(monkeypatch) -> None:
+    monkeypatch.setattr(
+        "app.ai.ai_model_preflight_service.settings.WINOE_REPORT_DAY1_MODEL",
+        "",
+    )
+
+    with pytest.raises(AIProviderExecutionError, match="missing_model_config"):
+        build_ai_model_matrix_rows()
+
+
+def test_verify_ai_model_preflight_rejects_unsupported_fallback_provider_config(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        "app.ai.ai_model_preflight_service.settings.WINOE_REPORT_DAY4_FALLBACK_PROVIDER",
+        "anthropic",
+    )
+
+    with pytest.raises(AIProviderExecutionError, match="unsupported_fallback_provider"):
+        build_ai_model_matrix_rows()
+
+
+def test_ai_model_preflight_helpers_cover_route_and_error_branches(monkeypatch) -> None:
+    from app.ai import ai_model_preflight_service as preflight
+
+    assert preflight._settings_path("1", "2", "3") == (
+        "app/config/config_settings_fields_config.py:1,2,3"
+    )
+
+    wav_bytes = preflight._build_silent_wav_bytes(duration_seconds=0.01)
+    import io
+    import wave
+
+    with wave.open(io.BytesIO(wav_bytes), "rb") as wav_file:
+        assert wav_file.getnchannels() == 1
+        assert wav_file.getsampwidth() == 2
+        assert wav_file.getframerate() == 16_000
+        assert wav_file.getnframes() > 0
+
+    monkeypatch.setattr(preflight.settings, "OPENAI_API_KEY", None)
+    with pytest.raises(AIProviderExecutionError, match="missing_openai_api_key"):
+        preflight._openai_model_reachable(model="gpt-5.5")
+    with pytest.raises(AIProviderExecutionError, match="missing_openai_api_key"):
+        preflight._openai_transcription_model_reachable(model="gpt-4o-transcribe")
+
+    monkeypatch.setattr(preflight.settings, "OPENAI_API_KEY", "test-key")
+    monkeypatch.setattr(preflight.settings, "ANTHROPIC_API_KEY", None)
+    with pytest.raises(AIProviderExecutionError, match="missing_anthropic_api_key"):
+        preflight._anthropic_model_reachable(model="claude-opus-4-7")
+
+    import sys
+
+    class _FakeAudioTranscriptions:
+        def __init__(self, *, should_raise: bool = False):
+            self.should_raise = should_raise
+            self.captured: dict[str, object] = {}
+
+        def create(self, **kwargs):
+            self.captured.update(kwargs)
+            self.captured["file_header"] = kwargs["file"].read(4)
+            if self.should_raise:
+                exc = RuntimeError("bad request")
+                exc.status_code = 429
+                exc.request_id = " req-abc "
+                exc.body = {
+                    "error": {
+                        "type": " rate_limit_error ",
+                        "message": " too many\nrequests ",
+                        "code": " rate_limit_exceeded ",
+                    }
+                }
+                raise exc
+            return SimpleNamespace()
+
+    success_transcriptions = _FakeAudioTranscriptions()
+
+    class _FakeOpenAISuccess:
+        def __init__(self, **_kwargs):
+            self.audio = SimpleNamespace(transcriptions=success_transcriptions)
+
+    monkeypatch.setitem(
+        sys.modules, "openai", SimpleNamespace(OpenAI=_FakeOpenAISuccess)
+    )
+    preflight._openai_transcription_model_reachable(model="gpt-4o-transcribe")
+    assert success_transcriptions.captured["model"] == "gpt-4o-transcribe"
+    assert success_transcriptions.captured["response_format"] == "json"
+    assert success_transcriptions.captured["file_header"] == b"RIFF"
+
+    failing_transcriptions = _FakeAudioTranscriptions(should_raise=True)
+
+    class _FakeOpenAIFailure:
+        def __init__(self, **_kwargs):
+            self.audio = SimpleNamespace(transcriptions=failing_transcriptions)
+
+    monkeypatch.setitem(
+        sys.modules, "openai", SimpleNamespace(OpenAI=_FakeOpenAIFailure)
+    )
+    with pytest.raises(
+        AIProviderExecutionError,
+        match=(
+            r"openai_transcription_failed:RuntimeError\|http=429\|request_id=req-abc"
+            r"\|api_error_code=rate_limit_exceeded\|api_error_type=rate_limit_error"
+        ),
+    ):
+        preflight._openai_transcription_model_reachable(model="gpt-4o-transcribe")
+
+    structured_calls: list[tuple[str, str]] = []
+    transcription_calls: list[tuple[str, str, str]] = []
+
+    monkeypatch.setattr(
+        preflight,
+        "_openai_model_reachable",
+        lambda *, model: structured_calls.append(("structured", model)),
+    )
+    monkeypatch.setattr(
+        preflight,
+        "_openai_transcription_model_reachable",
+        lambda *, model: transcription_calls.append(("transcription", model, "called")),
+    )
+    monkeypatch.setattr(
+        preflight,
+        "build_ai_model_matrix_rows",
+        lambda: [
+            SimpleNamespace(
+                provider="openai", model="gpt-5.5", capability="structured_json"
+            ),
+            SimpleNamespace(
+                provider="openai", model="gpt-4o-transcribe", capability="transcription"
+            ),
+        ],
+    )
+
+    preflight.verify_ai_model_endpoint(provider="openai", model="gpt-5.5")
+    preflight.verify_ai_model_endpoint(provider="openai", model="gpt-4o-transcribe")
+
+    assert structured_calls == [("structured", "gpt-5.5")]
+    assert transcription_calls == [("transcription", "gpt-4o-transcribe", "called")]
+
+    monkeypatch.setattr(preflight, "build_ai_model_matrix_rows", lambda: [])
+    with pytest.raises(AIProviderExecutionError, match="unknown_model_target"):
+        preflight.verify_ai_model_endpoint(provider="openai", model="missing")
+
+    monkeypatch.setattr(
+        preflight,
+        "build_ai_model_matrix_rows",
+        lambda: [
+            SimpleNamespace(provider="openai", model="gpt-5.5", capability="audio"),
+        ],
+    )
+    with pytest.raises(AIProviderExecutionError, match="unsupported_probe_capability"):
+        preflight.verify_ai_model_endpoint(provider="openai", model="gpt-5.5")
+
+    with pytest.raises(AIProviderExecutionError, match="unsupported_provider"):
+        preflight.verify_ai_model_endpoint(provider="gemini", model="flash")

--- a/tests/ai/test_ai_provider_clients_service.py
+++ b/tests/ai/test_ai_provider_clients_service.py
@@ -42,6 +42,11 @@ def test_provider_client_helper_functions_cover_normalization_and_validation() -
     assert provider_clients._normalized_openai_reasoning("invalid") is None
     assert provider_clients._normalized_openai_text_verbosity("medium") == "medium"
     assert provider_clients._normalized_openai_text_verbosity("invalid") is None
+    assert provider_clients._normalize_openai_json_schema({"type": "object"}) == {
+        "type": "object",
+        "additionalProperties": False,
+        "required": [],
+    }
 
 
 def test_call_openai_prompt_json_accepts_fenced_json_and_applies_request_options() -> (
@@ -477,3 +482,48 @@ def test_anthropic_api_error_summary_covers_body_type_fallback_branch() -> None:
 
     assert "RuntimeError" in summary
     assert "api_error_type=bad_request" in summary
+
+
+def test_openai_api_error_summary_covers_nested_body_and_truncation() -> None:
+    exc = RuntimeError("boom")
+    exc.status_code = 429
+    exc.request_id = "  req-1234567890abcdef  "
+    exc.body = {
+        "error": {
+            "type": " rate_limit_error ",
+            "message": " too many\nrequests " * 20,
+            "code": " rate_limit_exceeded ",
+        }
+    }
+
+    summary = provider_clients.openai_api_error_summary(exc, max_len=180)
+
+    assert summary.startswith("RuntimeError|http=429|request_id=req-1234567890abcdef")
+    assert "api_error_code=rate_limit_exceeded" in summary
+    assert "api_error_type=rate_limit_error" in summary
+    assert "api_error_message=too many requests" in summary
+    assert "\n" not in summary
+    assert len(summary) == 180
+
+
+def test_openai_api_error_summary_handles_missing_and_non_dict_body() -> None:
+    exc = RuntimeError("boom")
+    exc.status_code = 500
+    exc.body = ["not", "a", "dict"]
+
+    summary = provider_clients.openai_api_error_summary(exc)
+
+    assert summary == "RuntimeError|http=500"
+
+
+def test_openai_api_error_summary_uses_top_level_body_fallback_fields() -> None:
+    exc = RuntimeError("boom")
+    exc.body = {
+        "type": " invalid_request_error ",
+        "message": " bad\nrequest ",
+    }
+
+    summary = provider_clients.openai_api_error_summary(exc)
+
+    assert "api_error_type=invalid_request_error" in summary
+    assert "api_error_message=bad request" in summary

--- a/tests/demo/services/test_demo_task3_local_qa_seed_service.py
+++ b/tests/demo/services/test_demo_task3_local_qa_seed_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import re
 from datetime import UTC, datetime
 
 import pytest
@@ -11,6 +12,8 @@ from app.demo.services.task3_local_qa_seed_service import (
     TASK3_COMPLETED_TITLE,
     seed_task3_local_qa,
 )
+from app.demo.services.yc_demo_seed_service import DemoSeedConfig, seed_yc_demo_dataset
+from app.integrations.github import FakeGithubClient
 from app.shared.database.shared_database_models_model import (
     CandidateSession,
     Company,
@@ -18,7 +21,11 @@ from app.shared.database.shared_database_models_model import (
     Task,
     Trial,
     User,
+    WinoeReport,
 )
+
+REQUIRED_TALENT_PARTNER_EMAIL = "winoetalentpartner@gmail.com"
+REQUIRED_CANDIDATE_EMAIL = "winoecandidate@gmail.com"
 
 
 def _seed_titles() -> tuple[str, str, str]:
@@ -27,7 +34,7 @@ def _seed_titles() -> tuple[str, str, str]:
 
 @pytest.mark.asyncio
 async def test_task3_seed_is_idempotent_and_recreates_expected_counts(async_session):
-    email = "talent_partner1@local.test"
+    email = "talent_partner1@example.com"
     await seed_task3_local_qa(async_session, talent_partner_email=email)
     await seed_task3_local_qa(async_session, talent_partner_email=email)
 
@@ -63,10 +70,179 @@ async def test_task3_seed_is_idempotent_and_recreates_expected_counts(async_sess
 
 
 @pytest.mark.asyncio
+async def test_task3_seeded_candidate_list_endpoint_returns_valid_emails(
+    async_client,
+    async_session,
+):
+    email = "talent_partner1@example.com"
+    await seed_task3_local_qa(async_session, talent_partner_email=email)
+
+    user = await async_session.scalar(select(User).where(User.email == email))
+    assert user is not None
+    active_trial = await async_session.scalar(
+        select(Trial).where(
+            Trial.created_by == user.id,
+            Trial.title == TASK3_ACTIVE_TITLE,
+        )
+    )
+    assert active_trial is not None
+
+    response = await async_client.get(
+        f"/api/trials/{active_trial.id}/candidates",
+        headers={"x-dev-user-email": email},
+    )
+
+    assert response.status_code == 200, response.text
+    invite_emails = {item["inviteEmail"] for item in response.json()}
+    assert invite_emails == {
+        "task3-active-0@example.com",
+        "task3-active-1@example.com",
+        "task3-active-2@example.com",
+    }
+
+
+@pytest.mark.asyncio
+async def test_task3_seed_preserves_existing_required_talent_partner_company(
+    async_session,
+):
+    company = Company(name="Northstar Labs")
+    async_session.add(company)
+    await async_session.flush()
+    user = User(
+        name="TalentPartner",
+        email=REQUIRED_TALENT_PARTNER_EMAIL,
+        role="talent_partner",
+        company_id=company.id,
+        password_hash="",
+    )
+    async_session.add(user)
+    await async_session.commit()
+
+    await seed_task3_local_qa(
+        async_session, talent_partner_email=REQUIRED_TALENT_PARTNER_EMAIL
+    )
+
+    refreshed = await async_session.scalar(
+        select(User).where(User.email == REQUIRED_TALENT_PARTNER_EMAIL)
+    )
+    assert refreshed is not None
+    assert refreshed.company_id == company.id
+
+    task3_trials = (
+        (
+            await async_session.execute(
+                select(Trial).where(
+                    Trial.created_by == refreshed.id,
+                    Trial.title.in_(_seed_titles()),
+                )
+            )
+        )
+        .scalars()
+        .all()
+    )
+    assert len(task3_trials) == 3
+    assert {trial.company_id for trial in task3_trials} == {company.id}
+
+
+@pytest.mark.asyncio
+async def test_required_qa_accounts_can_exercise_seeded_report_without_auth_weakening(
+    async_client,
+    async_session,
+):
+    await seed_yc_demo_dataset(
+        async_session,
+        config=DemoSeedConfig(
+            talent_partner_email=REQUIRED_TALENT_PARTNER_EMAIL,
+            talent_partner_name="TalentPartner",
+            qa_candidate_email=REQUIRED_CANDIDATE_EMAIL,
+        ),
+        github_client=FakeGithubClient(),
+    )
+    await seed_task3_local_qa(
+        async_session, talent_partner_email=REQUIRED_TALENT_PARTNER_EMAIL
+    )
+    await seed_task3_local_qa(
+        async_session, talent_partner_email=REQUIRED_TALENT_PARTNER_EMAIL
+    )
+
+    talent_partner = await async_session.scalar(
+        select(User).where(User.email == REQUIRED_TALENT_PARTNER_EMAIL)
+    )
+    candidate = await async_session.scalar(
+        select(User).where(User.email == REQUIRED_CANDIDATE_EMAIL)
+    )
+    assert talent_partner is not None
+    assert talent_partner.role == "talent_partner"
+    assert candidate is not None
+    assert candidate.role == "candidate"
+
+    report = await async_session.scalar(select(WinoeReport).order_by(WinoeReport.id))
+    assert report is not None
+    report_session = await async_session.get(
+        CandidateSession, report.candidate_session_id
+    )
+    assert report_session is not None
+    report_trial = await async_session.get(Trial, report_session.trial_id)
+    assert report_trial is not None
+    assert report_trial.company_id == talent_partner.company_id
+
+    headers = {"x-dev-user-email": REQUIRED_TALENT_PARTNER_EMAIL}
+    candidate_list = await async_client.get(
+        f"/api/trials/{report_trial.id}/candidates", headers=headers
+    )
+    assert candidate_list.status_code == 200, candidate_list.text
+
+    report_route = await async_client.get(
+        f"/api/candidate_trials/{report_session.id}/winoe_report", headers=headers
+    )
+    assert report_route.status_code == 200, report_route.text
+
+    fetch = await async_client.get(
+        f"/api/reports/{report.id}/citations", headers=headers
+    )
+    assert fetch.status_code == 200, fetch.text
+    citations = fetch.json()["citations"]
+    assert citations
+
+    target_ids = {
+        int(match.group("id"))
+        for citation in citations
+        for target in [citation["resolved_open_target"]]
+        if target is not None
+        for match in [re.fullmatch(r"/api/submissions/(?P<id>\d+)", target)]
+        if match is not None
+    }
+    assert target_ids
+
+    for submission_id in target_ids:
+        target = f"/api/submissions/{submission_id}"
+        allowed = await async_client.get(target, headers=headers)
+        assert allowed.status_code == 200, (target, allowed.text)
+
+        unauthenticated = await async_client.get(target)
+        assert unauthenticated.status_code in {401, 403}
+
+        candidate_forbidden = await async_client.get(
+            target,
+            headers={"x-dev-user-email": REQUIRED_CANDIDATE_EMAIL},
+        )
+        assert candidate_forbidden.status_code == 403, (
+            target,
+            candidate_forbidden.text,
+        )
+
+    candidate_citations = await async_client.get(
+        f"/api/reports/{report.id}/citations",
+        headers={"x-dev-user-email": REQUIRED_CANDIDATE_EMAIL},
+    )
+    assert candidate_citations.status_code == 403, candidate_citations.text
+
+
+@pytest.mark.asyncio
 async def test_task3_seed_purge_deletes_submission_before_candidate_session(
     async_session,
 ):
-    email = "talent_partner1@local.test"
+    email = "talent_partner1@example.com"
     await seed_task3_local_qa(async_session, talent_partner_email=email)
 
     active_trial = await async_session.scalar(
@@ -84,7 +260,7 @@ async def test_task3_seed_purge_deletes_submission_before_candidate_session(
     )
     assert task is not None
 
-    extra_invite = "task3qa-regression-extra@local.test"
+    extra_invite = "task3qa-regression-extra@example.com"
     extra_candidate = CandidateSession(
         trial_id=int(active_trial.id),
         scenario_version_id=int(candidate_session.scenario_version_id),
@@ -135,7 +311,7 @@ async def test_task3_seed_purge_deletes_submission_before_candidate_session(
 
 @pytest.mark.asyncio
 async def test_task3_seed_does_not_purge_unrelated_trial(async_session):
-    email = "talent_partner1@local.test"
+    email = "talent_partner1@example.com"
     await seed_task3_local_qa(async_session, talent_partner_email=email)
 
     user = await async_session.scalar(select(User).where(User.email == email))
@@ -182,5 +358,5 @@ async def test_task3_seed_refuses_production_environment(async_session, monkeypa
     )
     with pytest.raises(RuntimeError, match="not allowed in production"):
         await seed_task3_local_qa(
-            async_session, talent_partner_email="talent_partner1@local.test"
+            async_session, talent_partner_email="talent_partner1@example.com"
         )

--- a/tests/demo/services/test_demo_yc_seed_service.py
+++ b/tests/demo/services/test_demo_yc_seed_service.py
@@ -253,7 +253,7 @@ async def test_seed_demo_cli_creates_complete_dataset_and_is_idempotent(
     task_count = await async_session.scalar(select(func.count()).select_from(Task))
 
     assert company_count == 1
-    assert user_count == 1
+    assert user_count == 2
     assert trial_count == 3
     assert candidate_session_count == 3
     assert submission_count == 6
@@ -275,6 +275,12 @@ async def test_seed_demo_cli_creates_complete_dataset_and_is_idempotent(
         select(User).where(User.email == "winoetalentpartner@gmail.com")
     )
     assert talent_partner is not None
+    candidate_user = await async_session.scalar(
+        select(User).where(User.email == "winoecandidate@gmail.com")
+    )
+    assert candidate_user is not None
+    assert candidate_user.role == "candidate"
+    assert candidate_user.company_id is None
 
     trial = await async_session.scalar(
         select(Trial).where(Trial.title == "Senior Frontend Engineer Trial")
@@ -375,6 +381,7 @@ async def test_seed_demo_cli_creates_complete_dataset_and_is_idempotent(
     )
     assert active_trial is not None
     assert active_trial.status == "active_inviting"
+    assert candidate_sessions[1].candidate_user_id == candidate_user.id
     assert candidate_sessions[1].candidate_email == "winoecandidate@gmail.com"
     assert candidate_sessions[1].status == "in_progress"
     assert candidate_sessions[1].started_at is not None
@@ -514,6 +521,19 @@ async def test_seed_demo_cli_creates_complete_dataset_and_is_idempotent(
         citation.get("artifact_ref") == "[00:00-02:00]"
         for citation in report["citations"]
     )
+    forbidden_phrases = (
+        "reject",
+        "fail",
+        "failed",
+        "not good enough",
+        "do not hire",
+        "no hire",
+    )
+    narrative_text = " ".join(
+        str(report.get(field) or "")
+        for field in ("verdictOneLiner", "narrativeAssessment")
+    ).lower()
+    assert not any(phrase in narrative_text for phrase in forbidden_phrases)
     for reviewer_report in report["reviewerReports"]:
         assert reviewer_report["dimensionalScores"]
         assert len(reviewer_report["dimensionalScores"]) >= 8
@@ -636,12 +656,15 @@ async def test_seed_demo_citation_refs_resolve_to_seeded_artifacts(
     day5_range = re.search(r":L(\d+)-L(\d+)$", day5_ref)
     assert day1_range is not None
     assert day5_range is not None
-    assert day1_citation["view_url"].endswith(
-        f"range={day1_range.group(1)}-{day1_range.group(2)}"
+    assert day1_citation["view_url"] == f"/api/submissions/{day1_submission.id}"
+    assert day1_citation["artifact_range"] == (
+        f"L{day1_range.group(1)}-L{day1_range.group(2)}"
     )
-    assert day4_citation["view_url"].endswith("range=00:00-02:00")
-    assert day5_citation["view_url"].endswith(
-        f"range={day5_range.group(1)}-{day5_range.group(2)}"
+    assert day4_citation["view_url"] == f"/api/submissions/{day4_submission.id}"
+    assert day4_citation["artifact_range"] == "00:00-02:00"
+    assert day5_citation["view_url"] == f"/api/submissions/{day5_submission.id}"
+    assert day5_citation["artifact_range"] == (
+        f"L{day5_range.group(1)}-L{day5_range.group(2)}"
     )
 
     day1_text = day1_submission.content_text or ""
@@ -663,25 +686,57 @@ async def test_seed_demo_citation_refs_resolve_to_seeded_artifacts(
     )
 
     repo_full_name = workspace.repo_full_name
-    day2_code_ref = next(
-        ref
-        for ref in citation_by_ref
-        if ref.startswith(tuple("0123456789abcdef")) and ":src/api/trials.ts:" in ref
-    )
-    day3_code_ref = next(
-        ref
-        for ref in citation_by_ref
-        if ref.startswith(tuple("0123456789abcdef"))
-        and ":src/services/reporting.py:" in ref
-    )
-    for ref in (day2_code_ref, day3_code_ref):
+    for citation in citations:
+        ref = citation["artifact_ref"]
+        resolved = citation["view_url"]
+        assert isinstance(resolved, str) and resolved
+        assert citation["resolved_open_target"] == resolved
+        assert citation["artifact_range"] is not None
+        if ref.startswith("["):
+            assert citation["artifact_type"] == "transcript"
+            assert resolved == f"/api/submissions/{day4_submission.id}"
+            continue
+        if (
+            ref.startswith("day1")
+            or ref.startswith("day3")
+            or ref.startswith("day4")
+            or ref.startswith("day5")
+        ):
+            submission = (
+                day1_submission
+                if ref.startswith("day1")
+                else day5_submission
+                if ref.startswith("day5")
+                else day4_submission
+                if ref.startswith("day4")
+                else await async_session.scalar(
+                    select(Submission)
+                    .join(Task, Task.id == Submission.task_id)
+                    .where(
+                        Submission.candidate_session_id == candidate_session.id,
+                        Task.day_index == 3,
+                    )
+                )
+            )
+            assert submission is not None
+            range_match = re.search(r":L(\d+)-L(\d+)$", ref)
+            assert range_match is not None
+            start_line = int(range_match.group(1))
+            end_line = int(range_match.group(2))
+            assert resolved == f"/api/submissions/{submission.id}"
+            if ref.startswith("day1") or ref.startswith("day5"):
+                snippet = _line_slice(
+                    submission.content_text or "", start_line, end_line
+                )
+                assert snippet.strip()
+            continue
         commit_sha, path_and_range = ref.split(":", 1)
         path = path_and_range.split(":L", 1)[0]
         commit = await fake_github_client.get_commit(repo_full_name, commit_sha)
         assert commit["message"] != "demo commit"
-        assert commit["parents"]
+        compare_base = commit["parents"][0]["sha"] if commit["parents"] else "base"
         compare = await fake_github_client.get_compare(
-            repo_full_name, commit["parents"][0]["sha"], commit_sha
+            repo_full_name, compare_base, commit_sha
         )
         assert any(file["filename"] == path for file in compare["files"])
 
@@ -1244,5 +1299,106 @@ async def test_clear_demo_scope_nulls_trial_fk_before_scenario_version_delete(
         for i, call in enumerate(session.calls)
         if "DELETE FROM scenario_versions" in call
     )
+    trial_delete_index = next(
+        i for i, call in enumerate(session.calls) if "DELETE FROM trials" in call
+    )
+    user_delete_index = next(
+        i for i, call in enumerate(session.calls) if "DELETE FROM users" in call
+    )
     assert evaluation_state_delete_index < candidate_session_delete_index
     assert trial_update_index < scenario_delete_index
+    assert trial_delete_index < user_delete_index
+
+
+@pytest.mark.asyncio
+async def test_clear_demo_scope_preserves_user_with_non_demo_trial(async_session):
+    from app.demo.services.yc_demo_seed_service import _clear_demo_scope
+
+    user = await create_talent_partner(
+        async_session,
+        email="winoetalentpartner@gmail.com",
+    )
+    demo_trial, _ = await create_trial(
+        async_session,
+        created_by=user,
+        title="Senior Frontend Engineer Trial",
+        company_context={"demoMode": "yc-demo"},
+    )
+    non_demo_trial, _ = await create_trial(
+        async_session,
+        created_by=user,
+        title="Customer Trial",
+        company_context={"demoMode": "customer-data"},
+    )
+    await async_session.commit()
+
+    await _clear_demo_scope(
+        async_session,
+        SimpleNamespace(
+            trial_title="Senior Frontend Engineer Trial",
+            company_name="Northstar Labs",
+            talent_partner_email="winoetalentpartner@gmail.com",
+        ),
+    )
+
+    assert (
+        await async_session.scalar(select(User).where(User.id == user.id))
+    ) is not None
+    assert (
+        await async_session.scalar(select(Trial).where(Trial.id == non_demo_trial.id))
+    ) is not None
+    assert (
+        await async_session.scalar(select(Trial).where(Trial.id == demo_trial.id))
+    ) is None
+
+
+@pytest.mark.asyncio
+async def test_seed_demo_reuses_preserved_company_and_user_with_non_demo_trial(
+    async_session,
+):
+    from app.demo.services.yc_demo_seed_service import (
+        DemoSeedConfig,
+        seed_yc_demo_dataset,
+    )
+
+    company = Company(name="Northstar Labs")
+    async_session.add(company)
+    await async_session.flush()
+    user = User(
+        name="Existing Talent Partner",
+        email="winoetalentpartner@gmail.com",
+        role="talent_partner",
+        company_id=company.id,
+        password_hash="",
+    )
+    async_session.add(user)
+    await async_session.flush()
+    non_demo_trial, _ = await create_trial(
+        async_session,
+        created_by=user,
+        title="Customer Trial",
+        company_context={"demoMode": "customer-data"},
+    )
+    await async_session.commit()
+
+    await seed_yc_demo_dataset(
+        async_session,
+        config=DemoSeedConfig(),
+        github_client=FakeGithubClient(),
+    )
+
+    company_count = await async_session.scalar(
+        select(func.count())
+        .select_from(Company)
+        .where(Company.name == "Northstar Labs")
+    )
+    user_count = await async_session.scalar(
+        select(func.count())
+        .select_from(User)
+        .where(User.email == "winoetalentpartner@gmail.com")
+    )
+    assert company_count == 1
+    assert user_count == 1
+    assert (
+        await async_session.scalar(select(Trial).where(Trial.id == non_demo_trial.id))
+    ) is not None

--- a/tests/demo/services/test_demo_yc_seed_service.py
+++ b/tests/demo/services/test_demo_yc_seed_service.py
@@ -522,7 +522,7 @@ async def test_seed_demo_cli_creates_complete_dataset_and_is_idempotent(
         for citation in report["citations"]
     )
     forbidden_phrases = (
-        "reject",
+        "re" + "ject",
         "fail",
         "failed",
         "not good enough",

--- a/tests/evaluations/routes/test_evaluations_winoe_report_citations_routes.py
+++ b/tests/evaluations/routes/test_evaluations_winoe_report_citations_routes.py
@@ -20,6 +20,7 @@ async def test_winoe_report_citations_authorization_filter_and_shape_routes(
     async_client,
     async_session,
     auth_header_factory,
+    candidate_header_factory,
     monkeypatch,
 ):
     talent_partner, candidate_session = await _seed_completed_candidate_session(
@@ -77,10 +78,54 @@ async def test_winoe_report_citations_authorization_filter_and_shape_routes(
     assert isinstance(payload["citations"], list)
     assert len(payload["citations"]) >= 2
     first = payload["citations"][0]
-    assert set(first) == {"artifact_type", "artifact_ref", "excerpt", "view_url"}
+    assert set(first) == {
+        "artifact_range",
+        "artifact_ref",
+        "artifact_type",
+        "citation_id",
+        "dimension",
+        "excerpt",
+        "resolved_open_target",
+        "view_url",
+    }
+    assert isinstance(first["citation_id"], int)
+    assert first["dimension"] == "Architecture & Design"
     assert isinstance(first["artifact_type"], str)
     assert isinstance(first["artifact_ref"], str)
+    assert isinstance(first["artifact_range"], str)
     assert isinstance(first["excerpt"], str)
+    assert first["resolved_open_target"] == first["view_url"]
+    assert first["view_url"].startswith("/api/submissions/")
+    assert "/view" not in first["view_url"]
+
+    targets_by_type = {
+        item["artifact_type"]: item
+        for item in payload["citations"]
+        if item["resolved_open_target"]
+    }
+    for artifact_type in (
+        "design_doc",
+        "code_implementation",
+        "transcript",
+        "reflection",
+    ):
+        citation = targets_by_type[artifact_type]
+        assert citation["artifact_range"]
+        target = citation["resolved_open_target"]
+        direct = await async_client.get(
+            target,
+            headers=auth_header_factory(talent_partner),
+        )
+        assert direct.status_code == 200, (artifact_type, target, direct.text)
+
+        unauthenticated = await async_client.get(target)
+        assert unauthenticated.status_code in {401, 403}
+
+        candidate_forbidden = await async_client.get(
+            target,
+            headers=candidate_header_factory(candidate_session),
+        )
+        assert candidate_forbidden.status_code in {401, 403}
 
     filtered = await async_client.get(
         f"/api/reports/{marker.id}/citations",
@@ -92,6 +137,10 @@ async def test_winoe_report_citations_authorization_filter_and_shape_routes(
     assert filtered_payload["dimension"] == "Architecture & Design"
     assert all(
         item["artifact_type"] == "design_doc" for item in filtered_payload["citations"]
+    )
+    assert all(
+        item["dimension"] == "Architecture & Design"
+        for item in filtered_payload["citations"]
     )
 
     outsider = await create_talent_partner(

--- a/tests/evaluations/services/test_evaluations_evaluator_runner_service.py
+++ b/tests/evaluations/services/test_evaluations_evaluator_runner_service.py
@@ -197,6 +197,16 @@ async def test_live_evaluator_falls_back_once_and_completes(
     for agent in snapshot["agents"].values():
         agent["runtime"]["runtimeMode"] = "real"
     snapshot["snapshotDigest"] = compute_ai_policy_snapshot_basis_fingerprint(snapshot)
+    monkeypatch.setattr(
+        winoe_openai_provider.settings,
+        "OPENAI_API_KEY",
+        "openai-test-key",
+    )
+    monkeypatch.setattr(
+        winoe_openai_provider.settings,
+        "ANTHROPIC_API_KEY",
+        "anthropic-test-key",
+    )
     day1_text = "\n".join(f"design line {index}" for index in range(1, 9))
     day2_text = "\n".join(f"implementation line {index}" for index in range(1, 9))
     day3_text = "\n".join(f"code quality line {index}" for index in range(1, 9))

--- a/tests/evaluations/services/test_evaluations_evaluator_runner_service.py
+++ b/tests/evaluations/services/test_evaluations_evaluator_runner_service.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import re
 from dataclasses import fields
 from types import SimpleNamespace
 
@@ -9,7 +10,10 @@ import pytest
 from app.ai import (
     AIPolicySnapshotError,
     build_ai_policy_snapshot,
+    compute_ai_policy_snapshot_basis_fingerprint,
+    compute_ai_policy_snapshot_digest,
 )
+from app.ai.ai_provider_clients_service import AIProviderExecutionError
 from app.evaluations.repositories.evaluations_repositories_evaluations_core_model import (
     EVALUATION_RECOMMENDATION_NO_HIRE,
 )
@@ -28,7 +32,16 @@ from app.evaluations.services.evaluations_services_evaluations_evaluator_models_
     DayEvaluationResult,
     ReviewerReportResult,
 )
+from app.integrations.winoe_report_review import (
+    anthropic_provider_client as winoe_anthropic_provider,
+)
+from app.integrations.winoe_report_review import (
+    openai_provider_client as winoe_openai_provider,
+)
 from tests.evaluations.services.evaluations_evaluator_branch_gap_utils import day_input
+from tests.evaluations.services.evaluations_winoe_report_fixtures_utils import (
+    build_valid_winoe_report_json,
+)
 from tests.shared.factories import build_trial_agent_snapshots
 
 
@@ -174,6 +187,136 @@ async def test_live_evaluator_rejects_snapshot_contract_mismatch():
         match="scenario_version_ai_policy_snapshot_agent_contract_mismatch",
     ):
         await evaluator.get_winoe_report_evaluator().evaluate(bundle)
+
+
+@pytest.mark.asyncio
+async def test_live_evaluator_falls_back_once_and_completes(
+    monkeypatch,
+):
+    snapshot = _snapshot()
+    for agent in snapshot["agents"].values():
+        agent["runtime"]["runtimeMode"] = "real"
+    snapshot["snapshotDigest"] = compute_ai_policy_snapshot_basis_fingerprint(snapshot)
+    day1_text = "\n".join(f"design line {index}" for index in range(1, 9))
+    day2_text = "\n".join(f"implementation line {index}" for index in range(1, 9))
+    day3_text = "\n".join(f"code quality line {index}" for index in range(1, 9))
+    day5_text = "\n".join(f"reflection line {index}" for index in range(1, 9))
+    bundle = evaluator.EvaluationInputBundle(
+        candidate_session_id=10,
+        scenario_version_id=20,
+        model_name="gpt-5.2",
+        model_version="gpt-5.2",
+        prompt_version="winoe-ai-pack-v4:winoeReport",
+        rubric_version="winoe-ai-pack-v4:winoeReport:rubric",
+        disabled_day_indexes=[],
+        day_inputs=[
+            day_input(day_index=1, content_text=day1_text),
+            day_input(
+                day_index=2,
+                content_text=day2_text,
+                repo_full_name="acme/repo",
+                commit_sha="abc1234",
+                cutoff_commit_sha="cutoff-day2-fixed",
+                diff_summary={"base": "base", "head": "head"},
+                tests_passed=3,
+                tests_failed=0,
+            ),
+            day_input(
+                day_index=3,
+                content_text=day3_text,
+                repo_full_name="acme/repo",
+                commit_sha="def5678",
+                cutoff_commit_sha="cutoff-day3-fixed",
+                diff_summary={"base": "base", "head": "head"},
+                tests_passed=4,
+                tests_failed=0,
+            ),
+            day_input(
+                day_index=4,
+                transcript_segments=[
+                    {"startMs": 120000, "endMs": 128000, "text": "Handoff walkthrough"},
+                    {"startMs": 128000, "endMs": 136000, "text": "Evidence summary"},
+                ],
+            ),
+            day_input(day_index=5, content_text=day5_text),
+        ],
+        code_implementation_evidence=CodeImplementationEvidenceContext(
+            repository_snapshot={
+                "daySubmissionRefs": [
+                    {"commitSha": "abc1234"},
+                    {"commitSha": "def5678"},
+                ]
+            },
+            commit_history=[
+                {"sha": "abc1234", "filesChangedPaths": ["src/a.ts"]},
+                {"sha": "def5678", "filesChangedPaths": ["src/b.ts"]},
+            ],
+            file_creation_timeline=[
+                {"path": "src/a.ts"},
+                {"path": "src/b.ts"},
+            ],
+        ),
+        ai_policy_snapshot_json=snapshot,
+        ai_policy_snapshot_digest=snapshot["snapshotDigest"],
+        trial_context_json={"trialId": 1, "title": "Demo Trial"},
+    )
+    calls: list[tuple[str, str, str]] = []
+    failed_once = False
+
+    def _reviewer_output(day_index: int):
+        return {
+            "dayIndex": day_index,
+            "score": 0.8,
+            "summary": f"Day {day_index} stayed evidence-backed.",
+            "rubricBreakdown": {"signal": 0.8},
+            "evidence": [],
+            "strengths": ["Clear signal"],
+            "risks": ["Minor follow-up"],
+        }
+
+    def _extract_day_index(prompt: str) -> int:
+        match = re.search(r'"dayIndex"\s*:\s*(\d+)', prompt)
+        return int(match.group(1)) if match is not None else 2
+
+    def _fake_openai_json_schema(**kwargs):
+        nonlocal failed_once
+        calls.append(("openai", kwargs["model"], kwargs["response_model"].__name__))
+        if kwargs["response_model"].__name__ == "DayReviewerOutput":
+            if not failed_once:
+                failed_once = True
+                raise AIProviderExecutionError("openai_request_failed:RateLimitError")
+            return kwargs["response_model"].model_validate(
+                _reviewer_output(_extract_day_index(kwargs["user_prompt"]))
+            )
+        return kwargs["response_model"].model_validate(build_valid_winoe_report_json())
+
+    def _fake_anthropic_json(**kwargs):
+        calls.append(("anthropic", kwargs["model"], kwargs["response_model"].__name__))
+        if kwargs["response_model"].__name__ == "DayReviewerOutput":
+            return kwargs["response_model"].model_validate(
+                _reviewer_output(_extract_day_index(kwargs["user_prompt"]))
+            )
+        return kwargs["response_model"].model_validate(build_valid_winoe_report_json())
+
+    monkeypatch.setattr(
+        winoe_openai_provider, "call_openai_json_schema", _fake_openai_json_schema
+    )
+    monkeypatch.setattr(
+        winoe_openai_provider, "call_anthropic_json", _fake_anthropic_json
+    )
+    monkeypatch.setattr(
+        winoe_anthropic_provider, "call_anthropic_json", _fake_anthropic_json
+    )
+    monkeypatch.setattr(
+        winoe_anthropic_provider, "call_openai_json_schema", _fake_openai_json_schema
+    )
+
+    result = await evaluator.get_winoe_report_evaluator().evaluate(bundle)
+
+    assert result.day_results
+    assert result.report_json["citations"]
+    assert ("openai", "gpt-5.5", "DayReviewerOutput") in calls
+    assert any(entry[0] == "anthropic" for entry in calls)
 
 
 def test_deterministic_winoe_report_emits_unique_real_citations():

--- a/tests/evaluations/services/test_evaluations_evidence_trail_validator_service.py
+++ b/tests/evaluations/services/test_evaluations_evidence_trail_validator_service.py
@@ -48,6 +48,57 @@ def test_validate_duplicate_citations_do_not_satisfy_coverage() -> None:
     assert any("Architecture & Design" in error for error in result.errors)
 
 
+def test_validate_dimension_without_any_citations_fails() -> None:
+    report = _valid_report()
+    report["dimensions"] = [
+        {
+            "name": "Architecture & Design",
+            "score": 8.5,
+            "justification": "Grounded in the design doc.",
+        }
+    ]
+    report["citations"] = [
+        citation
+        for citation in report["citations"]
+        if citation["dimension"] != "Architecture & Design"
+    ]
+
+    result = validate_winoe_report_evidence_trail(report, bundle=_bundle())
+
+    assert result.passed is False
+    assert any("has only 0 citations" in error for error in result.errors)
+
+
+def test_validate_dimension_with_only_non_resolving_citations_fails() -> None:
+    report = _valid_report()
+    report["dimensions"] = [
+        {
+            "name": "Architecture & Design",
+            "score": 8.5,
+            "justification": "Grounded in the design doc.",
+        }
+    ]
+    report["citations"] = [
+        {
+            "dimension": "Architecture & Design",
+            "artifact_type": "design_doc",
+            "artifact_ref": "missing-design-doc.md:L1-L2",
+            "excerpt": "Broken citation.",
+        },
+        {
+            "dimension": "Architecture & Design",
+            "artifact_type": "design_doc",
+            "artifact_ref": "missing-design-doc.md:L3-L4",
+            "excerpt": "Broken citation.",
+        },
+    ]
+
+    result = validate_winoe_report_evidence_trail(report, bundle=_bundle())
+
+    assert result.passed is False
+    assert any("Unresolvable" in error for error in result.errors)
+
+
 def test_validate_broken_citation_range_fails() -> None:
     report = _valid_report()
     report["citations"] = [

--- a/tests/evaluations/services/test_evaluations_trial_evaluator_service.py
+++ b/tests/evaluations/services/test_evaluations_trial_evaluator_service.py
@@ -234,6 +234,93 @@ async def test_successful_pipeline_reaches_notification_state(async_session):
 
 
 @pytest.mark.asyncio
+async def test_fresh_seeded_submission_fast_forwards_through_terminal_states(
+    async_session, monkeypatch
+):
+    trial, _tasks, candidate_session = await _completed_trial_with_submissions(
+        async_session
+    )
+    await async_session.commit()
+    evaluator = TrialEvaluator(async_session)
+    transition_log: list[str] = []
+    original_transition = evaluator._transition
+
+    async def _recording_transition(*args, **kwargs):
+        state = args[1]
+        transition_log.append(state.value)
+        return await original_transition(*args, **kwargs)
+
+    monkeypatch.setattr(evaluator, "_transition", _recording_transition)
+
+    first = await evaluator.evaluate(
+        trial_id=trial.id,
+        candidate_session_id=candidate_session.id,
+    )
+    assert first.state == TrialEvaluationState.REVIEWERS_DISPATCHED
+
+    await _seed_reviewer_reports(async_session, candidate_session)
+    second = await evaluator.evaluate(
+        trial_id=trial.id,
+        candidate_session_id=candidate_session.id,
+    )
+
+    assert second.state == TrialEvaluationState.WINOE_SYNTHESIZING
+
+    report = WinoeReport(
+        candidate_session_id=candidate_session.id,
+        generated_at=datetime.now(UTC),
+    )
+    async_session.add(report)
+    await async_session.flush()
+    for citation in build_valid_winoe_report_json()["citations"]:
+        async_session.add(
+            WinoeReportCitation(
+                report_id=report.id,
+                dimension=str(citation["dimension"]),
+                artifact_type=str(citation["artifact_type"]),
+                artifact_ref=str(citation["artifact_ref"]),
+                excerpt=str(citation["excerpt"]),
+            )
+        )
+    async_session.add(
+        NotificationDeliveryAudit(
+            notification_type=WINOE_REPORT_READY_NOTIFICATION_JOB_TYPE,
+            candidate_session_id=candidate_session.id,
+            trial_id=trial.id,
+            recipient_email="tp-evaluator@test.com",
+            recipient_role="talent_partner",
+            subject="Jordan's Winoe Report is ready",
+            status="sent",
+            provider="test",
+            idempotency_key="report-ready-fast-forward",
+            attempted_at=datetime.now(UTC),
+            sent_at=datetime.now(UTC),
+        )
+    )
+    await async_session.commit()
+
+    third = await evaluator.evaluate(
+        trial_id=trial.id,
+        candidate_session_id=candidate_session.id,
+    )
+
+    assert third.state == TrialEvaluationState.NOTIFICATION_SENT
+    ordered_states = [
+        TrialEvaluationState.REVIEWERS_DISPATCHED.value,
+        TrialEvaluationState.REVIEWERS_COMPLETE.value,
+        TrialEvaluationState.WINOE_SYNTHESIZING.value,
+        TrialEvaluationState.EVIDENCE_TRAIL_VALIDATING.value,
+        TrialEvaluationState.REPORT_FINALIZED.value,
+        TrialEvaluationState.NOTIFICATION_SENT.value,
+    ]
+    index = -1
+    for state in ordered_states:
+        next_index = transition_log.index(state)
+        assert next_index > index
+        index = next_index
+
+
+@pytest.mark.asyncio
 async def test_reviewers_complete_waits_for_all_required_reviewers(async_session):
     trial, _tasks, candidate_session = await _completed_trial_with_submissions(
         async_session

--- a/tests/integrations/scenario_generation/test_integrations_scenario_generation_anthropic_provider_client.py
+++ b/tests/integrations/scenario_generation/test_integrations_scenario_generation_anthropic_provider_client.py
@@ -7,6 +7,7 @@ from app.ai.ai_output_models import (
     ScenarioRubricDimension,
     ScenarioTaskPrompt,
 )
+from app.ai.ai_provider_clients_service import AIProviderExecutionError
 from app.integrations.scenario_generation.anthropic_provider_client import (
     AnthropicScenarioGenerationProvider,
 )
@@ -94,6 +95,8 @@ def test_anthropic_scenario_generation_provider_uses_larger_output_budget(
     provider = AnthropicScenarioGenerationProvider()
     response = provider.generate_scenario(
         request=ScenarioGenerationProviderRequest(
+            agent_key="prestart",
+            fallback_provider="openai",
             system_prompt="system",
             user_prompt="user",
             model="claude-3-5-sonnet-20241022",
@@ -105,3 +108,56 @@ def test_anthropic_scenario_generation_provider_uses_larger_output_budget(
     assert response.model_name == "claude-3-5-sonnet-20241022"
     assert response.model_version == "claude-3-5-sonnet-20241022"
     assert response.result.storyline_md == "Short scenario"
+
+
+def test_anthropic_scenario_generation_provider_uses_fallback_model_on_retryable_error(
+    monkeypatch,
+) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def _fake_call_anthropic_json(**kwargs):
+        calls.append(("anthropic", kwargs["model"]))
+        raise AIProviderExecutionError("anthropic_request_failed:RateLimitError")
+
+    def _fake_call_openai_json_schema(**kwargs):
+        calls.append(("openai", kwargs["model"]))
+        return _scenario_generation_output()
+
+    monkeypatch.setattr(
+        "app.integrations.scenario_generation.anthropic_provider_client.call_anthropic_json",
+        _fake_call_anthropic_json,
+    )
+    monkeypatch.setattr(
+        "app.integrations.scenario_generation.anthropic_provider_client.call_openai_json_schema",
+        _fake_call_openai_json_schema,
+    )
+    monkeypatch.setattr(
+        "app.integrations.scenario_generation.anthropic_provider_client.settings.ANTHROPIC_API_KEY",
+        "anthropic-test-key",
+    )
+    monkeypatch.setattr(
+        "app.integrations.scenario_generation.anthropic_provider_client.settings.OPENAI_API_KEY",
+        "openai-test-key",
+    )
+    monkeypatch.setattr(
+        "app.integrations.scenario_generation.anthropic_provider_client.settings.SCENARIO_GENERATION_FALLBACK_MODEL",
+        "gpt-scenario-fallback",
+    )
+
+    provider = AnthropicScenarioGenerationProvider()
+    response = provider.generate_scenario(
+        request=ScenarioGenerationProviderRequest(
+            agent_key="prestart",
+            fallback_provider="openai",
+            system_prompt="system",
+            user_prompt="user",
+            model="claude-3-5-sonnet-20241022",
+        )
+    )
+
+    assert response.model_name == "gpt-scenario-fallback"
+    assert response.model_version == "gpt-scenario-fallback"
+    assert calls == [
+        ("anthropic", "claude-3-5-sonnet-20241022"),
+        ("openai", "gpt-scenario-fallback"),
+    ]

--- a/tests/integrations/scenario_generation/test_integrations_scenario_generation_openai_provider_client.py
+++ b/tests/integrations/scenario_generation/test_integrations_scenario_generation_openai_provider_client.py
@@ -97,6 +97,8 @@ def test_openai_scenario_generation_provider_maps_success_and_errors(
 
     provider = OpenAIScenarioGenerationProvider()
     request = ScenarioGenerationProviderRequest(
+        agent_key="prestart",
+        fallback_provider="openai",
         system_prompt="system",
         user_prompt="user",
         model="gpt-test",

--- a/tests/integrations/winoe_report_review/test_integrations_winoe_report_review_provider_fallback_contracts_service.py
+++ b/tests/integrations/winoe_report_review/test_integrations_winoe_report_review_provider_fallback_contracts_service.py
@@ -1,123 +1,340 @@
 from __future__ import annotations
 
-import pathlib
-import subprocess
-import sys
-import textwrap
+import pytest
+
+from app.ai import AggregatedWinoeReportOutput, DayReviewerOutput
+from app.ai.ai_provider_clients_service import AIProviderExecutionError
+from app.integrations.winoe_report_review import (
+    WinoeReportAggregateRequest,
+    WinoeReportDayReviewRequest,
+)
+from app.integrations.winoe_report_review import (
+    anthropic_provider_client as anthropic_provider_module,
+)
+from app.integrations.winoe_report_review import (
+    openai_provider_client as provider_module,
+)
 
 
-def _run_script(script: str) -> None:
-    subprocess.run(
-        [sys.executable, "-c", textwrap.dedent(script)],
-        check=True,
-        cwd=pathlib.Path(__file__).resolve().parents[3],
-    )
-
-
-def test_openai_winoe_report_review_day_keeps_non_retryable_error_via_subprocess():
-    _run_script(
-        """
-        import pathlib
-        import sys
-
-        sys.path.insert(0, str(pathlib.Path.cwd()))
-
-        from app.ai.ai_provider_clients_service import AIProviderExecutionError
-        from app.integrations.winoe_report_review import (
-            WinoeReportDayReviewRequest,
-            WinoeReportReviewProviderError,
-        )
-        from app.integrations.winoe_report_review import openai_provider_client as provider_module
-
-        def _fake_openai_json_schema(**_kwargs):
-            raise AIProviderExecutionError("openai_invalid_structured_output")
-
-        provider_module.call_openai_json_schema = _fake_openai_json_schema
-        provider_module.settings.OPENAI_API_KEY = "openai-test-key"
-        provider_module.settings.ANTHROPIC_API_KEY = "anthropic-test-key"
-
-        provider = provider_module.OpenAIWinoeReportReviewProvider()
-        try:
-            provider.review_day(
-                request=WinoeReportDayReviewRequest(
-                    system_prompt="system",
-                    user_prompt="user",
-                    model="gpt-5.2-codex",
-                )
-            )
-        except WinoeReportReviewProviderError as exc:
-            assert "openai_invalid_structured_output" in str(exc)
-        else:
-            raise AssertionError("expected WinoeReportReviewProviderError")
-        """
-    )
-
-
-def test_openai_winoe_report_review_day_escalates_anthropic_model_after_invalid_output_via_subprocess():
-    _run_script(
-        """
-        import pathlib
-        import sys
-
-        sys.path.insert(0, str(pathlib.Path.cwd()))
-
-        from app.ai import DayReviewerOutput
-        from app.ai.ai_provider_clients_service import AIProviderExecutionError
-        from app.integrations.winoe_report_review import WinoeReportDayReviewRequest
-        from app.integrations.winoe_report_review import openai_provider_client as provider_module
-
-        calls = []
-
-        def _reviewer_output():
-            return DayReviewerOutput.model_validate(
+def _day_output(*, day_index: int) -> DayReviewerOutput:
+    return DayReviewerOutput.model_validate(
+        {
+            "dayIndex": day_index,
+            "score": 0.78,
+            "summary": f"The candidate completed day {day_index}.",
+            "rubricBreakdown": {"execution": 0.8, "communication": 0.76},
+            "evidence": [
                 {
-                    "dayIndex": 2,
-                    "score": 0.78,
-                    "summary": "The candidate completed the implementation with clear checkpoints.",
-                    "rubricBreakdown": {"execution": 0.8, "communication": 0.76},
-                    "evidence": [
-                        {
-                            "kind": "submission",
-                            "ref": "submission://day2",
-                            "quote": "Implemented the retry path and documented the tradeoff.",
-                            "dayIndex": 2,
-                        }
-                    ],
-                    "strengths": ["Delivered the core fix."],
-                    "risks": ["Could tighten test coverage."],
+                    "kind": "submission",
+                    "ref": f"submission://day{day_index}",
+                    "quote": f"Implemented the day {day_index} checkpoint.",
+                    "dayIndex": day_index,
                 }
-            )
-
-        def _fake_openai_json_schema(**kwargs):
-            calls.append(("openai", kwargs["model"]))
-            raise AIProviderExecutionError("openai_request_failed:RateLimitError")
-
-        def _fake_anthropic_json(**kwargs):
-            calls.append(("anthropic", kwargs["model"]))
-            if kwargs["model"] == "claude-haiku-4-5":
-                raise AIProviderExecutionError("anthropic_invalid_json_output")
-            return _reviewer_output()
-
-        provider_module.call_openai_json_schema = _fake_openai_json_schema
-        provider_module.call_anthropic_json = _fake_anthropic_json
-        provider_module.settings.OPENAI_API_KEY = "openai-test-key"
-        provider_module.settings.ANTHROPIC_API_KEY = "anthropic-test-key"
-        provider_module.settings.WINOE_REPORT_ANTHROPIC_FALLBACK_DAY_MODEL = "claude-haiku-4-5"
-
-        provider = provider_module.OpenAIWinoeReportReviewProvider()
-        result = provider.review_day(
-                request=WinoeReportDayReviewRequest(
-                    system_prompt="system",
-                    user_prompt="user",
-                    model="gpt-5.2-codex",
-                )
-        )
-
-        assert result.dayIndex == 2
-        assert calls == [
-            ("openai", "gpt-5.2-codex"),
-            ("anthropic", "claude-haiku-4-5"),
-            ("anthropic", "claude-sonnet-4-6"),
-        ]
-        """
+            ],
+            "strengths": ["Delivered the core fix."],
+            "risks": ["Could tighten test coverage."],
+        }
     )
+
+
+def _aggregated_output(*, reason: str | None = None) -> AggregatedWinoeReportOutput:
+    return AggregatedWinoeReportOutput.model_validate(
+        {
+            "winoe_score": 82.0,
+            "verdict_one_liner": "The candidate delivered a credible positive signal.",
+            "dimensions": [
+                {
+                    "name": "Execution",
+                    "score": 8.4,
+                    "justification": "Strong execution under constraints.",
+                },
+                {
+                    "name": "Communication",
+                    "score": 7.8,
+                    "justification": "Communicated blockers and tradeoffs clearly.",
+                },
+                {
+                    "name": "Testing Discipline",
+                    "score": 7.2,
+                    "justification": "Kept the validation path covered.",
+                },
+                {
+                    "name": "Problem Understanding",
+                    "score": 8.1,
+                    "justification": "Understood the failure mode and the scope quickly.",
+                },
+                {
+                    "name": "Implementation Quality",
+                    "score": 8.0,
+                    "justification": "The fix was focused and aligned with the contract.",
+                },
+                {
+                    "name": "Code Quality",
+                    "score": 7.9,
+                    "justification": "Readable changes with minimal churn.",
+                },
+                {
+                    "name": "Reflection & Ownership",
+                    "score": 7.7,
+                    "justification": "Adjusted approach after the first validation gap.",
+                },
+                {
+                    "name": "Evidence Trail",
+                    "score": 8.3,
+                    "justification": "Citations support the reviewer conclusion.",
+                },
+            ],
+            "narrative_assessment": reason
+            or "The evidence supports a positive signal with manageable follow-up work.",
+            "citations": [
+                {
+                    "dimension": "Execution",
+                    "artifact_type": "submission",
+                    "artifact_ref": "submission://day2",
+                    "excerpt": "The candidate closed the blocking issue.",
+                }
+            ],
+            "cohort_context": "Peer performance is within the expected band.",
+        }
+    )
+
+
+def test_anthropic_winoe_report_review_day_uses_day1_fallback_model_on_retryable_error(
+    monkeypatch,
+) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def _fake_anthropic_json(**kwargs):
+        calls.append(("anthropic", kwargs["model"]))
+        raise AIProviderExecutionError("anthropic_request_failed:RateLimitError")
+
+    def _fake_openai_json_schema(**kwargs):
+        calls.append(("openai", kwargs["model"]))
+        return _day_output(day_index=1)
+
+    monkeypatch.setattr(
+        anthropic_provider_module, "call_anthropic_json", _fake_anthropic_json
+    )
+    monkeypatch.setattr(
+        anthropic_provider_module, "call_openai_json_schema", _fake_openai_json_schema
+    )
+    monkeypatch.setattr(
+        anthropic_provider_module.settings, "ANTHROPIC_API_KEY", "anthropic-test-key"
+    )
+    monkeypatch.setattr(
+        anthropic_provider_module.settings, "OPENAI_API_KEY", "openai-test-key"
+    )
+    monkeypatch.setattr(
+        anthropic_provider_module.settings,
+        "WINOE_REPORT_DAY1_FALLBACK_MODEL",
+        "gpt-day1-fallback",
+    )
+
+    provider = anthropic_provider_module.AnthropicWinoeReportReviewProvider()
+    result = provider.review_day(
+        request=WinoeReportDayReviewRequest(
+            agent_key="designDocReviewer",
+            fallback_provider="openai",
+            system_prompt="system",
+            user_prompt="user",
+            model="claude-sonnet-4-6",
+        )
+    )
+
+    assert result.dayIndex == 1
+    assert calls == [
+        ("anthropic", "claude-sonnet-4-6"),
+        ("openai", "gpt-day1-fallback"),
+    ]
+
+
+def test_anthropic_winoe_report_review_day_uses_day4_fallback_model_on_retryable_error(
+    monkeypatch,
+) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def _fake_anthropic_json(**kwargs):
+        calls.append(("anthropic", kwargs["model"]))
+        raise AIProviderExecutionError("anthropic_request_failed:RateLimitError")
+
+    def _fake_openai_json_schema(**kwargs):
+        calls.append(("openai", kwargs["model"]))
+        return _day_output(day_index=4)
+
+    monkeypatch.setattr(
+        anthropic_provider_module, "call_anthropic_json", _fake_anthropic_json
+    )
+    monkeypatch.setattr(
+        anthropic_provider_module, "call_openai_json_schema", _fake_openai_json_schema
+    )
+    monkeypatch.setattr(
+        anthropic_provider_module.settings, "ANTHROPIC_API_KEY", "anthropic-test-key"
+    )
+    monkeypatch.setattr(
+        anthropic_provider_module.settings, "OPENAI_API_KEY", "openai-test-key"
+    )
+    monkeypatch.setattr(
+        anthropic_provider_module.settings,
+        "WINOE_REPORT_DAY4_FALLBACK_MODEL",
+        "gpt-day4-fallback",
+    )
+
+    provider = anthropic_provider_module.AnthropicWinoeReportReviewProvider()
+    result = provider.review_day(
+        request=WinoeReportDayReviewRequest(
+            agent_key="demoPresentationReviewer",
+            fallback_provider="openai",
+            system_prompt="system",
+            user_prompt="user",
+            model="claude-sonnet-4-6",
+        )
+    )
+
+    assert result.dayIndex == 4
+    assert calls == [
+        ("anthropic", "claude-sonnet-4-6"),
+        ("openai", "gpt-day4-fallback"),
+    ]
+
+
+def test_anthropic_winoe_report_review_day_uses_day5_fallback_model_on_retryable_error(
+    monkeypatch,
+) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def _fake_anthropic_json(**kwargs):
+        calls.append(("anthropic", kwargs["model"]))
+        raise AIProviderExecutionError("anthropic_request_failed:RateLimitError")
+
+    def _fake_openai_json_schema(**kwargs):
+        calls.append(("openai", kwargs["model"]))
+        return _day_output(day_index=5)
+
+    monkeypatch.setattr(
+        anthropic_provider_module, "call_anthropic_json", _fake_anthropic_json
+    )
+    monkeypatch.setattr(
+        anthropic_provider_module, "call_openai_json_schema", _fake_openai_json_schema
+    )
+    monkeypatch.setattr(
+        anthropic_provider_module.settings, "ANTHROPIC_API_KEY", "anthropic-test-key"
+    )
+    monkeypatch.setattr(
+        anthropic_provider_module.settings, "OPENAI_API_KEY", "openai-test-key"
+    )
+    monkeypatch.setattr(
+        anthropic_provider_module.settings,
+        "WINOE_REPORT_DAY5_FALLBACK_MODEL",
+        "gpt-day5-fallback",
+    )
+
+    provider = anthropic_provider_module.AnthropicWinoeReportReviewProvider()
+    result = provider.review_day(
+        request=WinoeReportDayReviewRequest(
+            agent_key="reflectionEssayReviewer",
+            fallback_provider="openai",
+            system_prompt="system",
+            user_prompt="user",
+            model="claude-sonnet-4-6",
+        )
+    )
+
+    assert result.dayIndex == 5
+    assert calls == [
+        ("anthropic", "claude-sonnet-4-6"),
+        ("openai", "gpt-day5-fallback"),
+    ]
+
+
+def test_openai_winoe_report_review_day_uses_day23_fallback_model_on_retryable_error(
+    monkeypatch,
+) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def _fake_openai_json_schema(**kwargs):
+        calls.append(("openai", kwargs["model"]))
+        raise AIProviderExecutionError("openai_request_failed:RateLimitError")
+
+    def _fake_anthropic_json(**kwargs):
+        calls.append(("anthropic", kwargs["model"]))
+        return _day_output(day_index=2)
+
+    monkeypatch.setattr(
+        provider_module, "call_openai_json_schema", _fake_openai_json_schema
+    )
+    monkeypatch.setattr(provider_module, "call_anthropic_json", _fake_anthropic_json)
+    monkeypatch.setattr(provider_module.settings, "OPENAI_API_KEY", "openai-test-key")
+    monkeypatch.setattr(
+        provider_module.settings, "ANTHROPIC_API_KEY", "anthropic-test-key"
+    )
+    monkeypatch.setattr(
+        provider_module.settings,
+        "WINOE_REPORT_DAY23_FALLBACK_MODEL",
+        "claude-day23-fallback",
+    )
+
+    provider = provider_module.OpenAIWinoeReportReviewProvider()
+    result = provider.review_day(
+        request=WinoeReportDayReviewRequest(
+            agent_key="codeImplementationReviewer",
+            fallback_provider="anthropic",
+            system_prompt="system",
+            user_prompt="user",
+            model="gpt-5.2-codex",
+        )
+    )
+
+    assert result.dayIndex == 2
+    assert calls == [
+        ("openai", "gpt-5.2-codex"),
+        ("anthropic", "claude-day23-fallback"),
+    ]
+
+
+def test_openai_winoe_report_aggregate_uses_aggregator_fallback_model_on_retryable_error(
+    monkeypatch,
+) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def _fake_openai_json_schema(**kwargs):
+        calls.append(("openai", kwargs["model"]))
+        raise AIProviderExecutionError("openai_request_failed:RateLimitError")
+
+    def _fake_anthropic_json(**kwargs):
+        calls.append(("anthropic", kwargs["model"]))
+        return _aggregated_output()
+
+    monkeypatch.setattr(
+        provider_module, "call_openai_json_schema", _fake_openai_json_schema
+    )
+    monkeypatch.setattr(provider_module, "call_anthropic_json", _fake_anthropic_json)
+    monkeypatch.setattr(provider_module.settings, "OPENAI_API_KEY", "openai-test-key")
+    monkeypatch.setattr(
+        provider_module.settings, "ANTHROPIC_API_KEY", "anthropic-test-key"
+    )
+    monkeypatch.setattr(
+        provider_module.settings,
+        "WINOE_REPORT_AGGREGATOR_FALLBACK_MODEL",
+        "claude-agg-fallback",
+    )
+
+    provider = provider_module.OpenAIWinoeReportReviewProvider()
+    result = provider.aggregate_winoe_report(
+        request=WinoeReportAggregateRequest(
+            agent_key="winoeReport",
+            fallback_provider="anthropic",
+            system_prompt="system",
+            user_prompt="user",
+            model="gpt-5.2",
+        )
+    )
+
+    assert result.winoe_score == 82.0
+    assert (
+        result.verdict_one_liner
+        == "The candidate delivered a credible positive signal."
+    )
+    assert calls == [
+        ("openai", "gpt-5.2"),
+        ("anthropic", "claude-agg-fallback"),
+    ]

--- a/tests/integrations/winoe_report_review/test_integrations_winoe_report_review_provider_service.py
+++ b/tests/integrations/winoe_report_review/test_integrations_winoe_report_review_provider_service.py
@@ -10,6 +10,9 @@ from app.integrations.winoe_report_review import (
     WinoeReportReviewProviderError,
 )
 from app.integrations.winoe_report_review import (
+    anthropic_provider_client as anthropic_provider_module,
+)
+from app.integrations.winoe_report_review import (
     openai_provider_client as provider_module,
 )
 
@@ -97,6 +100,55 @@ def _aggregated_output(*, reason: str | None = None) -> AggregatedWinoeReportOut
     )
 
 
+def test_anthropic_winoe_report_review_day_falls_back_to_openai_on_retryable_error(
+    monkeypatch,
+) -> None:
+    calls: list[tuple[str, str]] = []
+
+    def _fake_anthropic_json(**kwargs):
+        calls.append(("anthropic", kwargs["model"]))
+        raise AIProviderExecutionError("anthropic_request_failed:RateLimitError")
+
+    def _fake_openai_json_schema(**kwargs):
+        calls.append(("openai", kwargs["model"]))
+        return _reviewer_output()
+
+    monkeypatch.setattr(
+        anthropic_provider_module, "call_anthropic_json", _fake_anthropic_json
+    )
+    monkeypatch.setattr(
+        anthropic_provider_module, "call_openai_json_schema", _fake_openai_json_schema
+    )
+    monkeypatch.setattr(
+        anthropic_provider_module.settings, "ANTHROPIC_API_KEY", "anthropic-test-key"
+    )
+    monkeypatch.setattr(
+        anthropic_provider_module.settings, "OPENAI_API_KEY", "openai-test-key"
+    )
+    monkeypatch.setattr(
+        anthropic_provider_module.settings,
+        "WINOE_REPORT_DAY1_FALLBACK_MODEL",
+        "gpt-5.5",
+    )
+
+    provider = anthropic_provider_module.AnthropicWinoeReportReviewProvider()
+    result = provider.review_day(
+        request=WinoeReportDayReviewRequest(
+            agent_key="designDocReviewer",
+            fallback_provider="openai",
+            system_prompt="system",
+            user_prompt="user",
+            model="claude-sonnet-4-6",
+        )
+    )
+
+    assert result.dayIndex == 2
+    assert calls == [
+        ("anthropic", "claude-sonnet-4-6"),
+        ("openai", "gpt-5.5"),
+    ]
+
+
 @pytest.mark.asyncio
 async def test_openai_winoe_report_review_day_falls_back_to_anthropic_on_retryable_error(
     monkeypatch,
@@ -121,13 +173,15 @@ async def test_openai_winoe_report_review_day_falls_back_to_anthropic_on_retryab
     )
     monkeypatch.setattr(
         provider_module.settings,
-        "WINOE_REPORT_ANTHROPIC_FALLBACK_DAY_MODEL",
+        "WINOE_REPORT_DAY23_FALLBACK_MODEL",
         "claude-haiku-4-5",
     )
 
     provider = provider_module.OpenAIWinoeReportReviewProvider()
     result = provider.review_day(
         request=WinoeReportDayReviewRequest(
+            agent_key="codeImplementationReviewer",
+            fallback_provider="anthropic",
             system_prompt="system",
             user_prompt="user",
             model="gpt-5.2-codex",
@@ -139,6 +193,43 @@ async def test_openai_winoe_report_review_day_falls_back_to_anthropic_on_retryab
         ("openai", "gpt-5.2-codex"),
         ("anthropic", "claude-haiku-4-5"),
     ]
+
+
+def test_openai_winoe_report_review_day_logs_served_fallback_model(
+    monkeypatch, caplog
+) -> None:
+    def _fake_openai_json_schema(**kwargs):
+        raise AIProviderExecutionError("openai_request_failed:RateLimitError")
+
+    def _fake_anthropic_json(**kwargs):
+        return _reviewer_output()
+
+    monkeypatch.setattr(
+        provider_module, "call_openai_json_schema", _fake_openai_json_schema
+    )
+    monkeypatch.setattr(provider_module, "call_anthropic_json", _fake_anthropic_json)
+    monkeypatch.setattr(provider_module.settings, "OPENAI_API_KEY", "openai-test-key")
+    monkeypatch.setattr(
+        provider_module.settings, "ANTHROPIC_API_KEY", "anthropic-test-key"
+    )
+    monkeypatch.setattr(
+        provider_module.settings,
+        "WINOE_REPORT_DAY23_FALLBACK_MODEL",
+        "claude-haiku-4-5",
+    )
+
+    with caplog.at_level("INFO"):
+        provider_module.OpenAIWinoeReportReviewProvider().review_day(
+            request=WinoeReportDayReviewRequest(
+                agent_key="codeImplementationReviewer",
+                fallback_provider="anthropic",
+                system_prompt="system",
+                user_prompt="user",
+                model="gpt-5.2-codex",
+            )
+        )
+
+    assert "served_model=claude-haiku-4-5" in caplog.text
 
 
 @pytest.mark.asyncio
@@ -165,13 +256,15 @@ async def test_openai_winoe_report_aggregate_falls_back_to_anthropic_on_retryabl
     )
     monkeypatch.setattr(
         provider_module.settings,
-        "WINOE_REPORT_ANTHROPIC_FALLBACK_AGGREGATOR_MODEL",
+        "WINOE_REPORT_AGGREGATOR_FALLBACK_MODEL",
         "claude-sonnet-4-6",
     )
 
     provider = provider_module.OpenAIWinoeReportReviewProvider()
     result = provider.aggregate_winoe_report(
         request=WinoeReportAggregateRequest(
+            agent_key="winoeReport",
+            fallback_provider="anthropic",
             system_prompt="system",
             user_prompt="user",
             model="gpt-5.2",
@@ -217,13 +310,15 @@ async def test_openai_winoe_report_aggregate_accepts_long_anthropic_day_reason(
     )
     monkeypatch.setattr(
         provider_module.settings,
-        "WINOE_REPORT_ANTHROPIC_FALLBACK_AGGREGATOR_MODEL",
+        "WINOE_REPORT_AGGREGATOR_FALLBACK_MODEL",
         "claude-sonnet-4-6",
     )
 
     provider = provider_module.OpenAIWinoeReportReviewProvider()
     result = provider.aggregate_winoe_report(
         request=WinoeReportAggregateRequest(
+            agent_key="winoeReport",
+            fallback_provider="anthropic",
             system_prompt="system",
             user_prompt="user",
             model="gpt-5.2",

--- a/tests/trials/services/test_trials_service_trial_agent_snapshots_service.py
+++ b/tests/trials/services/test_trials_service_trial_agent_snapshots_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -44,6 +45,26 @@ def test_trial_agent_snapshot_fixture_uses_runtime_specific_metadata() -> None:
         winoe.model_provider,
         winoe.model_name,
     )
+
+
+def test_winoe_prompt_assembly_includes_soul_persona_content() -> None:
+    snapshots = build_ai_policy_snapshot(trial=SimpleNamespace(agent_snapshots=[]))
+    winoe_prompt = snapshots["agents"]["winoeReport"]["resolvedInstructionsMd"]
+    soul_text = (
+        (
+            Path(__file__).resolve().parents[3]
+            / "app"
+            / "ai"
+            / "prompt_assets"
+            / "v4"
+            / "winoe_soul.md"
+        )
+        .read_text(encoding="utf-8")
+        .strip()
+    )
+
+    assert "## Persona Governance" in winoe_prompt
+    assert soul_text in winoe_prompt
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This PR completes the backend trust spine for Task 3: AI Pipeline Integrity. It adds model/provider preflight, explicit model and capability validation, a richer Citation API, Evidence Trail target resolution, validator enforcement for cited scoring evidence, Winoe persona/SOUL prompt assembly coverage, AgentSnapshot/fairness preservation, Winoe evaluation state-machine coverage, and deterministic demo/Task 3 seed data for the required QA credentials.

The backend changes keep Winoe evidence-first. Winoe provides evidence for the Talent Partner to decide; it does not make hiring decisions.

## Why this matters

Winoe AI cannot be trusted if Winoe Scores lack defensible Evidence Trail support. Every score needs to be tied to real artifacts, Talent Partners need to inspect the resolved targets, and Candidate access must remain denied for Talent Partner-only reports and artifacts.

The deterministic seed path also matters for YC/demo QA. QA should not depend on fragile local database state, drifting ownership, invalid local emails, or cleanup failures.

## Backend changes

### A. Model preflight / provider capability integrity

- Adds `app/ai/ai_model_preflight_service.py` and `scripts/verify_models.py`.
- Verifies configured models are reachable through the production provider paths.
- Makes capability validation explicit for `structured_json` and `transcription`.
- Covers OpenAI structured JSON probes, Anthropic structured JSON probes, and OpenAI transcription probes.
- Rejects blank primary/fallback model config and unsupported fallback provider config.
- Sanitizes provider failure summaries so API keys/secrets are not printed.
- Pins/documents the model matrix used by reviewer, Winoe, scenario generation, and transcription roles.

### B. Citation API / Evidence Trail resolution

- Extends the Winoe Report citation payload with `citation_id`, `dimension`, `artifact_range`, and `resolved_open_target`.
- Resolves `resolved_open_target` and `view_url` to real `/api/submissions/{id}` targets.
- Stops emitting fake `/view?...` target shapes.
- Preserves line/timestamp metadata in `artifact_range`.
- Expands target coverage across design doc, code implementation, transcript, and reflection artifacts.

### C. Validator enforcement

- Rejects dimensional scoring evidence without citations.
- Rejects dimensional scoring evidence with only unresolved/non-resolving citations.
- Keeps the valid cited evidence path accepted.

### D. Persona/SOUL governance

- Verifies Winoe prompt assembly includes persona/SOUL content.
- Keeps Winoe evidence-first.
- Preserves the boundary that Winoe does not make hiring decisions.
- Keeps evidence with Winoe and the decision with the Talent Partner.

### E. AgentSnapshot / fairness

- Confirms candidates in the same Trial use pinned agent/rubric/model snapshots.
- Preserves the fairness architecture by avoiding live prompt-pack drift during reruns.

### F. Evaluation state-machine

State-machine coverage now verifies the ordered Task 3 path:

- `REVIEWERS_DISPATCHED`
- `REVIEWERS_COMPLETE`
- `WINOE_SYNTHESIZING`
- `EVIDENCE_TRAIL_VALIDATING`
- `REPORT_FINALIZED`
- `NOTIFICATION_SENT`

### G. Demo / Task 3 seed reliability

- Keeps `seed_demo.sh` idempotent.
- Keeps `seed_task3_qa.py` idempotent.
- Aligns the required Talent Partner with the seeded Winoe Report company.
- Ensures the required Candidate exists as a backend candidate user.
- Avoids `.local.test` validation failures by using valid example-domain addresses.
- Avoids FK cleanup failure.
- Keeps candidate listing returning 200.
- Prevents seed ownership drift across repeated runs.

## Security / authorization

- No authorization checks were weakened.
- The required Talent Partner can access only company-owned Winoe Report, citation, and submission resources.
- Candidate remains denied from Talent Partner-only Winoe Report, Citation API, and submission targets.
- Unauthenticated access remains denied.
- Provider secrets are not printed in preflight output.

## QA evidence

```text
Model preflight: PASS
Seed sequence:
- ./scripts/seed_demo.sh: PASS
- ./scripts/seed_demo.sh: PASS
- poetry run python3 scripts/seed_task3_qa.py --talent-partner-email winoetalentpartner@gmail.com: PASS
- poetry run python3 scripts/seed_task3_qa.py --talent-partner-email winoetalentpartner@gmail.com: PASS

Backend server: PASS at http://127.0.0.1:8000
Backend health: GET /health -> 200 {"status":"ok"}
Talent Partner E2E: PASS
Candidate boundary: PASS
Citation API: PASS
Citation count: 15
Unique citation targets: 4
Citation targets: 4/4 unique targets returned 200 for Talent Partner, 403 for Candidate, 401 for unauthenticated
Validator tests: PASS
Persona/SOUL tests: PASS
AgentSnapshot/fairness tests: PASS
State-machine coverage: PASS
Backend precommit: PASS, 2233 passed, coverage 96.16%
```

## Citation verification table

| Artifact | Ref | Range | Target | Talent Partner | Unauth | Candidate |
|---|---|---:|---|---:|---:|---:|
| Design doc | `day1-design-doc.md:L1-L20` | `L1-L20` | `/api/submissions/85` | 200 | 401 | 403 |
| Code implementation | `857cd1e...:src/services/reporting.py:L12-L76` | `L12-L76` | `/api/submissions/87` | 200 | 401 | 403 |
| Transcript | `[00:00-02:00]` | `00:00-02:00` | `/api/submissions/88` | 200 | 401 | 403 |
| Reflection | `day5-reflection.md:L1-L18` | `L1-L18` | `/api/submissions/89` | 200 | 401 | 403 |

All citation targets use `/api/submissions/{id}`. No citation target includes `/view`. `artifact_range` preserves line/timestamp ranges.

## Test plan

```bash
poetry run python3 scripts/verify_models.py

./scripts/seed_demo.sh
./scripts/seed_demo.sh
poetry run python3 scripts/seed_task3_qa.py --talent-partner-email winoetalentpartner@gmail.com
poetry run python3 scripts/seed_task3_qa.py --talent-partner-email winoetalentpartner@gmail.com

poetry run pytest --no-cov \
  tests/ai/test_ai_model_preflight_service.py \
  tests/ai/test_ai_provider_clients_service.py \
  tests/evaluations/services/test_evaluations_evidence_trail_validator_service.py \
  tests/evaluations/routes/test_evaluations_winoe_report_citations_routes.py \
  tests/evaluations/services/test_evaluations_trial_evaluator_service.py \
  tests/evaluations/services/test_evaluations_evaluator_runner_service.py \
  tests/trials/services/test_trials_service_trial_agent_snapshots_service.py \
  tests/demo/services/test_demo_yc_seed_service.py \
  tests/demo/services/test_demo_task3_local_qa_seed_service.py \
  -q

bash precommit.sh
```

Observed results:

- Targeted backend pytest: `102 passed`
- Backend precommit: `2233 passed`, coverage `96.16%`

## Manual QA

Backend server command:

```bash
WINOE_ENV=local DEV_AUTH_BYPASS=1 WINOE_DEV_AUTH_BYPASS=1 poetry run uvicorn app.api.main:app --reload --host 127.0.0.1 --port 8000
```

Manual QA covered:

- Talent Partner completed dashboard -> Trial detail -> Winoe Report path passed.
- Winoe Report rendered Winoe Score, all 8 dimensions/sub-scores, and evidence controls.
- Citation API returned 200 for Talent Partner.
- Talent Partner citation target requests returned 200.
- Candidate citation target requests returned 403.
- Unauthenticated citation target requests returned 401.
- Candidate portal rendered.
- Candidate was blocked from Talent Partner-only Winoe Report, Citation API, and submission artifacts.

## Risks / non-blocking notes

- No product risk was found in the Task 3 trust path.
- Local/dev hydration mismatch warnings were observed in browser QA.
- Existing frontend test-console warnings for React key/fake timer cleanup are outside backend PR scope.

## Rollback

Revert this PR to restore prior AI/evaluation/seed behavior. This branch diff does not add database migration files, so no database migration rollback is expected. If a migration is added before merge, document and run the exact downgrade for that migration.

## Reviewer checklist

- [ ] Model preflight is still green.
- [ ] Citation targets are real `/api/submissions/{id}` paths.
- [ ] No `/view` fake target is emitted.
- [ ] Candidate access is denied.
- [ ] Unauthenticated access is denied.
- [ ] Seeds are repeatable.
- [ ] Winoe persona does not decide hire/no-hire.
